### PR TITLE
Implement Go kvstore example service

### DIFF
--- a/examples/go/kvstore/.golangci.yml
+++ b/examples/go/kvstore/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - ineffassign
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/examples/go/kvstore/Makefile
+++ b/examples/go/kvstore/Makefile
@@ -1,0 +1,15 @@
+.PHONY: build test lint run
+
+GOLANGCI_LINT_VERSION := v2.11.4
+
+build: test lint
+	go build ./...
+
+test:
+	go test ./...
+
+lint:
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
+
+run:
+	go run ./cmd/kvstore

--- a/examples/go/kvstore/README.md
+++ b/examples/go/kvstore/README.md
@@ -1,0 +1,109 @@
+# kvstore
+
+Example in-memory key/value database with a public JSON REST API.
+
+## Features
+
+- `set`, `get`, `delete`, and `list` operations.
+- `list` returns all keys by prefix.
+- Key limit: 256 bytes.
+- Value limit: 4 MiB.
+- Errors are returned when limits are exceeded.
+
+## Requirements
+
+- Go 1.22+
+- Network access on first lint run (the pinned `golangci-lint` version is fetched automatically)
+
+## Run
+
+```bash
+make run
+```
+
+The service listens on `:8080` by default. Set `PORT` to override.
+
+## REST API
+
+All endpoints use JSON request and response bodies.
+
+### `POST /set`
+
+Request:
+
+```json
+{"key":"app:1","value":"hello"}
+```
+
+Response:
+
+```json
+{"message":"ok"}
+```
+
+### `POST /get`
+
+Request:
+
+```json
+{"key":"app:1"}
+```
+
+Response:
+
+```json
+{"value":"hello"}
+```
+
+### `POST /delete`
+
+Request:
+
+```json
+{"key":"app:1"}
+```
+
+Response:
+
+```json
+{"message":"deleted"}
+```
+
+### `POST /list`
+
+Request:
+
+```json
+{"prefix":"app:"}
+```
+
+Response:
+
+```json
+{"keys":["app:1","app:2"]}
+```
+
+### `GET /health`
+
+Response:
+
+```json
+{"message":"ok"}
+```
+
+## Build, test, lint
+
+```bash
+make build
+```
+
+`build` runs tests and linting first, then compiles all packages.
+
+## Example curl session
+
+```bash
+curl -sS -X POST localhost:8080/set -H 'Content-Type: application/json' -d '{"key":"app:1","value":"value1"}'
+curl -sS -X POST localhost:8080/get -H 'Content-Type: application/json' -d '{"key":"app:1"}'
+curl -sS -X POST localhost:8080/list -H 'Content-Type: application/json' -d '{"prefix":"app:"}'
+curl -sS -X POST localhost:8080/delete -H 'Content-Type: application/json' -d '{"key":"app:1"}'
+```

