### PR TITLE
Add VS Code observer lifecycle commands

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -23,7 +23,23 @@
     "commands": [
       {
         "command": "observability-studio.openObserver",
-        "title": "Open Observer"
+        "title": "Observability Studio: Open Observer"
+      },
+      {
+        "command": "observability-studio.statusMenu",
+        "title": "Observability Studio: Observer Status"
+      },
+      {
+        "command": "observability-studio.startObserver",
+        "title": "Observability Studio: Start Observer"
+      },
+      {
+        "command": "observability-studio.stopObserver",
+        "title": "Observability Studio: Stop Observer"
+      },
+      {
+        "command": "observability-studio.restartObserver",
+        "title": "Observability Studio: Restart Observer"
       }
     ]
   },
@@ -40,7 +56,7 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "test:unit": "npm run compile-tests && node --test --experimental-test-coverage out/test/extension.test.js",
+    "test:unit": "npm run compile-tests && node --test --experimental-test-coverage out/test/extension.test.js out/test/webview-html.test.js out/test/observer-lifecycle.test.js",
     "test:integration": "tsc --outDir out --rootDir src --module Node16 --target ES2022 --strict --skipLibCheck --esModuleInterop src/test/extension-integration.test.ts && node --test out/test/extension-integration.test.js",
     "test:all": "npm run test:unit && npm run test:integration",
     "test": "vscode-test"

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,16 +1,37 @@
 import * as cp from 'node:child_process';
 import * as net from 'node:net';
-import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { resolveBackend } from './backend';
+import {
+	assertObserverRunCurrent,
+	beginObserverStart,
+	completeObserverStart,
+	createObserverLifecycleState,
+	failObserverStart,
+	finishObserverRun,
+	isObserverLifecycleCancelled,
+	isObserverRunCurrent,
+	stopObserverRun,
+} from './observer-lifecycle';
+import {
+	getObserverWebviewHtml,
+	getObserverLoadingWebviewHtml,
+	getObserverErrorWebviewHtml,
+	getObserverStoppedWebviewHtml,
+	getStatusBarUpdate,
+	getErrorMessage,
+} from './webview-html';
 
 // Extension-global observer state. The extension hosts one local observer process
 // and optionally one WebView panel that embeds its UI.
 let observerProcess: cp.ChildProcess | undefined;
 let observerOutputChannel: vscode.OutputChannel | undefined;
 let observerPanel: vscode.WebviewPanel | undefined;
-let observerPort: number | undefined;
 let observerStartupPromise: Promise<void> | undefined;
+let observerStopPromise: Promise<void> | undefined;
+let observerStatusBarItem: vscode.StatusBarItem | undefined;
+const observerLifecycleState = createObserverLifecycleState();
+let lastObserverPanelRenderKey: string | undefined;
 
 const observerPanelViewType = 'observabilityStudioObserver';
 
@@ -22,72 +43,234 @@ const observerOtlpGrpcPort = 4317;
 export async function activate(context: vscode.ExtensionContext) {
 	observerOutputChannel = vscode.window.createOutputChannel('Observability Studio');
 	context.subscriptions.push(observerOutputChannel);
+	logObserverLifecycle('Extension activated.');
 
 	context.subscriptions.push(
 		vscode.window.registerWebviewPanelSerializer(observerPanelViewType, {
 			async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel) {
 				observerPanel = webviewPanel;
 				configureObserverPanel(webviewPanel, context);
-				await showObserverWhenReady(context);
+				logObserverLifecycle('Restored observer webview panel.');
+				webviewPanel.webview.html = getObserverLoadingWebviewHtml();
+				try {
+					await ensureObserverRunning(context);
+					refreshObserverPanel();
+				} catch {
+					refreshObserverPanel();
+				}
 			},
 		}),
 	);
 
+	// Status bar item reflects observer state and toggles the panel.
+	observerStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+	observerStatusBarItem.command = 'observability-studio.openObserver';
+	updateStatusBar('starting');
+	observerStatusBarItem.show();
+	logObserverLifecycle('Status bar item created.');
+
 	// Start the packaged observer as soon as the extension activates so the UI
 	// and OTLP receiver are ready before the user opens the panel.
