### PR TITLE
Add CI workflow and refine Python skill reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main, feature/**]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  observer-go:
+    name: Observer-Go – vet, build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: observer-go/go.mod
+          cache-dependency-path: observer-go/go.sum
+
+      - name: Stage embedded skills
+        run: |
+          cp -R skills observer-go/cmd/obstudio/_skills
+          cp docs/examples.md observer-go/cmd/obstudio/_skills/examples.md
+
+      - name: go vet
+        working-directory: observer-go
+        run: go vet ./...
+
+      - name: Build binary
+        run: make build
+
+      - name: Run tests
+        run: make test

--- a/demo/python-flask-basic/Makefile
+++ b/demo/python-flask-basic/Makefile
@@ -1,10 +1,17 @@
-.PHONY: sync dev clean
+.PHONY: sync dev run clean
 
 sync:
 	uv sync
 
 dev: sync
 	uv run flask run --port 8000 --reload
+
+run: sync
+	OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+	OTEL_SERVICE_NAME=python-flask-basic \
+	OTEL_BSP_SCHEDULE_DELAY=100 \
+	OTEL_METRIC_EXPORT_INTERVAL=1000 \
+	uv run flask run --port 8000
 
 clean:
 	rm -rf .venv __pycache__ *.db .observe

--- a/demo/python-flask-basic/app.py
+++ b/demo/python-flask-basic/app.py
@@ -1,12 +1,46 @@
+from otel_setup import configure_opentelemetry
+
+configure_opentelemetry()
+
+from opentelemetry import metrics
+from opentelemetry.metrics import Observation
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from flask import Flask, jsonify, request
 
 app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app)
+
+meter = metrics.get_meter("python-flask-basic")
+
+tasks_created_counter = meter.create_counter(
+    "tasks.created.count",
+    description="Total tasks created",
+    unit="{tasks}",
+)
+
+tasks_completed_counter = meter.create_counter(
+    "tasks.completed.count",
+    description="Total tasks marked as completed",
+    unit="{tasks}",
+)
 
 tasks = [
     {"id": 1, "title": "Buy groceries", "done": False},
     {"id": 2, "title": "Walk the dog", "done": True},
 ]
 next_id = 3
+
+
+def _observe_collection_size(_options):
+    yield Observation(len(tasks))
+
+
+tasks_collection_gauge = meter.create_observable_gauge(
+    "tasks.collection.size",
+    callbacks=[_observe_collection_size],
+    description="Current number of tasks in the collection",
+    unit="{tasks}",
+)
 
 
 @app.get("/health")
@@ -34,6 +68,7 @@ def create_task():
     task = {"id": next_id, "title": body.get("title", ""), "done": False}
     next_id += 1
     tasks.append(task)
+    tasks_created_counter.add(1)
     return jsonify(task), 201
 
 
@@ -46,6 +81,8 @@ def update_task(task_id):
     task["title"] = body.get("title", task["title"])
     was_done = task["done"]
     task["done"] = body.get("done", task["done"])
+    if not was_done and task["done"]:
+        tasks_completed_counter.add(1)
     return jsonify(task)
 
 

--- a/demo/python-flask-basic/pyproject.toml
+++ b/demo/python-flask-basic/pyproject.toml
@@ -5,6 +5,10 @@ description = "Greenfield Flask task API -- demo app for obstudio skills"
 requires-python = ">=3.11"
 dependencies = [
     "flask>=3.1",
+    "opentelemetry-api>=1.40",
+    "opentelemetry-sdk>=1.40",
+    "opentelemetry-exporter-otlp-proto-http>=1.40",
+    "opentelemetry-instrumentation-flask>=0.61b0",
 ]
 
 [project.scripts]

--- a/skills/references/languages/python.md
+++ b/skills/references/languages/python.md
@@ -181,8 +181,13 @@ order_duration = meter.create_histogram(
 )
 
 # Observable Gauge (callback-based)
-def get_queue_depth(result):
-    result.observe(current_queue_depth())
+# CAUTION: The callback receives CallbackOptions, NOT an observation object.
+# It must yield Observation instances. Using result.observe() will raise
+# AttributeError at export time (not at registration), making it hard to catch.
+from opentelemetry.metrics import Observation
+
+def get_queue_depth(_options):
+    yield Observation(current_queue_depth())
 
 meter.create_observable_gauge(
     "orders.queue.depth",
@@ -240,3 +245,14 @@ For local development with the Observer:
   process gets its own SDK instance.
 - **Singleton provider**: Never call `trace.set_tracer_provider()` more
   than once. If existing OTel setup exists, extend it.
+- **Observable gauge callback signature**: The callback receives a
+  `CallbackOptions` argument and must **yield `Observation` objects**
+  (from `opentelemetry.metrics`). A common mistake is writing
+  `result.observe(value)` -- this fails with `AttributeError` at metric
+  export time, not at registration, so the error only surfaces after the
+  app is running. Correct pattern:
+  ```python
+  from opentelemetry.metrics import Observation
+  def my_callback(_options):
+      yield Observation(current_value())
+  ```


### PR DESCRIPTION
- Add GitHub Actions CI workflow for observer-go (vet, build, test)
- Update Python language reference with OTel instrumentation patterns
- Enhance Flask demo app with OTel metrics and instrumentation
- Add OTel dependencies to demo pyproject.toml

Made-with: Cursor