--- a/examples/go/kvstore/cmd/kvstore/main.go
+++ b/examples/go/kvstore/cmd/kvstore/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"kvstore/internal/api"
+	"kvstore/internal/store"
+)
+
+func main() {
+	addr := ":8080"
+	if p := os.Getenv("PORT"); p != "" {
+		addr = ":" + p
+	}
+
+	s := store.New()
+	h := api.New(s)
+
+	server := &http.Server{
+		Addr:    addr,
+		Handler: h,
+	}
+
+	log.Printf("kvstore listening on %s", addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/examples/go/kvstore/go.mod
+++ b/examples/go/kvstore/go.mod
@@ -1,0 +1,3 @@
+module kvstore
+
+go 1.22

--- a/examples/go/kvstore/internal/api/api.go
+++ b/examples/go/kvstore/internal/api/api.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"kvstore/internal/store"
+)
+
+// Server provides HTTP handlers for key/value operations.
+type Server struct {
+	store *store.Store
+	mux   *http.ServeMux
+}
+
+// New creates a new API server for the given store.
+func New(s *store.Store) *Server {
+	srv := &Server{
+		store: s,
+		mux:   http.NewServeMux(),
+	}
+
+	srv.mux.HandleFunc("/set", srv.handleSet)
+	srv.mux.HandleFunc("/get", srv.handleGet)
+	srv.mux.HandleFunc("/delete", srv.handleDelete)
+	srv.mux.HandleFunc("/list", srv.handleList)
+	srv.mux.HandleFunc("/health", srv.handleHealth)
+
+	return srv
+}
+
+// ServeHTTP routes requests to API handlers.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+type setRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type keyRequest struct {
+	Key string `json:"key"`
+}
+
+type listRequest struct {
+	Prefix string `json:"prefix"`
+}
+
+type getResponse struct {
+	Value string `json:"value"`
+}
+
+type listResponse struct {
+	Keys []string `json:"keys"`
+}
+
+type messageResponse struct {
+	Message string `json:"message"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func (s *Server) handleSet(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r, http.MethodPost) {
+		return
+	}
+
+	var req setRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := s.store.Set(req.Key, req.Value); err != nil {
+		writeStoreError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, messageResponse{Message: "ok"})
+}
+
+func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r, http.MethodPost) {
+		return
+	}
+
+	var req keyRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	value, err := s.store.Get(req.Key)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, getResponse{Value: value})
+}
+
+func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r, http.MethodPost) {
+		return
+	}
+
+	var req keyRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := s.store.Delete(req.Key); err != nil {
+		writeStoreError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, messageResponse{Message: "deleted"})
+}
+
+func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r, http.MethodPost) {
+		return
+	}
+
+	var req listRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	keys, err := s.store.ListByPrefix(req.Prefix)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listResponse{Keys: keys})
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r, http.MethodGet) {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, messageResponse{Message: "ok"})
+}
+
+func allowMethod(w http.ResponseWriter, r *http.Request, method string) bool {
+	if r.Method != method {
+		w.Header().Set("Allow", method)
+		writeError(w, http.StatusMethodNotAllowed, fmt.Errorf("method %s is required", method))
+		return false
+	}
+	return true
+}
+
+func decodeJSON(r *http.Request, dst any) error {
+	defer func() {
+		_ = r.Body.Close()
+	}()
+
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return fmt.Errorf("invalid JSON body: %w", err)
+	}
+
+	if err := dec.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+		return errors.New("request body must contain a single JSON object")
+	}
+
+	return nil
+}
+
+func writeStoreError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		writeError(w, http.StatusNotFound, err)
+	case errors.Is(err, store.ErrKeyTooLarge), errors.Is(err, store.ErrValueTooLarge):
+		writeError(w, http.StatusBadRequest, err)
+	default:
+		writeError(w, http.StatusInternalServerError, err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	writeJSON(w, status, errorResponse{Error: err.Error()})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}

--- a/examples/go/kvstore/internal/api/api_test.go
+++ b/examples/go/kvstore/internal/api/api_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"kvstore/internal/store"
+)
+
+func TestAPISetGetListDelete(t *testing.T) {
+	h := New(store.New())
+
+	status, body := doJSON(t, h, http.MethodPost, "/set", map[string]string{"key": "app:a", "value": "1"})
+	if status != http.StatusOK {
+		t.Fatalf("/set status = %d, want %d; body=%s", status, http.StatusOK, body)
+	}
+
+	status, body = doJSON(t, h, http.MethodPost, "/set", map[string]string{"key": "app:b", "value": "2"})
+	if status != http.StatusOK {
+		t.Fatalf("/set status = %d, want %d; body=%s", status, http.StatusOK, body)
+	}
+
+	status, body = doJSON(t, h, http.MethodPost, "/get", map[string]string{"key": "app:a"})
+	if status != http.StatusOK {
+		t.Fatalf("/get status = %d, want %d; body=%s", status, http.StatusOK, body)
+	}
+	var getResp map[string]string
+	if err := json.Unmarshal([]byte(body), &getResp); err != nil {
+		t.Fatalf("unmarshal /get response: %v", err)
+	}
+	if getResp["value"] != "1" {
+		t.Fatalf("/get value = %q, want %q", getResp["value"], "1")
+	}
+
+	status, body = doJSON(t, h, http.MethodPost, "/list", map[string]string{"prefix": "app:"})
+	if status != http.StatusOK {
+		t.Fatalf("/list status = %d, want %d; body=%s", status, http.StatusOK, body)
+	}
+	var listResp struct {
+		Keys []string `json:"keys"`
+	}
+	if err := json.Unmarshal([]byte(body), &listResp); err != nil {
+		t.Fatalf("unmarshal /list response: %v", err)
+	}
+	if len(listResp.Keys) != 2 {
+		t.Fatalf("/list keys len = %d, want 2", len(listResp.Keys))
+	}
+
+	status, body = doJSON(t, h, http.MethodPost, "/delete", map[string]string{"key": "app:a"})
+	if status != http.StatusOK {
+		t.Fatalf("/delete status = %d, want %d; body=%s", status, http.StatusOK, body)
+	}
+
+	status, _ = doJSON(t, h, http.MethodPost, "/get", map[string]string{"key": "app:a"})
+	if status != http.StatusNotFound {
+		t.Fatalf("/get after delete status = %d, want %d", status, http.StatusNotFound)
+	}
+}
+
+func TestAPIKeyTooLarge(t *testing.T) {
+	h := New(store.New())
+	largeKey := strings.Repeat("k", store.MaxKeySize+1)
+
+	status, _ := doJSON(t, h, http.MethodPost, "/set", map[string]string{"key": largeKey, "value": "v"})
+	if status != http.StatusBadRequest {
+		t.Fatalf("/set status = %d, want %d", status, http.StatusBadRequest)
+	}
+}
+
+func TestAPIValueTooLarge(t *testing.T) {
+	h := New(store.New())
+	largeValue := strings.Repeat("v", store.MaxValueSize+1)
+
+	status, _ := doJSON(t, h, http.MethodPost, "/set", map[string]string{"key": "k", "value": largeValue})
+	if status != http.StatusBadRequest {
+		t.Fatalf("/set status = %d, want %d", status, http.StatusBadRequest)
+	}
+}
+
+func TestAPIMethodNotAllowed(t *testing.T) {
+	h := New(store.New())
+	req := httptest.NewRequest(http.MethodGet, "/set", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func doJSON(t *testing.T, h http.Handler, method, path string, payload any) (int, string) {
+	t.Helper()
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	return rr.Code, rr.Body.String()
+}

--- a/examples/go/kvstore/internal/store/store.go
+++ b/examples/go/kvstore/internal/store/store.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+const (
+	// MaxKeySize is the maximum key size in bytes.
+	MaxKeySize = 256
+	// MaxValueSize is the maximum value size in bytes.
+	MaxValueSize = 4 * 1024 * 1024
+)
+
+var (
+	// ErrNotFound indicates the key does not exist in the store.
+	ErrNotFound = errors.New("key not found")
+	// ErrKeyTooLarge indicates the key exceeds MaxKeySize.
+	ErrKeyTooLarge = errors.New("key exceeds 256-byte limit")
+	// ErrValueTooLarge indicates the value exceeds MaxValueSize.
+	ErrValueTooLarge = errors.New("value exceeds 4MiB limit")
+)
+
+// Store is an in-memory key/value database safe for concurrent access.
+type Store struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+// New creates a new empty Store.
+func New() *Store {
+	return &Store{data: make(map[string]string)}
+}
+
+// Set stores value under key.
+func (s *Store) Set(key, value string) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
+	if err := validateValue(value); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.data[key] = value
+	s.mu.Unlock()
+
+	return nil
+}
+
+// Get returns the value stored under key.
+func (s *Store) Get(key string) (string, error) {
+	if err := validateKey(key); err != nil {
+		return "", err
+	}
+
+	s.mu.RLock()
+	value, ok := s.data[key]
+	s.mu.RUnlock()
+	if !ok {
+		return "", ErrNotFound
+	}
+
+	return value, nil
+}
+
+// Delete removes key from the store.
+func (s *Store) Delete(key string) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.data[key]; !ok {
+		return ErrNotFound
+	}
+	delete(s.data, key)
+
+	return nil
+}
+
+// ListByPrefix returns all keys that start with prefix.
+func (s *Store) ListByPrefix(prefix string) ([]string, error) {
+	if len(prefix) > MaxKeySize {
+		return nil, fmt.Errorf("invalid prefix: %w", ErrKeyTooLarge)
+	}
+
+	s.mu.RLock()
+	keys := make([]string, 0)
+	for key := range s.data {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			keys = append(keys, key)
+		}
+	}
+	s.mu.RUnlock()
+
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func validateKey(key string) error {
+	if len(key) > MaxKeySize {
+		return fmt.Errorf("invalid key: %w", ErrKeyTooLarge)
+	}
+	return nil
+}
+
+func validateValue(value string) error {
+	if len(value) > MaxValueSize {
+		return fmt.Errorf("invalid value: %w", ErrValueTooLarge)
+	}
+	return nil
+}

--- a/examples/go/kvstore/internal/store/store_test.go
+++ b/examples/go/kvstore/internal/store/store_test.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestStoreSetGetDelete(t *testing.T) {
+	s := New()
+
+	if err := s.Set("k1", "v1"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	got, err := s.Get("k1")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got != "v1" {
+		t.Fatalf("Get() value = %q, want %q", got, "v1")
+	}
+
+	if err := s.Delete("k1"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	_, err = s.Get("k1")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreListByPrefix(t *testing.T) {
+	s := New()
+	mustSet(t, s, "app:1", "x")
+	mustSet(t, s, "app:2", "y")
+	mustSet(t, s, "other", "z")
+
+	keys, err := s.ListByPrefix("app:")
+	if err != nil {
+		t.Fatalf("ListByPrefix() error = %v", err)
+	}
+
+	want := []string{"app:1", "app:2"}
+	if len(keys) != len(want) {
+		t.Fatalf("ListByPrefix() len = %d, want %d", len(keys), len(want))
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("ListByPrefix() key[%d] = %q, want %q", i, keys[i], want[i])
+		}
+	}
+}
+
+func TestStoreLimits(t *testing.T) {
+	s := New()
+	largeKey := strings.Repeat("k", MaxKeySize+1)
+	if err := s.Set(largeKey, "v"); !errors.Is(err, ErrKeyTooLarge) {
+		t.Fatalf("Set() error = %v, want ErrKeyTooLarge", err)
+	}
+
+	largeValue := strings.Repeat("v", MaxValueSize+1)
+	if err := s.Set("k", largeValue); !errors.Is(err, ErrValueTooLarge) {
+		t.Fatalf("Set() error = %v, want ErrValueTooLarge", err)
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	s := New()
+	err := s.Delete("missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete() error = %v, want ErrNotFound", err)
+	}
+}
+
+func mustSet(t *testing.T, s *Store, key, value string) {
+	t.Helper()
+	if err := s.Set(key, value); err != nil {
+		t.Fatalf("Set(%q, %q) error = %v", key, value, err)
+	}
+}


### PR DESCRIPTION
- add in-memory concurrent key/value store with set, get, delete, and prefix list
- enforce limits: keys <= 256 bytes, values <= 4 MiB; return explicit errors on violations
- expose JSON REST API endpoints: POST /set, POST /get, POST /delete, POST /list, GET /health
- add unit tests for store behavior, API flows, and limit validation
- add Go module entrypoint and runnable server under cmd/kvstore
- add comprehensive README with usage, API contract, and curl examples
- add Makefile targets: build, test, lint, run with build gating on tests+lint

Prompt used:

Create an example database store in Go.

The database is a key/value store with typical set/get/list/delete operations supported. “list” operation must list all keys by prefix. Support public REST API for operations using JSON as request/response formats. Build, run and verify the example works. Include unit tests. Include documentation. Add doccoments to all public types and methods. Follow Effective Go recommendations.

Add Go linter and make sure all errors are handled.

Limit key sizes to 256 bytes and value sizes to 4MiB. Return errors if API call tries to exceed the limits.

Add makefile with "build”, “test”, “lint” targets. Make sure "build" target runs all tests and does linting.