-	void startObserver(context, observerOutputChannel).catch((error) => {
+	void ensureObserverRunning(context).catch((error) => {
+		if (isObserverLifecycleCancelled(error)) {
+			return;
+		}
 		const message = getErrorMessage(error);
-		observerOutputChannel?.appendLine(`Observer startup failed: ${message}`);
+		appendObserverOutputLine(`Observer startup failed: ${message}`);
 		void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
-		refreshObserverPanel();
 	});
 
 	const openObserverDisposable = vscode.commands.registerCommand('observability-studio.openObserver', () => {
 		openObserverPanel(context);
 	});
-	const observerStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
 
-	observerStatusBarItem.command = 'observability-studio.openObserver';
-	observerStatusBarItem.text = '$(pulse) Observer';
-	observerStatusBarItem.tooltip = 'Open Observability Studio Observer';
-	observerStatusBarItem.show();
+	const statusMenuDisposable = vscode.commands.registerCommand('observability-studio.statusMenu', async () => {
+		if (observerLifecycleState.status === 'running') {
+			const pick = await vscode.window.showQuickPick(
+				[
+					{ label: '$(window) Open Observer', id: 'open' },
+					{ label: '$(debug-restart) Restart Observer', id: 'restart' },
+					{ label: '$(debug-stop) Stop Observer', id: 'stop' },
+					{ label: '$(output) Show Output Log', id: 'log' },
+				],
+				{ placeHolder: `Observer is running on port ${observerLifecycleState.port ?? '?'}` },
+			);
+			if (pick?.id === 'open') {
+				void vscode.commands.executeCommand('observability-studio.openObserver');
+			} else if (pick?.id === 'restart') {
+				void vscode.commands.executeCommand('observability-studio.restartObserver');
+			} else if (pick?.id === 'stop') {
+				void vscode.commands.executeCommand('observability-studio.stopObserver');
+			} else if (pick?.id === 'log') {
+				observerOutputChannel?.show();
+			}
+		} else if (observerLifecycleState.status === 'starting') {
+			const pick = await vscode.window.showQuickPick(
+				[
+					{ label: '$(debug-stop) Stop Observer', id: 'stop' },
+					{ label: '$(debug-restart) Restart Observer', id: 'restart' },
+					{ label: '$(output) Show Output Log', id: 'log' },
+				],
+				{ placeHolder: 'Observer is starting...' },
+			);
+			if (pick?.id === 'stop') {
+				void vscode.commands.executeCommand('observability-studio.stopObserver');
+			} else if (pick?.id === 'restart') {
+				void vscode.commands.executeCommand('observability-studio.restartObserver');
+			} else if (pick?.id === 'log') {
+				observerOutputChannel?.show();
+			}
+		} else {
+			const pick = await vscode.window.showQuickPick(
+				[
+					{ label: '$(play) Start Observer', id: 'start' },
+					{ label: '$(output) Show Output Log', id: 'log' },
+				],
+				{
+					placeHolder: observerLifecycleState.startupError
+						? `Observer failed: ${observerLifecycleState.startupError}`
+						: 'Observer is stopped',
+				},
+			);
+			if (pick?.id === 'start') {
+				void vscode.commands.executeCommand('observability-studio.startObserver');
+			} else if (pick?.id === 'log') {
+				observerOutputChannel?.show();
+			}
+		}
+	});
+
+	const startDisposable = vscode.commands.registerCommand('observability-studio.startObserver', async () => {
+		if (observerLifecycleState.status === 'running') {
+			void vscode.window.showInformationMessage('Observer is already running.');
+			return;
+		}
+		if (observerLifecycleState.status === 'starting') {
+			void vscode.window.showInformationMessage('Observer is already starting.');
+			return;
+		}
+		try {
+			await ensureObserverRunning(context);
+			refreshObserverPanel();
+		} catch (error) {
+			if (isObserverLifecycleCancelled(error)) {
+				refreshObserverPanel();
+				return;
+			}
+			const message = getErrorMessage(error);
+			void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
+			refreshObserverPanel();
+		}
+	});
+
+	const stopDisposable = vscode.commands.registerCommand('observability-studio.stopObserver', async () => {
+		if (observerProcess === undefined && observerStartupPromise === undefined) {
+			void vscode.window.showInformationMessage('Observer is not running.');
+			return;
+		}
+		await stopObserver();
+		void vscode.window.showInformationMessage('Observer stopped.');
+	});
+
+	const restartDisposable = vscode.commands.registerCommand('observability-studio.restartObserver', async () => {
+		await stopObserver();
+		try {
+			await ensureObserverRunning(context);
+			refreshObserverPanel();
+		} catch (error) {
+			if (isObserverLifecycleCancelled(error)) {
+				refreshObserverPanel();
+				return;
+			}
+			const message = getErrorMessage(error);
+			void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
+			refreshObserverPanel();
+		}
+	});
 
 	context.subscriptions.push(openObserverDisposable);
+	context.subscriptions.push(statusMenuDisposable);
+	context.subscriptions.push(startDisposable);
+	context.subscriptions.push(stopDisposable);
+	context.subscriptions.push(restartDisposable);
 	context.subscriptions.push(observerStatusBarItem);
 	context.subscriptions.push({
 		dispose: () => {
-			stopObserver();
+			logObserverLifecycle('Extension disposed; terminating observer process.');
+			stopObserverRun(observerLifecycleState);
+			observerStartupPromise = undefined;
+			observerStopPromise = undefined;
+			terminateObserverProcess(observerProcess, 'SIGTERM');
+			observerProcess = undefined;
 		},
 	});
 }
 
 export function deactivate() {
-	stopObserver();
+	logObserverLifecycle('Extension deactivated; terminating observer process.');
+	stopObserverRun(observerLifecycleState);
+	observerStartupPromise = undefined;
+	observerStopPromise = undefined;
+	terminateObserverProcess(observerProcess, 'SIGTERM');
+	observerProcess = undefined;
 }
 
-async function startObserver(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel): Promise<void> {
+// ---------------------------------------------------------------------------
+// Observer process lifecycle
+// ---------------------------------------------------------------------------
+
+async function ensureObserverRunning(context: vscode.ExtensionContext): Promise<void> {
 	if (observerStartupPromise !== undefined) {
+		logObserverLifecycle('Start requested while startup is already in progress; waiting for existing startup.');
 		return observerStartupPromise;
 	}
-
-	if (observerProcess !== undefined) {
+	if (observerStopPromise !== undefined) {
+		logObserverLifecycle('Start requested while stop is in progress; waiting for observer shutdown.');
+		await observerStopPromise;
+	}
+	if (observerLifecycleState.status === 'running' && observerProcess !== undefined) {
+		logObserverLifecycle(`Start requested while observer is already running on port ${observerLifecycleState.port ?? '?'}.`);
 		return;
 	}
 
-	observerStartupPromise = (async () => {
+	if (observerOutputChannel === undefined) {
+		throw new Error('Observer output channel is not initialized.');
+	}
+
+	return startObserver(context);
+}
+
+async function startObserver(context: vscode.ExtensionContext): Promise<void> {
+	if (observerStartupPromise !== undefined) {
+		return observerStartupPromise;
+	}
+	if (observerLifecycleState.status === 'running' && observerProcess !== undefined) {
+		return;
+	}
+
+	const runId = beginObserverStart(observerLifecycleState);
+	let startedProcess: cp.ChildProcess | undefined;
+
+	logObserverLifecycle(`Starting observer run ${runId}.`);
+	syncObserverUi();
+
+	const startupPromise = (async () => {
 		const backend = resolveBackend(context.extensionPath);
-		observerPort = await getAvailablePort();
+		const observerPort = await getAvailablePort();
+		logObserverLifecycle(`Run ${runId}: reserved UI port ${observerPort}.`);
+		assertObserverRunCurrent(observerLifecycleState, runId);
 
-		// The observer UI can move to any free localhost port, but OTLP stays fixed so
-		// external telemetry producers do not need to rediscover the receiver port.
 		const otlpHttpPort = await ensurePortAvailable(observerOtlpHttpPort);
+		assertObserverRunCurrent(observerLifecycleState, runId);
 		const otlpGrpcPort = await ensurePortAvailable(observerOtlpGrpcPort);
+		assertObserverRunCurrent(observerLifecycleState, runId);
+		logObserverLifecycle(`Run ${runId}: OTLP ports ready (HTTP ${otlpHttpPort}, gRPC ${otlpGrpcPort}).`);
 
-		observerOutputChannel?.appendLine(`Starting ${backend.label} on http://127.0.0.1:${observerPort}`);
-		observerOutputChannel?.appendLine(`OTLP/HTTP receiver listening on http://127.0.0.1:${otlpHttpPort}`);
-		observerOutputChannel?.appendLine(`OTLP/gRPC receiver listening on 127.0.0.1:${otlpGrpcPort}`);
+		appendObserverOutputLine(`Starting ${backend.label} on http://127.0.0.1:${observerPort}`);
+		appendObserverOutputLine(`OTLP/HTTP receiver listening on http://127.0.0.1:${otlpHttpPort}`);
+		appendObserverOutputLine(`OTLP/gRPC receiver listening on 127.0.0.1:${otlpGrpcPort}`);
 
-		observerProcess = cp.spawn(backend.command, backend.args, {
+		startedProcess = cp.spawn(backend.command, backend.args, {
 			cwd: backend.cwd,
 			env: {
 				...process.env,
@@ -100,123 +283,186 @@ async function startObserver(context: vscode.ExtensionContext, outputChannel: vs
 			},
 			stdio: ['ignore', 'pipe', 'pipe'],
 		});
+		assertObserverRunCurrent(observerLifecycleState, runId);
+		logObserverLifecycle(`Run ${runId}: spawned observer PID ${startedProcess.pid ?? 'unknown'}.`);
 
-		observerProcess.stdout?.on('data', (chunk: Buffer | string) => {
-			outputChannel.append(chunk.toString());
+		observerProcess = startedProcess;
+
+		startedProcess.stdout?.on('data', (chunk: Buffer | string) => {
+			appendObserverOutput(chunk.toString());
 		});
 
-		observerProcess.stderr?.on('data', (chunk: Buffer | string) => {
-			outputChannel.append(chunk.toString());
+		startedProcess.stderr?.on('data', (chunk: Buffer | string) => {
+			appendObserverOutput(chunk.toString());
 		});
 
-		observerProcess.on('exit', (code, signal) => {
-			outputChannel.appendLine(`Observer exited with code=${code ?? 'null'} signal=${signal ?? 'null'}`);
-			observerProcess = undefined;
-			observerPort = undefined;
-			observerStartupPromise = undefined;
-			refreshObserverPanel();
+		startedProcess.on('exit', (code, signal) => {
+			appendObserverOutputLine(`Observer exited with code=${code ?? 'null'} signal=${signal ?? 'null'}`);
+			logObserverLifecycle(`Run ${runId}: observer process exited with code=${code ?? 'null'} signal=${signal ?? 'null'}.`);
+			if (observerProcess === startedProcess) {
+				observerProcess = undefined;
+			}
+			if (finishObserverRun(observerLifecycleState, runId)) {
+				syncObserverUi();
+			}
 		});
 
-		observerProcess.on('error', (error) => {
-			outputChannel.appendLine(`Failed to start observer: ${error.message}`);
-			void vscode.window.showErrorMessage(`Observability Studio failed to start observer: ${error.message}`);
-			observerProcess = undefined;
-			observerPort = undefined;
-			observerStartupPromise = undefined;
-			refreshObserverPanel();
+		startedProcess.on('error', (error) => {
+			appendObserverOutputLine(`Failed to start observer: ${error.message}`);
+			logObserverLifecycle(`Run ${runId}: observer process error: ${error.message}`);
+			if (observerProcess === startedProcess) {
+				observerProcess = undefined;
+			}
+			if (failObserverStart(observerLifecycleState, runId, error.message)) {
+				syncObserverUi();
+				void vscode.window.showErrorMessage(`Observability Studio failed to start observer: ${error.message}`);
+			}
 		});
 
-		refreshObserverPanel();
-		await waitForObserverReady();
+		await waitForObserverReady(observerPort, runId);
+		logObserverLifecycle(`Run ${runId}: observer is accepting connections on UI port ${observerPort}.`);
+		if (!completeObserverStart(observerLifecycleState, runId, observerPort)) {
+			if (observerProcess === startedProcess) {
+				observerProcess = undefined;
+			}
+			logObserverLifecycle(`Run ${runId}: startup completed after the run was superseded; terminating stale process.`);
+			terminateObserverProcess(startedProcess, 'SIGTERM');
+			return;
+		}
+
+		syncObserverUi();
 	})().catch((error) => {
-		observerStartupPromise = undefined;
+		if (isObserverLifecycleCancelled(error)) {
+			logObserverLifecycle(`Run ${runId}: startup cancelled because lifecycle state changed.`);
+			if (observerProcess === startedProcess) {
+				observerProcess = undefined;
+			}
+			terminateObserverProcess(startedProcess, 'SIGTERM');
+			return;
+		}
+
+		if (observerProcess === startedProcess) {
+			observerProcess = undefined;
+		}
+		terminateObserverProcess(startedProcess, 'SIGTERM');
+		if (failObserverStart(observerLifecycleState, runId, getErrorMessage(error))) {
+			logObserverLifecycle(`Run ${runId}: startup failed: ${getErrorMessage(error)}`);
+			syncObserverUi();
+		}
 		throw error;
+	}).finally(() => {
+		if (observerStartupPromise === startupPromise) {
+			observerStartupPromise = undefined;
+		}
 	});
 
+	observerStartupPromise = startupPromise;
 	return observerStartupPromise;
 }
 
-function stopObserver(): void {
-	if (observerProcess === undefined) {
+async function stopObserver(): Promise<void> {
+	if (observerStopPromise !== undefined) {
+		logObserverLifecycle('Stop requested while shutdown is already in progress; waiting for existing shutdown.');
+		return observerStopPromise;
+	}
+
+	const proc = observerProcess;
+	if (proc === undefined && observerStartupPromise === undefined) {
+		logObserverLifecycle('Stop requested but observer is already idle.');
 		return;
 	}
 
-	observerProcess.kill();
+	logObserverLifecycle(
+		`Stopping observer (status=${observerLifecycleState.status}, pid=${proc?.pid ?? 'none'}, port=${observerLifecycleState.port ?? 'none'}).`,
+	);
+	stopObserverRun(observerLifecycleState);
 	observerProcess = undefined;
-	observerPort = undefined;
+	observerStartupPromise = undefined;
+	syncObserverUi();
+
+	if (proc === undefined) {
+		logObserverLifecycle('No observer process existed; shutdown completed after clearing in-flight startup state.');
+		return;
+	}
+
+	const stopPromise = (async () => {
+		const exitPromise = new Promise<void>((resolve) => {
+			const timeout = setTimeout(() => {
+				terminateObserverProcess(proc, 'SIGKILL');
+				resolve();
+			}, 2000);
+			proc.once('exit', () => {
+				clearTimeout(timeout);
+				resolve();
+			});
+		});
+
+		terminateObserverProcess(proc, 'SIGTERM');
+		await exitPromise;
+		await delay(300);
+	})().finally(() => {
+		if (observerStopPromise === stopPromise) {
+			observerStopPromise = undefined;
+		}
+	});
+
+	observerStopPromise = stopPromise;
+	return observerStopPromise;
+}
+
+function syncObserverUi(): void {
+	updateStatusBar(observerLifecycleState.status);
 	refreshObserverPanel();
 }
 
-// Ask the OS for an ephemeral localhost port for the observer HTTP UI.
-async function getAvailablePort(): Promise<number> {
-	return new Promise((resolve, reject) => {
-		const server = net.createServer();
-
-		server.once('error', reject);
-		server.listen(0, '127.0.0.1', () => {
-			const address = server.address();
-			if (address === null || typeof address === 'string') {
-				server.close(() => {
-					reject(new Error('Unable to allocate a local port for the observer.'));
-				});
-				return;
-			}
-
-			server.close((error) => {
-				if (error) {
-					reject(error);
-					return;
-				}
-
-				resolve(address.port);
-			});
-		});
-	});
-}
-
-// Probe the fixed OTLP port during startup so activation can fail with a clear
-// message before spawning the observer process.
-async function ensurePortAvailable(port: number): Promise<number> {
-	return new Promise((resolve, reject) => {
-		const server = net.createServer();
-
-		server.once('error', (error) => {
-			reject(error);
-		});
-		server.listen(port, '127.0.0.1', () => {
-			server.close((error) => {
-				if (error) {
-					reject(error);
-					return;
-				}
-
-				resolve(port);
-			});
-		});
-	});
-}
-
-async function openObserverPanel(context: vscode.ExtensionContext): Promise<void> {
-	// Reuse the existing panel so the embedded app keeps its current state when the
-	// user invokes the command again.
-	if (observerPanel !== undefined) {
-		await showObserverWhenReady(context);
-		observerPanel.reveal(vscode.ViewColumn.One);
+function terminateObserverProcess(
+	proc: cp.ChildProcess | undefined,
+	signal: NodeJS.Signals,
+): void {
+	if (proc === undefined || proc.exitCode !== null || proc.signalCode !== null) {
 		return;
 	}
 
-	observerPanel = vscode.window.createWebviewPanel(
-		observerPanelViewType,
-		'Observer',
-		vscode.ViewColumn.One,
-		{
-			enableScripts: true,
-			retainContextWhenHidden: true,
-		},
-	);
+	proc.kill(signal);
+}
 
-	configureObserverPanel(observerPanel, context);
-	await showObserverWhenReady(context);
+// ---------------------------------------------------------------------------
+// WebView panel
+// ---------------------------------------------------------------------------
+
+async function openObserverPanel(context: vscode.ExtensionContext): Promise<void> {
+	if (observerPanel === undefined) {
+		logObserverLifecycle('Creating observer webview panel.');
+		lastObserverPanelRenderKey = undefined;
+		observerPanel = vscode.window.createWebviewPanel(
+			observerPanelViewType,
+			'Observer',
+			vscode.ViewColumn.One,
+			{
+				enableScripts: true,
+				retainContextWhenHidden: true,
+			},
+		);
+		configureObserverPanel(observerPanel, context);
+	}
+
+	logObserverLifecycle('Revealing observer webview panel.');
+	observerPanel.reveal(vscode.ViewColumn.One);
+
+	// If already running, show the UI immediately.
+	if (observerLifecycleState.status === 'running' && observerLifecycleState.port !== undefined) {
+		refreshObserverPanel();
+		return;
+	}
+
+	// Not running — show loading, auto-start, then show result.
+	observerPanel.webview.html = getObserverLoadingWebviewHtml();
+	try {
+		await ensureObserverRunning(context);
+		refreshObserverPanel();
+	} catch {
+		refreshObserverPanel();
+	}
 }
 
 function configureObserverPanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext): void {
@@ -225,6 +471,8 @@ function configureObserverPanel(panel: vscode.WebviewPanel, context: vscode.Exte
 	};
 	panel.onDidDispose(() => {
 		if (observerPanel === panel) {
+			logObserverLifecycle('Observer webview panel disposed.');
+			lastObserverPanelRenderKey = undefined;
 			observerPanel = undefined;
 		}
 	}, undefined, context.subscriptions);
@@ -235,41 +483,115 @@ function refreshObserverPanel(): void {
 		return;
 	}
 
-	observerPanel.webview.html = observerPort === undefined
-		? getObserverLoadingWebviewHtml()
-		: getObserverWebviewHtml(observerPort);
-}
+	const renderKey = `${observerLifecycleState.status}:${observerLifecycleState.port ?? 'none'}:${observerLifecycleState.startupError ?? 'none'}`;
+	if (renderKey !== lastObserverPanelRenderKey) {
+		logObserverLifecycle(`Rendering observer panel state ${renderKey}.`);
+		lastObserverPanelRenderKey = renderKey;
+	}
 
-async function showObserverWhenReady(context: vscode.ExtensionContext): Promise<void> {
-	refreshObserverPanel();
-
-	try {
-		if (observerOutputChannel === undefined) {
-			throw new Error('Observer output channel is not initialized.');
-		}
-
-		await startObserver(context, observerOutputChannel);
-		refreshObserverPanel();
-	} catch (error) {
-		refreshObserverPanel();
-		throw error;
+	switch (observerLifecycleState.status) {
+		case 'running':
+			observerPanel.webview.html = observerLifecycleState.port === undefined
+				? getObserverLoadingWebviewHtml()
+				: getObserverWebviewHtml(observerLifecycleState.port);
+			return;
+		case 'error':
+			observerPanel.webview.html = getObserverErrorWebviewHtml(
+				observerLifecycleState.startupError ?? 'Observer could not start.',
+			);
+			return;
+		case 'starting':
+			observerPanel.webview.html = getObserverLoadingWebviewHtml();
+			return;
+		case 'stopped':
+			observerPanel.webview.html = getObserverStoppedWebviewHtml();
+			return;
 	}
 }
 
-async function waitForObserverReady(): Promise<void> {
-	if (observerPort === undefined) {
-		throw new Error('Observer port is not available.');
-	}
+// ---------------------------------------------------------------------------
+// Port helpers
+// ---------------------------------------------------------------------------
 
+async function getAvailablePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			if (address === null || typeof address === 'string') {
+				server.close(() => reject(new Error('Unable to allocate a local port for the observer.')));
+				return;
+			}
+			server.close((error) => {
+				if (error) { reject(error); return; }
+				resolve(address.port);
+			});
+		});
+	});
+}
+
+async function ensurePortAvailable(port: number): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.once('error', (error: NodeJS.ErrnoException) => {
+			if (error.code === 'EADDRINUSE') {
+				void identifyPortOwner(port).then((owner) => {
+					const detail = owner
+						? `Port ${port} is already in use by "${owner}".`
+						: `Port ${port} is already in use.`;
+					logObserverLifecycle(detail);
+					reject(new Error(
+						`${detail} Stop the other process or run: kill $(lsof -ti :${port})`
+					));
+				});
+				return;
+			}
+			logObserverLifecycle(`Port check failed for ${port}: ${error.message}`);
+			reject(error);
+		});
+		server.listen(port, '127.0.0.1', () => {
+			server.close((error) => {
+				if (error) { reject(error); return; }
+				resolve(port);
+			});
+		});
+	});
+}
+
+async function identifyPortOwner(port: number): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		cp.exec(`lsof -i :${port} -sTCP:LISTEN -n -P 2>/dev/null`, { timeout: 3000 }, (error, stdout) => {
+			if (error || !stdout) { resolve(undefined); return; }
+			const lines = stdout.trim().split('\n');
+			if (lines.length < 2) { resolve(undefined); return; }
+			const fields = lines[1].split(/\s+/);
+			const command = fields[0];
+			const pid = fields[1];
+			resolve(command && pid ? `${command} (PID ${pid})` : undefined);
+		});
+	});
+}
+
+async function waitForObserverReady(port: number, runId: number): Promise<void> {
 	const startupDeadline = Date.now() + 15_000;
 	let lastError: unknown;
 
 	while (Date.now() < startupDeadline) {
+		assertObserverRunCurrent(observerLifecycleState, runId);
+
 		try {
-			await waitForPort(observerPort, 500);
+			await waitForPort(port, 500);
+			assertObserverRunCurrent(observerLifecycleState, runId);
 			return;
 		} catch (error) {
 			lastError = error;
+			if (isObserverLifecycleCancelled(error)) {
+				throw error;
+			}
+			if (!isObserverRunCurrent(observerLifecycleState, runId)) {
+				assertObserverRunCurrent(observerLifecycleState, runId);
+			}
 			if (observerProcess === undefined) {
 				break;
 			}
@@ -277,6 +599,9 @@ async function waitForObserverReady(): Promise<void> {
 		}
 	}
 
+	if (lastError !== undefined) {
+		logObserverLifecycle(`Run ${runId}: readiness check timed out on port ${port}: ${getErrorMessage(lastError)}`);
+	}
 	throw lastError instanceof Error
 		? lastError
 		: new Error('Observer did not become ready in time.');
@@ -286,16 +611,12 @@ async function waitForPort(port: number, timeoutMs: number): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const socket = new net.Socket();
 		let settled = false;
-
 		const finish = (callback: () => void) => {
-			if (settled) {
-				return;
-			}
+			if (settled) { return; }
 			settled = true;
 			socket.destroy();
 			callback();
 		};
-
 		socket.setTimeout(timeoutMs);
 		socket.once('connect', () => finish(resolve));
 		socket.once('timeout', () => finish(() => reject(new Error(`Timed out waiting for observer on port ${port}.`))));
@@ -305,83 +626,39 @@ async function waitForPort(port: number, timeoutMs: number): Promise<void> {
 }
 
 function delay(ms: number): Promise<void> {
-	return new Promise((resolve) => {
-		setTimeout(resolve, ms);
-	});
+	return new Promise((resolve) => { setTimeout(resolve, ms); });
 }
 
-function getObserverWebviewHtml(port: number): string {
-	const observerUrl = `http://127.0.0.1:${port}`;
-
-	return `<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta
-		http-equiv="Content-Security-Policy"
-		content="default-src 'none'; frame-src ${observerUrl}; style-src 'unsafe-inline'; worker-src 'none';"
-	>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Observer</title>
-	<style>
-		html, body, iframe {
-			height: 100%;
-			margin: 0;
-			padding: 0;
-			width: 100%;
-		}
-
-		body {
-			background: var(--vscode-editor-background);
-		}
-
-		iframe {
-			border: 0;
-		}
-	</style>
-</head>
-<body>
-	<iframe src="${observerUrl}" title="Observer" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
-</body>
-</html>`;
-}
-
-function getObserverLoadingWebviewHtml(): string {
-	return `<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta
-		http-equiv="Content-Security-Policy"
-		content="default-src 'none'; style-src 'unsafe-inline';"
-	>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Observer</title>
-	<style>
-		body {
-			align-items: center;
-			background: var(--vscode-editor-background);
-			color: var(--vscode-foreground);
-			display: flex;
-			font-family: var(--vscode-font-family);
-			height: 100vh;
-			justify-content: center;
-			margin: 0;
-			padding: 24px;
-			text-align: center;
-		}
-	</style>
-</head>
-<body>
-	<div>Observability Studio is starting…</div>
-</body>
-</html>`;
-}
-
-function getErrorMessage(error: unknown): string {
-	if (error instanceof Error) {
-		return error.message;
+function appendObserverOutput(text: string): void {
+	if (observerOutputChannel === undefined) {
+		return;
 	}
 
-	return String(error);
+	try {
+		observerOutputChannel.append(text);
+	} catch {
+		// VS Code can dispose the output channel during extension-host shutdown.
+	}
+}
+
+function appendObserverOutputLine(text: string): void {
+	appendObserverOutput(`${text}\n`);
+}
+
+function logObserverLifecycle(message: string): void {
+	appendObserverOutputLine(`[extension] ${message}`);
+}
+
+// ---------------------------------------------------------------------------
+// Status bar
+// ---------------------------------------------------------------------------
+
+function updateStatusBar(state: 'starting' | 'running' | 'stopped' | 'error'): void {
+	if (observerStatusBarItem === undefined) {
+		return;
+	}
+	const update = getStatusBarUpdate(state);
+	observerStatusBarItem.text = update.text;
+	observerStatusBarItem.tooltip = update.tooltip;
+	observerStatusBarItem.command = update.command;
 }

--- a/extension/src/observer-lifecycle.ts
+++ b/extension/src/observer-lifecycle.ts
@@ -1,0 +1,106 @@
+export type ObserverLifecycleStatus = 'starting' | 'running' | 'stopped' | 'error';
+
+export interface ObserverLifecycleState {
+	activeRunId: number | undefined;
+	currentRunId: number;
+	port: number | undefined;
+	startupError: string | undefined;
+	status: ObserverLifecycleStatus;
+}
+
+export class ObserverLifecycleCancelledError extends Error {
+	constructor() {
+		super('Observer lifecycle changed while startup was in progress.');
+		this.name = 'ObserverLifecycleCancelledError';
+	}
+}
+
+export function createObserverLifecycleState(): ObserverLifecycleState {
+	return {
+		activeRunId: undefined,
+		currentRunId: 0,
+		port: undefined,
+		startupError: undefined,
+		status: 'stopped',
+	};
+}
+
+export function beginObserverStart(state: ObserverLifecycleState): number {
+	const runId = state.currentRunId + 1;
+
+	state.activeRunId = runId;
+	state.currentRunId = runId;
+	state.port = undefined;
+	state.startupError = undefined;
+	state.status = 'starting';
+
+	return runId;
+}
+
+export function stopObserverRun(state: ObserverLifecycleState): void {
+	state.activeRunId = undefined;
+	state.currentRunId += 1;
+	state.port = undefined;
+	state.startupError = undefined;
+	state.status = 'stopped';
+}
+
+export function isObserverRunCurrent(state: ObserverLifecycleState, runId: number): boolean {
+	return state.activeRunId === runId;
+}
+
+export function assertObserverRunCurrent(state: ObserverLifecycleState, runId: number): void {
+	if (!isObserverRunCurrent(state, runId)) {
+		throw new ObserverLifecycleCancelledError();
+	}
+}
+
+export function completeObserverStart(
+	state: ObserverLifecycleState,
+	runId: number,
+	port: number,
+): boolean {
+	if (!isObserverRunCurrent(state, runId)) {
+		return false;
+	}
+
+	state.port = port;
+	state.startupError = undefined;
+	state.status = 'running';
+
+	return true;
+}
+
+export function failObserverStart(
+	state: ObserverLifecycleState,
+	runId: number,
+	errorMessage: string,
+): boolean {
+	if (!isObserverRunCurrent(state, runId)) {
+		return false;
+	}
+
+	state.activeRunId = undefined;
+	state.port = undefined;
+	state.startupError = errorMessage;
+	state.status = 'error';
+
+	return true;
+}
+
+export function finishObserverRun(state: ObserverLifecycleState, runId: number): boolean {
+	if (!isObserverRunCurrent(state, runId)) {
+		return false;
+	}
+
+	state.activeRunId = undefined;
+	state.port = undefined;
+	state.startupError = undefined;
+	state.status = 'stopped';
+
+	return true;
+}
+
+export function isObserverLifecycleCancelled(error: unknown): boolean {
+	return error instanceof ObserverLifecycleCancelledError;
+}

--- a/extension/src/test/extension-integration.test.ts
+++ b/extension/src/test/extension-integration.test.ts
@@ -174,6 +174,53 @@ it('integration: extension.js exports activate and deactivate', { timeout: 120_0
 		source.includes('obstudio'),
 		'extension.js should reference obstudio binary'
 	);
+
+	// Verify all 5 commands are registered in the compiled bundle
+	for (const cmd of [
+		'observability-studio.openObserver',
+		'observability-studio.statusMenu',
+		'observability-studio.startObserver',
+		'observability-studio.stopObserver',
+		'observability-studio.restartObserver',
+	]) {
+		assert.ok(source.includes(cmd), `extension.js should register command "${cmd}"`);
+	}
+
+	// Verify status bar states are present
+	assert.ok(source.includes('loading~spin'), 'extension.js should contain starting spinner icon');
+	assert.ok(source.includes('pulse'), 'extension.js should contain running pulse icon');
+	assert.ok(source.includes('circle-outline'), 'extension.js should contain stopped icon');
+
+	// Verify error and stopped webview pages are present
+	assert.ok(source.includes('Observer could not start'), 'extension.js should contain error webview heading');
+	assert.ok(source.includes('Observer is stopped'), 'extension.js should contain stopped webview message');
+
+	// Verify port conflict detection
+	assert.ok(source.includes('EADDRINUSE'), 'extension.js should handle EADDRINUSE port conflicts');
+	assert.ok(source.includes('lsof'), 'extension.js should use lsof to identify port owners');
+
+	// Verify async stop with SIGTERM/SIGKILL
+	assert.ok(source.includes('SIGTERM'), 'extension.js should send SIGTERM on stop');
+	assert.ok(source.includes('SIGKILL'), 'extension.js should fallback to SIGKILL');
+});
+
+it('integration: package.json registers all commands', () => {
+	const pkgPath = path.join(extensionRoot, 'package.json');
+	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+	const commands = (pkg.contributes?.commands ?? []).map((c: { command: string }) => c.command);
+
+	for (const expected of [
+		'observability-studio.openObserver',
+		'observability-studio.statusMenu',
+		'observability-studio.startObserver',
+		'observability-studio.stopObserver',
+		'observability-studio.restartObserver',
+	]) {
+		assert.ok(
+			commands.includes(expected),
+			`package.json should register command "${expected}"`
+		);
+	}
 });
 
 it('integration: binary serves client UI assets', { timeout: 180_000 }, async (t) => {

--- a/extension/src/test/observer-lifecycle.test.ts
+++ b/extension/src/test/observer-lifecycle.test.ts
@@ -1,0 +1,63 @@
+import * as assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	assertObserverRunCurrent,
+	beginObserverStart,
+	completeObserverStart,
+	createObserverLifecycleState,
+	finishObserverRun,
+	isObserverLifecycleCancelled,
+	stopObserverRun,
+} from '../observer-lifecycle';
+
+test('stale startup completion after stop is ignored', () => {
+	const state = createObserverLifecycleState();
+	const runId = beginObserverStart(state);
+
+	stopObserverRun(state);
+
+	assert.equal(completeObserverStart(state, runId, 4318), false);
+	assert.equal(state.status, 'stopped');
+	assert.equal(state.port, undefined);
+	assert.equal(state.startupError, undefined);
+});
+
+test('stale startup completion does not clobber a newer run', () => {
+	const state = createObserverLifecycleState();
+	const firstRun = beginObserverStart(state);
+
+	stopObserverRun(state);
+	const secondRun = beginObserverStart(state);
+
+	assert.equal(completeObserverStart(state, firstRun, 3100), false);
+	assert.equal(completeObserverStart(state, secondRun, 3200), true);
+	assert.equal(state.status, 'running');
+	assert.equal(state.port, 3200);
+});
+
+test('stale exit from an older run does not stop the current observer', () => {
+	const state = createObserverLifecycleState();
+	const firstRun = beginObserverStart(state);
+
+	assert.equal(completeObserverStart(state, firstRun, 3100), true);
+
+	stopObserverRun(state);
+	const secondRun = beginObserverStart(state);
+
+	assert.equal(completeObserverStart(state, secondRun, 3200), true);
+	assert.equal(finishObserverRun(state, firstRun), false);
+	assert.equal(state.status, 'running');
+	assert.equal(state.port, 3200);
+});
+
+test('stopped startup attempts fail with a cancellation error', () => {
+	const state = createObserverLifecycleState();
+	const runId = beginObserverStart(state);
+
+	stopObserverRun(state);
+
+	assert.throws(
+		() => assertObserverRunCurrent(state, runId),
+		(error: unknown) => isObserverLifecycleCancelled(error),
+	);
+});

--- a/extension/src/test/webview-html.test.ts
+++ b/extension/src/test/webview-html.test.ts
@@ -1,0 +1,139 @@
+import * as assert from 'node:assert/strict';
+import test, { describe, it } from 'node:test';
+import {
+	getObserverWebviewHtml,
+	getObserverLoadingWebviewHtml,
+	getObserverErrorWebviewHtml,
+	getObserverStoppedWebviewHtml,
+	getStatusBarUpdate,
+} from '../webview-html';
+
+// --- getObserverWebviewHtml ---
+
+describe('getObserverWebviewHtml', () => {
+	it('embeds the correct localhost URL with given port', () => {
+		const html = getObserverWebviewHtml(56652);
+		assert.ok(html.includes('http://127.0.0.1:56652'));
+	});
+
+	it('contains an iframe pointing to the observer URL', () => {
+		const html = getObserverWebviewHtml(3000);
+		assert.ok(html.includes('<iframe src="http://127.0.0.1:3000"'));
+	});
+
+	it('sets Content-Security-Policy with frame-src', () => {
+		const html = getObserverWebviewHtml(8080);
+		assert.ok(html.includes('frame-src http://127.0.0.1:8080'));
+	});
+
+	it('includes sandbox attributes on the iframe', () => {
+		const html = getObserverWebviewHtml(3000);
+		assert.ok(html.includes('sandbox="allow-scripts allow-same-origin allow-forms allow-popups"'));
+	});
+});
+
+// --- getObserverLoadingWebviewHtml ---
+
+describe('getObserverLoadingWebviewHtml', () => {
+	it('shows a starting message', () => {
+		const html = getObserverLoadingWebviewHtml();
+		assert.ok(html.includes('Observability Studio is starting'));
+	});
+
+	it('does not contain an iframe', () => {
+		const html = getObserverLoadingWebviewHtml();
+		assert.ok(!html.includes('<iframe'));
+	});
+});
+
+// --- getObserverErrorWebviewHtml ---
+
+describe('getObserverErrorWebviewHtml', () => {
+	it('shows the error message', () => {
+		const html = getObserverErrorWebviewHtml('Port 4317 is already in use by "obstudio (PID 1234)"');
+		assert.ok(html.includes('Port 4317 is already in use'));
+		assert.ok(html.includes('obstudio (PID 1234)'));
+	});
+
+	it('shows the "could not start" heading', () => {
+		const html = getObserverErrorWebviewHtml('some error');
+		assert.ok(html.includes('Observer could not start'));
+	});
+
+	it('includes restart hint', () => {
+		const html = getObserverErrorWebviewHtml('some error');
+		assert.ok(html.includes('Restart Observer'));
+	});
+
+	it('escapes HTML in error messages to prevent XSS', () => {
+		const html = getObserverErrorWebviewHtml('<script>alert("xss")</script>');
+		assert.ok(!html.includes('<script>alert'));
+		assert.ok(html.includes('&lt;script&gt;'));
+	});
+
+	it('escapes quotes in error messages', () => {
+		const html = getObserverErrorWebviewHtml('Port used by "nginx"');
+		assert.ok(html.includes('&quot;nginx&quot;'));
+	});
+});
+
+// --- getObserverStoppedWebviewHtml ---
+
+describe('getObserverStoppedWebviewHtml', () => {
+	it('shows stopped message', () => {
+		const html = getObserverStoppedWebviewHtml();
+		assert.ok(html.includes('Observer is stopped'));
+	});
+
+	it('includes start hint', () => {
+		const html = getObserverStoppedWebviewHtml();
+		assert.ok(html.includes('Start Observer'));
+	});
+
+	it('does not contain an iframe', () => {
+		const html = getObserverStoppedWebviewHtml();
+		assert.ok(!html.includes('<iframe'));
+	});
+});
+
+// --- getStatusBarUpdate ---
+
+describe('getStatusBarUpdate', () => {
+	it('returns spinner icon and starting tooltip for starting state', () => {
+		const update = getStatusBarUpdate('starting');
+		assert.ok(update.text.includes('loading~spin'));
+		assert.ok(update.text.includes('Observer'));
+		assert.ok(update.tooltip.includes('starting'));
+		assert.equal(update.command, 'observability-studio.statusMenu');
+	});
+
+	it('returns pulse icon for running state', () => {
+		const update = getStatusBarUpdate('running');
+		assert.ok(update.text.includes('pulse'));
+		assert.ok(update.tooltip.includes('running'));
+		assert.equal(update.command, 'observability-studio.statusMenu');
+	});
+
+	it('returns circle-outline icon for stopped state', () => {
+		const update = getStatusBarUpdate('stopped');
+		assert.ok(update.text.includes('circle-outline'));
+		assert.ok(update.tooltip.includes('stopped'));
+		assert.equal(update.command, 'observability-studio.statusMenu');
+	});
+
+	it('returns error icon for error state', () => {
+		const update = getStatusBarUpdate('error');
+		assert.ok(update.text.includes('error'));
+		assert.ok(update.tooltip.includes('failed'));
+		assert.equal(update.command, 'observability-studio.statusMenu');
+	});
+
+	it('always uses statusMenu command for all states', () => {
+		for (const state of ['starting', 'running', 'stopped', 'error'] as const) {
+			const update = getStatusBarUpdate(state);
+			assert.equal(update.command, 'observability-studio.statusMenu',
+				`State "${state}" should use statusMenu command`);
+		}
+	});
+});
+

--- a/extension/src/webview-html.ts
+++ b/extension/src/webview-html.ts
@@ -1,0 +1,213 @@
+// Pure functions for generating webview HTML and escaping content.
+// Extracted from extension.ts so they can be unit-tested without VS Code APIs.
+
+export function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+export function getObserverWebviewHtml(port: number): string {
+	const observerUrl = `http://127.0.0.1:${port}`;
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="default-src 'none'; frame-src ${observerUrl}; style-src 'unsafe-inline'; worker-src 'none';"
+	>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Observer</title>
+	<style>
+		html, body, iframe {
+			height: 100%;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+		}
+
+		body {
+			background: var(--vscode-editor-background);
+		}
+
+		iframe {
+			border: 0;
+		}
+	</style>
+</head>
+<body>
+	<iframe src="${observerUrl}" title="Observer" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
+</body>
+</html>`;
+}
+
+export function getObserverLoadingWebviewHtml(): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="default-src 'none'; style-src 'unsafe-inline';"
+	>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Observer</title>
+	<style>
+		body {
+			align-items: center;
+			background: var(--vscode-editor-background);
+			color: var(--vscode-foreground);
+			display: flex;
+			font-family: var(--vscode-font-family);
+			height: 100vh;
+			justify-content: center;
+			margin: 0;
+			padding: 24px;
+			text-align: center;
+		}
+	</style>
+</head>
+<body>
+	<div>Observability Studio is starting…</div>
+</body>
+</html>`;
+}
+
+export function getObserverErrorWebviewHtml(errorMessage: string): string {
+	const escaped = escapeHtml(errorMessage);
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="default-src 'none'; style-src 'unsafe-inline';"
+	>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Observer</title>
+	<style>
+		body {
+			align-items: center;
+			background: var(--vscode-editor-background);
+			color: var(--vscode-foreground);
+			display: flex;
+			font-family: var(--vscode-font-family);
+			height: 100vh;
+			justify-content: center;
+			margin: 0;
+			padding: 24px;
+			text-align: center;
+		}
+		.container { max-width: 520px; }
+		h2 { color: var(--vscode-errorForeground); margin-bottom: 12px; }
+		.error-detail {
+			background: var(--vscode-textBlockQuote-background);
+			border-left: 3px solid var(--vscode-errorForeground);
+			color: var(--vscode-foreground);
+			font-family: var(--vscode-editor-font-family, monospace);
+			font-size: 12px;
+			margin: 16px 0;
+			padding: 12px;
+			text-align: left;
+			white-space: pre-wrap;
+			word-break: break-word;
+		}
+		.hint {
+			color: var(--vscode-descriptionForeground);
+			font-size: 13px;
+			line-height: 1.5;
+		}
+	</style>
+</head>
+<body>
+	<div class="container">
+		<h2>Observer could not start</h2>
+		<div class="error-detail">${escaped}</div>
+		<p class="hint">
+			Use the Command Palette (Cmd+Shift+P) and run
+			<strong>Observability Studio: Restart Observer</strong> after
+			freeing the port.
+		</p>
+	</div>
+</body>
+</html>`;
+}
+
+export function getObserverStoppedWebviewHtml(): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="default-src 'none'; style-src 'unsafe-inline';"
+	>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Observer</title>
+	<style>
+		body {
+			align-items: center;
+			background: var(--vscode-editor-background);
+			color: var(--vscode-foreground);
+			display: flex;
+			font-family: var(--vscode-font-family);
+			height: 100vh;
+			justify-content: center;
+			margin: 0;
+			padding: 24px;
+			text-align: center;
+		}
+		.hint {
+			color: var(--vscode-descriptionForeground);
+			font-size: 13px;
+			margin-top: 8px;
+		}
+	</style>
+</head>
+<body>
+	<div>
+		<div>Observer is stopped.</div>
+		<p class="hint">
+			Use the Command Palette (Cmd+Shift+P) and run
+			<strong>Observability Studio: Start Observer</strong> to start it again.
+		</p>
+	</div>
+</body>
+</html>`;
+}
+
+export type StatusBarState = 'starting' | 'running' | 'stopped' | 'error';
+
+export interface StatusBarUpdate {
+	text: string;
+	tooltip: string;
+	command: string;
+}
+
+export function getStatusBarUpdate(state: StatusBarState): StatusBarUpdate {
+	const command = 'observability-studio.statusMenu';
+
+	switch (state) {
+		case 'starting':
+			return { text: '$(loading~spin) Observer', tooltip: 'Observer is starting...', command };
+		case 'running':
+			return { text: '$(pulse) Observer', tooltip: 'Observer is running — click for options', command };
+		case 'stopped':
+			return { text: '$(circle-outline) Observer', tooltip: 'Observer is stopped — click to start', command };
+		case 'error':
+			return { text: '$(error) Observer', tooltip: 'Observer failed — click for options', command };
+	}
+}
+
+export function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+}


### PR DESCRIPTION
add start, stop, restart, and status menu commands to the extension
serialize observer lifecycle state so rapid restarts do not blank the panel
add unit and integration coverage for lifecycle and packaged extension behavior