### PR TITLE
Support shared Observer backend discovery and reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,17 @@ jobs:
         working-directory: extension
         run: npm ci
 
-      - name: Run unit + integration tests
+      - name: Run unit tests
         working-directory: extension
-        run: npm run test:all
+        run: npm run test:unit
+
+      - name: Run integration tests
+        working-directory: extension
+        run: npm run test:integration
+
+      - name: Run VS Code host tests
+        working-directory: extension
+        run: xvfb-run -a npm run test:host
 
   client:
     name: Client – unit tests

--- a/extension/package.json
+++ b/extension/package.json
@@ -23,25 +23,55 @@
     "commands": [
       {
         "command": "observability-studio.openObserver",
-        "title": "Observability Studio: Open Observer"
+        "title": "Open Observer",
+        "category": "Observability Studio"
       },
       {
         "command": "observability-studio.statusMenu",
-        "title": "Observability Studio: Observer Status"
+        "title": "Observer Status",
+        "category": "Observability Studio"
       },
       {
         "command": "observability-studio.startObserver",
-        "title": "Observability Studio: Start Observer"
+        "title": "Start Observer",
+        "category": "Observability Studio"
       },
       {
         "command": "observability-studio.stopObserver",
-        "title": "Observability Studio: Stop Observer"
+        "title": "Stop Observer",
+        "category": "Observability Studio"
       },
       {
         "command": "observability-studio.restartObserver",
-        "title": "Observability Studio: Restart Observer"
+        "title": "Restart Observer",
+        "category": "Observability Studio"
+      },
+      {
+        "command": "observability-studio.configureCodexMCP",
+        "title": "Configure Codex MCP",
+        "category": "Observability Studio"
+      },
+      {
+        "command": "observability-studio.configureClaudeCodeMCP",
+        "title": "Configure Claude Code MCP",
+        "category": "Observability Studio"
+      },
+      {
+        "command": "observability-studio.configureCursorMCP",
+        "title": "Configure Cursor MCP",
+        "category": "Observability Studio"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Observability Studio",
+      "properties": {
+        "observability-studio.sharedObserverUrl": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional shared `obstudio` base URL or `/mcp` URL override. When unset, the extension reuses or starts `obstudio` on the fixed shared endpoint `http://127.0.0.1:3000`."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
@@ -58,7 +88,8 @@
     "lint": "eslint src",
     "test:unit": "npm run compile-tests && node --test --experimental-test-coverage out/test/extension.test.js out/test/webview-html.test.js out/test/observer-lifecycle.test.js",
     "test:integration": "tsc --outDir out --rootDir src --module Node16 --target ES2022 --strict --skipLibCheck --esModuleInterop src/test/extension-integration.test.ts && node --test out/test/extension-integration.test.js",
-    "test:all": "npm run test:unit && npm run test:integration",
+    "test:host": "npm run compile-tests && npm run compile && vscode-test --run out/test/extension-vscode.test.js --fail-zero --timeout 30000",
+    "test:all": "npm run test:unit && npm run test:integration && npm run test:host",
     "test": "vscode-test"
   },
   "devDependencies": {

--- a/extension/src/backend.ts
+++ b/extension/src/backend.ts
@@ -8,6 +8,54 @@ export type ObserverBackend = {
 	label: string;
 };
 
+export type ObserverHealth = {
+	apiVersion?: string;
+	endpoints?: Record<string, string>;
+	kind?: string;
+	mode?: string;
+	owner?: string;
+	startedAt?: string;
+	version?: string;
+};
+
+export function normalizeObserverBaseUrl(raw: string): string {
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) {
+		throw new Error('Observer URL cannot be empty.');
+	}
+
+	const parsed = new URL(trimmed);
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		throw new Error(`Observer URL must use http or https: ${raw}`);
+	}
+
+	if (parsed.pathname.endsWith('/mcp')) {
+		parsed.pathname = parsed.pathname.slice(0, -4) || '/';
+	}
+
+	parsed.search = '';
+	parsed.hash = '';
+	return parsed.toString().replace(/\/$/, '');
+}
+
+export function buildObserverHealthUrl(baseUrl: string): string {
+	return `${normalizeObserverBaseUrl(baseUrl)}/api/health`;
+}
+
+export function observerPortFromUrl(baseUrl: string): number | undefined {
+	const parsed = new URL(normalizeObserverBaseUrl(baseUrl));
+	if (parsed.port.length > 0) {
+		return Number(parsed.port);
+	}
+	if (parsed.protocol === 'http:') {
+		return 80;
+	}
+	if (parsed.protocol === 'https:') {
+		return 443;
+	}
+	return undefined;
+}
+
 export function resolveBackend(extensionPath: string): ObserverBackend {
 	const binary = path.join(extensionPath, 'dist', 'observer', 'obstudio');
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,7 +1,15 @@
 import * as cp from 'node:child_process';
+import * as http from 'node:http';
+import * as https from 'node:https';
 import * as net from 'node:net';
 import * as vscode from 'vscode';
-import { resolveBackend } from './backend';
+import {
+	buildObserverHealthUrl,
+	type ObserverHealth,
+	normalizeObserverBaseUrl,
+	observerPortFromUrl,
+	resolveBackend,
+} from './backend';
 import {
 	assertObserverRunCurrent,
 	beginObserverStart,
@@ -14,9 +22,8 @@ import {
 	stopObserverRun,
 } from './observer-lifecycle';
 import {
-	getObserverWebviewHtml,
-	getObserverLoadingWebviewHtml,
 	getObserverErrorWebviewHtml,
+	getObserverLoadingWebviewHtml,
 	getObserverStoppedWebviewHtml,
 	getStatusBarUpdate,
 	getErrorMessage,
@@ -27,18 +34,45 @@ import {
 let observerProcess: cp.ChildProcess | undefined;
 let observerOutputChannel: vscode.OutputChannel | undefined;
 let observerPanel: vscode.WebviewPanel | undefined;
+let observerBaseUrl: string | undefined;
 let observerStartupPromise: Promise<void> | undefined;
 let observerStopPromise: Promise<void> | undefined;
 let observerStatusBarItem: vscode.StatusBarItem | undefined;
+let observerUsesSharedServer = false;
 const observerLifecycleState = createObserverLifecycleState();
 let lastObserverPanelRenderKey: string | undefined;
 
 const observerPanelViewType = 'observabilityStudioObserver';
+const sharedObserverUrlSetting = 'sharedObserverUrl';
+const managedObserverHost = '127.0.0.1';
+const managedObserverPort = 3000;
+const managedObserverBaseUrl = `http://${managedObserverHost}:${managedObserverPort}`;
+const observerKind = 'obstudio';
+const observerAPIVersion = 'v1';
 
 // The extension exposes a stable OTLP endpoint so instrumented apps can target a
 // predictable localhost port.
 const observerOtlpHttpPort = 4318;
 const observerOtlpGrpcPort = 4317;
+const observerOtlpHttpEndpoint = `http://${managedObserverHost}:${observerOtlpHttpPort}`;
+const observerOtlpGrpcEndpoint = `${managedObserverHost}:${observerOtlpGrpcPort}`;
+
+type InternalRuntimeState = {
+	observerPort?: number;
+	observerUrl?: string;
+	panelHtml?: string;
+	panelVisible: boolean;
+	sharedMode: boolean;
+};
+
+type ObserverProbeOptions = {
+	requireStableOtlp: boolean;
+};
+
+type ObserverProbeResult =
+	| { health: ObserverHealth; status: 'ready' }
+	| { error: Error; status: 'unavailable' }
+	| { reason: string; status: 'mismatch' };
 
 export async function activate(context: vscode.ExtensionContext) {
 	observerOutputChannel = vscode.window.createOutputChannel('Observability Studio');
@@ -61,6 +95,12 @@ export async function activate(context: vscode.ExtensionContext) {
 			},
 		}),
 	);
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => {
+		if (!event.affectsConfiguration(`observability-studio.${sharedObserverUrlSetting}`)) {
+			return;
+		}
+		void restartObserver(context);
+	}));
 
 	// Status bar item reflects observer state and toggles the panel.
 	observerStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
@@ -93,7 +133,11 @@ export async function activate(context: vscode.ExtensionContext) {
 					{ label: '$(debug-stop) Stop Observer', id: 'stop' },
 					{ label: '$(output) Show Output Log', id: 'log' },
 				],
-				{ placeHolder: `Observer is running on port ${observerLifecycleState.port ?? '?'}` },
+				{
+					placeHolder: observerUsesSharedServer
+						? `Observer is reusing ${observerBaseUrl ?? 'a shared backend'}`
+						: `Observer is running on port ${observerLifecycleState.port ?? '?'}`,
+				},
 			);
 			if (pick?.id === 'open') {
 				void vscode.commands.executeCommand('observability-studio.openObserver');
@@ -187,12 +231,38 @@ export async function activate(context: vscode.ExtensionContext) {
 			refreshObserverPanel();
 		}
 	});
+	const configureCodexDisposable = vscode.commands.registerCommand(
+		'observability-studio.configureCodexMCP',
+		() => configureAgentMCP(context, 'codex', 'Codex'),
+	);
+	const configureClaudeDisposable = vscode.commands.registerCommand(
+		'observability-studio.configureClaudeCodeMCP',
+		() => configureAgentMCP(context, 'claude-code', 'Claude Code'),
+	);
+	const configureCursorDisposable = vscode.commands.registerCommand(
+		'observability-studio.configureCursorMCP',
+		() => configureAgentMCP(context, 'cursor', 'Cursor'),
+	);
+	const internalStateDisposable = vscode.commands.registerCommand(
+		'observability-studio.internal.getRuntimeState',
+		(): InternalRuntimeState => ({
+			observerPort: observerLifecycleState.port,
+			observerUrl: observerBaseUrl,
+			panelHtml: observerPanel?.webview.html,
+			panelVisible: observerPanel !== undefined,
+			sharedMode: observerUsesSharedServer,
+		}),
+	);
 
 	context.subscriptions.push(openObserverDisposable);
 	context.subscriptions.push(statusMenuDisposable);
 	context.subscriptions.push(startDisposable);
 	context.subscriptions.push(stopDisposable);
 	context.subscriptions.push(restartDisposable);
+	context.subscriptions.push(configureCodexDisposable);
+	context.subscriptions.push(configureClaudeDisposable);
+	context.subscriptions.push(configureCursorDisposable);
+	context.subscriptions.push(internalStateDisposable);
 	context.subscriptions.push(observerStatusBarItem);
 	context.subscriptions.push({
 		dispose: () => {
@@ -200,6 +270,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			stopObserverRun(observerLifecycleState);
 			observerStartupPromise = undefined;
 			observerStopPromise = undefined;
+			observerBaseUrl = undefined;
+			observerUsesSharedServer = false;
 			terminateObserverProcess(observerProcess, 'SIGTERM');
 			observerProcess = undefined;
 		},
@@ -211,6 +283,8 @@ export function deactivate() {
 	stopObserverRun(observerLifecycleState);
 	observerStartupPromise = undefined;
 	observerStopPromise = undefined;
+	observerBaseUrl = undefined;
+	observerUsesSharedServer = false;
 	terminateObserverProcess(observerProcess, 'SIGTERM');
 	observerProcess = undefined;
 }
@@ -228,8 +302,8 @@ async function ensureObserverRunning(context: vscode.ExtensionContext): Promise<
 		logObserverLifecycle('Start requested while stop is in progress; waiting for observer shutdown.');
 		await observerStopPromise;
 	}
-	if (observerLifecycleState.status === 'running' && observerProcess !== undefined) {
-		logObserverLifecycle(`Start requested while observer is already running on port ${observerLifecycleState.port ?? '?'}.`);
+	if (observerLifecycleState.status === 'running' && observerBaseUrl !== undefined) {
+		logObserverLifecycle(`Start requested while observer is already running at ${observerBaseUrl}.`);
 		return;
 	}
 
@@ -255,8 +329,49 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 	syncObserverUi();
 
 	const startupPromise = (async () => {
+		if (observerOutputChannel === undefined) {
+			throw new Error('Observer output channel is not initialized.');
+		}
+
+		const sharedObserverUrl = getConfiguredSharedObserverUrl();
+		if (sharedObserverUrl !== undefined) {
+			observerUsesSharedServer = true;
+			observerBaseUrl = sharedObserverUrl;
+			appendObserverOutputLine(`Using configured shared observer at ${sharedObserverUrl}`);
+			syncObserverUi();
+			await waitForObserverReady(sharedObserverUrl, { requireStableOtlp: false }, runId);
+			const sharedPort = observerPortFromUrl(sharedObserverUrl);
+			if (sharedPort === undefined) {
+				throw new Error(`Observer URL does not resolve to a usable port: ${sharedObserverUrl}`);
+			}
+			if (completeObserverStart(observerLifecycleState, runId, sharedPort)) {
+				syncObserverUi();
+			}
+			return;
+		}
+
+		const existingObserver = await probeObserver(managedObserverBaseUrl, 500, { requireStableOtlp: true });
+		assertObserverRunCurrent(observerLifecycleState, runId);
+
+		if (existingObserver.status === 'ready') {
+			observerUsesSharedServer = true;
+			observerBaseUrl = managedObserverBaseUrl;
+			appendObserverOutputLine(`Reusing shared observer at ${managedObserverBaseUrl}`);
+			if (completeObserverStart(observerLifecycleState, runId, managedObserverPort)) {
+				syncObserverUi();
+			}
+			return;
+		}
+
+		if (existingObserver.status === 'mismatch') {
+			throw new Error(
+				`Cannot use ${managedObserverBaseUrl}: ${existingObserver.reason}. ` +
+				`Stop the conflicting service or configure observability-studio.${sharedObserverUrlSetting}.`,
+			);
+		}
+
 		const backend = resolveBackend(context.extensionPath);
-		const observerPort = await getAvailablePort();
+		const observerPort = await ensurePortAvailable(managedObserverPort);
 		logObserverLifecycle(`Run ${runId}: reserved UI port ${observerPort}.`);
 		assertObserverRunCurrent(observerLifecycleState, runId);
 
@@ -265,17 +380,19 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 		const otlpGrpcPort = await ensurePortAvailable(observerOtlpGrpcPort);
 		assertObserverRunCurrent(observerLifecycleState, runId);
 		logObserverLifecycle(`Run ${runId}: OTLP ports ready (HTTP ${otlpHttpPort}, gRPC ${otlpGrpcPort}).`);
+		observerUsesSharedServer = false;
+		observerBaseUrl = managedObserverBaseUrl;
 
-		appendObserverOutputLine(`Starting ${backend.label} on http://127.0.0.1:${observerPort}`);
-		appendObserverOutputLine(`OTLP/HTTP receiver listening on http://127.0.0.1:${otlpHttpPort}`);
-		appendObserverOutputLine(`OTLP/gRPC receiver listening on 127.0.0.1:${otlpGrpcPort}`);
+		appendObserverOutputLine(`Starting ${backend.label} on ${managedObserverBaseUrl}`);
+		appendObserverOutputLine(`OTLP/HTTP receiver listening on ${observerOtlpHttpEndpoint}`);
+		appendObserverOutputLine(`OTLP/gRPC receiver listening on ${observerOtlpGrpcEndpoint}`);
 
 		startedProcess = cp.spawn(backend.command, backend.args, {
 			cwd: backend.cwd,
 			env: {
 				...process.env,
-				HOST: '127.0.0.1',
-				OTLP_HOST: '127.0.0.1',
+				HOST: managedObserverHost,
+				OTLP_HOST: managedObserverHost,
 				OTLP_PORT: String(otlpHttpPort),
 				OTLP_HTTP_PORT: String(otlpHttpPort),
 				OTLP_GRPC_PORT: String(otlpGrpcPort),
@@ -303,6 +420,8 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 				observerProcess = undefined;
 			}
 			if (finishObserverRun(observerLifecycleState, runId)) {
+				observerBaseUrl = undefined;
+				observerUsesSharedServer = false;
 				syncObserverUi();
 			}
 		});
@@ -314,13 +433,15 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 				observerProcess = undefined;
 			}
 			if (failObserverStart(observerLifecycleState, runId, error.message)) {
+				observerBaseUrl = undefined;
+				observerUsesSharedServer = false;
 				syncObserverUi();
 				void vscode.window.showErrorMessage(`Observability Studio failed to start observer: ${error.message}`);
 			}
 		});
 
-		await waitForObserverReady(observerPort, runId);
-		logObserverLifecycle(`Run ${runId}: observer is accepting connections on UI port ${observerPort}.`);
+		await waitForObserverReady(managedObserverBaseUrl, { requireStableOtlp: true }, runId);
+		logObserverLifecycle(`Run ${runId}: observer is accepting connections at ${managedObserverBaseUrl}.`);
 		if (!completeObserverStart(observerLifecycleState, runId, observerPort)) {
 			if (observerProcess === startedProcess) {
 				observerProcess = undefined;
@@ -346,6 +467,8 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 		}
 		terminateObserverProcess(startedProcess, 'SIGTERM');
 		if (failObserverStart(observerLifecycleState, runId, getErrorMessage(error))) {
+			observerBaseUrl = undefined;
+			observerUsesSharedServer = false;
 			logObserverLifecycle(`Run ${runId}: startup failed: ${getErrorMessage(error)}`);
 			syncObserverUi();
 		}
@@ -367,17 +490,19 @@ async function stopObserver(): Promise<void> {
 	}
 
 	const proc = observerProcess;
-	if (proc === undefined && observerStartupPromise === undefined) {
+	if (proc === undefined && observerStartupPromise === undefined && observerBaseUrl === undefined) {
 		logObserverLifecycle('Stop requested but observer is already idle.');
 		return;
 	}
 
 	logObserverLifecycle(
-		`Stopping observer (status=${observerLifecycleState.status}, pid=${proc?.pid ?? 'none'}, port=${observerLifecycleState.port ?? 'none'}).`,
+		`Stopping observer (status=${observerLifecycleState.status}, pid=${proc?.pid ?? 'none'}, port=${observerLifecycleState.port ?? 'none'}, url=${observerBaseUrl ?? 'none'}).`,
 	);
 	stopObserverRun(observerLifecycleState);
 	observerProcess = undefined;
 	observerStartupPromise = undefined;
+	observerBaseUrl = undefined;
+	observerUsesSharedServer = false;
 	syncObserverUi();
 
 	if (proc === undefined) {
@@ -450,7 +575,7 @@ async function openObserverPanel(context: vscode.ExtensionContext): Promise<void
 	observerPanel.reveal(vscode.ViewColumn.One);
 
 	// If already running, show the UI immediately.
-	if (observerLifecycleState.status === 'running' && observerLifecycleState.port !== undefined) {
+	if (observerLifecycleState.status === 'running' && observerBaseUrl !== undefined) {
 		refreshObserverPanel();
 		return;
 	}
@@ -483,7 +608,7 @@ function refreshObserverPanel(): void {
 		return;
 	}
 
-	const renderKey = `${observerLifecycleState.status}:${observerLifecycleState.port ?? 'none'}:${observerLifecycleState.startupError ?? 'none'}`;
+	const renderKey = `${observerLifecycleState.status}:${observerLifecycleState.port ?? 'none'}:${observerLifecycleState.startupError ?? 'none'}:${observerBaseUrl ?? 'none'}:${observerUsesSharedServer ? 'shared' : 'local'}`;
 	if (renderKey !== lastObserverPanelRenderKey) {
 		logObserverLifecycle(`Rendering observer panel state ${renderKey}.`);
 		lastObserverPanelRenderKey = renderKey;
@@ -491,9 +616,9 @@ function refreshObserverPanel(): void {
 
 	switch (observerLifecycleState.status) {
 		case 'running':
-			observerPanel.webview.html = observerLifecycleState.port === undefined
+			observerPanel.webview.html = observerLifecycleState.port === undefined || observerBaseUrl === undefined
 				? getObserverLoadingWebviewHtml()
-				: getObserverWebviewHtml(observerLifecycleState.port);
+				: getObserverWebviewHtmlForUrl(observerBaseUrl);
 			return;
 		case 'error':
 			observerPanel.webview.html = getObserverErrorWebviewHtml(
@@ -512,24 +637,6 @@ function refreshObserverPanel(): void {
 // ---------------------------------------------------------------------------
 // Port helpers
 // ---------------------------------------------------------------------------
-
-async function getAvailablePort(): Promise<number> {
-	return new Promise((resolve, reject) => {
-		const server = net.createServer();
-		server.once('error', reject);
-		server.listen(0, '127.0.0.1', () => {
-			const address = server.address();
-			if (address === null || typeof address === 'string') {
-				server.close(() => reject(new Error('Unable to allocate a local port for the observer.')));
-				return;
-			}
-			server.close((error) => {
-				if (error) { reject(error); return; }
-				resolve(address.port);
-			});
-		});
-	});
-}
 
 async function ensurePortAvailable(port: number): Promise<number> {
 	return new Promise((resolve, reject) => {
@@ -573,56 +680,190 @@ async function identifyPortOwner(port: number): Promise<string | undefined> {
 	});
 }
 
-async function waitForObserverReady(port: number, runId: number): Promise<void> {
+async function waitForObserverReady(
+	baseUrl: string,
+	options: ObserverProbeOptions,
+	runId: number,
+): Promise<void> {
 	const startupDeadline = Date.now() + 15_000;
-	let lastError: unknown;
+	let lastError: Error | undefined;
 
 	while (Date.now() < startupDeadline) {
 		assertObserverRunCurrent(observerLifecycleState, runId);
 
-		try {
-			await waitForPort(port, 500);
-			assertObserverRunCurrent(observerLifecycleState, runId);
-			return;
-		} catch (error) {
-			lastError = error;
-			if (isObserverLifecycleCancelled(error)) {
-				throw error;
-			}
-			if (!isObserverRunCurrent(observerLifecycleState, runId)) {
-				assertObserverRunCurrent(observerLifecycleState, runId);
-			}
-			if (observerProcess === undefined) {
-				break;
-			}
-			await delay(100);
+		const probe = await probeObserver(baseUrl, 500, options);
+		assertObserverRunCurrent(observerLifecycleState, runId);
+
+		switch (probe.status) {
+			case 'ready':
+				return;
+			case 'mismatch':
+				throw new Error(probe.reason);
+			case 'unavailable':
+				lastError = probe.error;
+				if (!observerUsesSharedServer && observerProcess === undefined) {
+					break;
+				}
+				await delay(100);
 		}
 	}
 
 	if (lastError !== undefined) {
-		logObserverLifecycle(`Run ${runId}: readiness check timed out on port ${port}: ${getErrorMessage(lastError)}`);
+		logObserverLifecycle(`Run ${runId}: readiness check timed out for ${baseUrl}: ${getErrorMessage(lastError)}`);
 	}
-	throw lastError instanceof Error
-		? lastError
-		: new Error('Observer did not become ready in time.');
+	throw lastError ?? new Error(`Observer did not become ready in time at ${baseUrl}.`);
 }
 
-async function waitForPort(port: number, timeoutMs: number): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const socket = new net.Socket();
+async function probeObserver(
+	baseUrl: string,
+	timeoutMs: number,
+	options: ObserverProbeOptions,
+): Promise<ObserverProbeResult> {
+	return new Promise((resolve) => {
+		const observerUrl = normalizeObserverBaseUrl(baseUrl);
+		const target = new URL(buildObserverHealthUrl(observerUrl));
+		const client = target.protocol === 'https:' ? https : http;
 		let settled = false;
+
 		const finish = (callback: () => void) => {
-			if (settled) { return; }
+			if (settled) {
+				return;
+			}
 			settled = true;
-			socket.destroy();
 			callback();
 		};
-		socket.setTimeout(timeoutMs);
-		socket.once('connect', () => finish(resolve));
-		socket.once('timeout', () => finish(() => reject(new Error(`Timed out waiting for observer on port ${port}.`))));
-		socket.once('error', (error) => finish(() => reject(error)));
-		socket.connect(port, '127.0.0.1');
+
+		const request = client.request(target, { method: 'GET' }, (response) => {
+			let body = '';
+			response.setEncoding('utf8');
+			response.on('data', (chunk) => {
+				body += chunk;
+			});
+			response.on('end', () => {
+				if ((response.statusCode ?? 0) !== 200) {
+					finish(() => resolve({
+						status: 'mismatch',
+						reason: `${target.toString()} returned status ${response.statusCode ?? 0}`,
+					}));
+					return;
+				}
+
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse(body);
+				} catch {
+					finish(() => resolve({
+						status: 'mismatch',
+						reason: `${target.toString()} returned invalid JSON`,
+					}));
+					return;
+				}
+
+				const reason = validateObserverHealth(parsed, options);
+				if (reason !== undefined) {
+					finish(() => resolve({ status: 'mismatch', reason }));
+					return;
+				}
+
+				finish(() => resolve({ status: 'ready', health: parsed as ObserverHealth }));
+			});
+		});
+
+		request.setTimeout(timeoutMs, () => {
+			request.destroy();
+			finish(() => resolve({
+				status: 'unavailable',
+				error: new Error(`Timed out waiting for observer health on ${target.toString()}`),
+			}));
+		});
+		request.once('error', (error: NodeJS.ErrnoException) => {
+			if (error.code === 'ECONNREFUSED' || error.code === 'EHOSTUNREACH' || error.code === 'ENOTFOUND') {
+				finish(() => resolve({ status: 'unavailable', error }));
+				return;
+			}
+			finish(() => resolve({
+				status: 'mismatch',
+				reason: `Failed to query ${target.toString()}: ${error.message}`,
+			}));
+		});
+		request.end();
 	});
+}
+
+function validateObserverHealth(raw: unknown, options: ObserverProbeOptions): string | undefined {
+	if (raw === null || typeof raw !== 'object') {
+		return 'health response was not a JSON object';
+	}
+
+	const health = raw as ObserverHealth;
+	if (health.kind !== observerKind) {
+		return `expected kind=${observerKind}, got ${String(health.kind)}`;
+	}
+	if (health.apiVersion !== observerAPIVersion) {
+		return `expected apiVersion=${observerAPIVersion}, got ${String(health.apiVersion)}`;
+	}
+	if (!options.requireStableOtlp) {
+		return undefined;
+	}
+	if (health.endpoints?.otlpHttp !== observerOtlpHttpEndpoint) {
+		return `expected OTLP/HTTP endpoint ${observerOtlpHttpEndpoint}, got ${String(health.endpoints?.otlpHttp)}`;
+	}
+	if (health.endpoints?.otlpGrpc !== observerOtlpGrpcEndpoint) {
+		return `expected OTLP/gRPC endpoint ${observerOtlpGrpcEndpoint}, got ${String(health.endpoints?.otlpGrpc)}`;
+	}
+	return undefined;
+}
+
+async function restartObserver(context: vscode.ExtensionContext): Promise<void> {
+	await stopObserver();
+	try {
+		await ensureObserverRunning(context);
+		refreshObserverPanel();
+	} catch (error) {
+		if (isObserverLifecycleCancelled(error)) {
+			refreshObserverPanel();
+			return;
+		}
+		const message = getErrorMessage(error);
+		void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
+		refreshObserverPanel();
+	}
+}
+
+function getObserverWebviewHtmlForUrl(observerUrl: string): string {
+	const normalizedObserverUrl = normalizeObserverBaseUrl(observerUrl);
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="default-src 'none'; frame-src ${normalizedObserverUrl}; style-src 'unsafe-inline'; worker-src 'none';"
+	>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Observer</title>
+	<style>
+		html, body, iframe {
+			height: 100%;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+		}
+
+		body {
+			background: var(--vscode-editor-background);
+		}
+
+		iframe {
+			border: 0;
+		}
+	</style>
+</head>
+<body>
+	<iframe src="${normalizedObserverUrl}" title="Observer" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
+</body>
+</html>`;
 }
 
 function delay(ms: number): Promise<void> {
@@ -647,6 +888,60 @@ function appendObserverOutputLine(text: string): void {
 
 function logObserverLifecycle(message: string): void {
 	appendObserverOutputLine(`[extension] ${message}`);
+}
+
+function getConfiguredSharedObserverUrl(): string | undefined {
+	const raw = vscode.workspace.getConfiguration('observability-studio').get<string>(sharedObserverUrlSetting);
+	if (raw === undefined) {
+		return undefined;
+	}
+
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) {
+		return undefined;
+	}
+	return normalizeObserverBaseUrl(trimmed);
+}
+
+async function configureAgentMCP(
+	context: vscode.ExtensionContext,
+	target: 'claude-code' | 'codex' | 'cursor',
+	label: string,
+): Promise<void> {
+	if (observerOutputChannel === undefined) {
+		throw new Error('Observer output channel is not initialized.');
+	}
+
+	try {
+		await ensureObserverRunning(context);
+		if (observerBaseUrl === undefined) {
+			throw new Error('Observer URL is not available.');
+		}
+
+		const mcpUrl = `${normalizeObserverBaseUrl(observerBaseUrl)}/mcp`;
+		const backend = resolveBackend(context.extensionPath);
+		observerOutputChannel.appendLine(`Configuring ${label} MCP for ${mcpUrl}`);
+		await execFile(backend.command, ['install', '--target', target, '--shared-url', mcpUrl], backend.cwd);
+		observerOutputChannel.appendLine(`${label} MCP configured for ${mcpUrl}`);
+		void vscode.window.showInformationMessage(`${label} MCP configured for ${mcpUrl}`);
+	} catch (error) {
+		const message = `${label} MCP configuration failed: ${getErrorMessage(error)}`;
+		observerOutputChannel.appendLine(message);
+		void vscode.window.showErrorMessage(message);
+		throw error;
+	}
+}
+
+function execFile(command: string, args: string[], cwd: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		cp.execFile(command, args, { cwd, env: { ...process.env } }, (error) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
 }
 
 // ---------------------------------------------------------------------------

--- a/extension/src/test/extension-integration.test.ts
+++ b/extension/src/test/extension-integration.test.ts
@@ -22,6 +22,19 @@ interface TestContext {
 	vsixFile?: string;
 }
 
+type ExtensionPackage = {
+	contributes?: {
+		commands?: Array<{
+			category?: string;
+			command: string;
+			title: string;
+		}>;
+		configuration?: {
+			properties?: Record<string, unknown>;
+		};
+	};
+};
+
 function cleanup(context: TestContext): void {
 	if (context.vsixFile && fs.existsSync(context.vsixFile)) {
 		try {
@@ -221,6 +234,36 @@ it('integration: package.json registers all commands', () => {
 			`package.json should register command "${expected}"`
 		);
 	}
+});
+
+it('integration: contributed commands are grouped under Observability Studio', async () => {
+	const packageJsonPath = path.join(extensionRoot, 'package.json');
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as ExtensionPackage;
+	const commands = packageJson.contributes?.commands ?? [];
+	const expectedCommands = [
+		'observability-studio.openObserver',
+		'observability-studio.configureCodexMCP',
+		'observability-studio.configureClaudeCodeMCP',
+		'observability-studio.configureCursorMCP',
+	];
+
+	for (const commandId of expectedCommands) {
+		const command = commands.find((entry) => entry.command === commandId);
+		assert.ok(command, `command ${commandId} should be contributed`);
+		assert.equal(
+			command?.category,
+			'Observability Studio',
+			`command ${commandId} should be grouped under Observability Studio`,
+		);
+	}
+});
+
+it('integration: package.json contributes sharedObserverUrl setting', async () => {
+	const packageJsonPath = path.join(extensionRoot, 'package.json');
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as ExtensionPackage;
+	const property = packageJson.contributes?.configuration?.properties?.['observability-studio.sharedObserverUrl'];
+
+	assert.ok(property, 'sharedObserverUrl setting should be contributed');
 });
 
 it('integration: binary serves client UI assets', { timeout: 180_000 }, async (t) => {

--- a/extension/src/test/extension-vscode.test.ts
+++ b/extension/src/test/extension-vscode.test.ts
@@ -1,0 +1,388 @@
+import * as assert from 'node:assert/strict';
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { suite, test } from 'mocha';
+import * as vscode from 'vscode';
+
+type RuntimeState = {
+	observerPort?: number;
+	observerUrl?: string;
+	panelHtml?: string;
+	panelVisible: boolean;
+	sharedMode: boolean;
+};
+
+type SharedObserverHandle = {
+	baseUrl: string;
+	dispose: () => Promise<void>;
+};
+
+type FileSnapshot = {
+	content?: string;
+	existed: boolean;
+	filePath: string;
+};
+
+async function waitFor<T>(load: () => Promise<T>, ready: (value: T) => boolean, timeoutMs: number): Promise<T> {
+	const deadline = Date.now() + timeoutMs;
+	let last: T | undefined;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			last = await load();
+			if (ready(last)) {
+				return last;
+			}
+			lastError = undefined;
+		} catch (error) {
+			lastError = error;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 200));
+	}
+	if (last !== undefined) {
+		return last;
+	}
+	if (lastError instanceof Error) {
+		throw lastError;
+	}
+	throw new Error('Timed out waiting for condition');
+}
+
+async function getExtension() {
+	const extension = vscode.extensions.all.find((item) => item.packageJSON.name === 'observability-studio');
+	assert.ok(extension, 'observability-studio extension should be installed in the test host');
+	if (!extension.isActive) {
+		await extension.activate();
+	}
+	return extension;
+}
+
+async function getAvailablePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			if (address === null || typeof address === 'string') {
+				server.close(() => reject(new Error('Unable to allocate a test port.')));
+				return;
+			}
+			server.close((error) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(address.port);
+			});
+		});
+	});
+}
+
+async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			await new Promise<void>((resolve, reject) => {
+				http.get(url, (response) => {
+					response.resume();
+					resolve();
+				}).on('error', reject);
+			});
+			return;
+		} catch (error) {
+			lastError = error;
+			await new Promise((resolve) => setTimeout(resolve, 200));
+		}
+	}
+	if (lastError instanceof Error) {
+		throw lastError;
+	}
+	throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function startSharedObserver(binaryPath: string): Promise<SharedObserverHandle> {
+	const port = await getAvailablePort();
+	const grpcPort = await getAvailablePort();
+	const httpPort = await getAvailablePort();
+	const baseUrl = `http://127.0.0.1:${port}`;
+	const child = cp.spawn(binaryPath, [], {
+		env: {
+			...process.env,
+			HOST: '127.0.0.1',
+			PORT: String(port),
+			OTLP_GRPC_PORT: String(grpcPort),
+			OTLP_HTTP_PORT: String(httpPort),
+		},
+		stdio: 'pipe',
+	});
+	let stderr = '';
+	child.stderr?.on('data', (chunk: Buffer | string) => {
+		stderr += chunk.toString();
+	});
+
+	try {
+		await waitForHttp(baseUrl, 10_000);
+	} catch (error) {
+		child.kill();
+		throw new Error(`shared observer failed to start: ${error instanceof Error ? error.message : String(error)}\n${stderr}`);
+	}
+
+	return {
+		baseUrl,
+		dispose: async () => {
+			if (child.exitCode !== null || child.killed) {
+				return;
+			}
+			child.kill();
+			await new Promise<void>((resolve) => {
+				child.once('exit', () => resolve());
+			});
+		},
+	};
+}
+
+async function startSlowSharedObserver(delayMs: number): Promise<SharedObserverHandle> {
+	const port = await getAvailablePort();
+	const baseUrl = `http://127.0.0.1:${port}`;
+	let healthRequestCount = 0;
+	const server = http.createServer(async (request, response) => {
+		if (request.url === '/api/health') {
+			healthRequestCount += 1;
+			if (healthRequestCount === 1) {
+				await new Promise((resolve) => setTimeout(resolve, delayMs));
+			}
+			response.setHeader('Content-Type', 'application/json');
+			response.end(JSON.stringify({
+				apiVersion: 'v1',
+				kind: 'obstudio',
+			}));
+			return;
+		}
+
+		response.setHeader('Content-Type', 'text/html; charset=utf-8');
+		response.end('<!doctype html><title>Observer</title>');
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(port, '127.0.0.1', () => resolve());
+	});
+
+	return {
+		baseUrl,
+		dispose: async () => {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		},
+	};
+}
+
+function readText(filePath: string): string {
+	return fs.readFileSync(filePath, 'utf8');
+}
+
+async function waitForFileText(filePath: string): Promise<string> {
+	return waitFor(
+		async () => {
+			if (!fs.existsSync(filePath)) {
+				throw new Error(`Missing file ${filePath}`);
+			}
+			return readText(filePath);
+		},
+		(content) => content.length > 0,
+		20_000,
+	);
+}
+
+async function assertCodexConfigured(filePaths: string[], mcpUrl: string): Promise<void> {
+	for (const filePath of filePaths) {
+		try {
+			const content = await waitForFileText(filePath);
+			assert.ok(content.includes('[mcp_servers.obstudio]'));
+			assert.ok(content.includes(`url = "${mcpUrl}"`));
+			return;
+		} catch {
+			// Try the next candidate path.
+		}
+	}
+
+	throw new Error(`Missing Codex config in any expected path: ${filePaths.join(', ')}`);
+}
+
+async function assertJSONMCPConfigured(filePaths: string[], serverName: string, mcpUrl: string): Promise<void> {
+	for (const filePath of filePaths) {
+		try {
+			const raw = JSON.parse(await waitForFileText(filePath));
+			assert.equal(raw?.mcpServers?.[serverName]?.type, 'http');
+			assert.equal(raw?.mcpServers?.[serverName]?.url, mcpUrl);
+			return;
+		} catch {
+			// Try the next candidate path.
+		}
+	}
+
+	throw new Error(`Missing JSON MCP config in any expected path: ${filePaths.join(', ')}`);
+}
+
+function snapshotFile(filePath: string): FileSnapshot {
+	if (!filePath || !fs.existsSync(filePath)) {
+		return { existed: false, filePath };
+	}
+
+	return {
+		content: readText(filePath),
+		existed: true,
+		filePath,
+	};
+}
+
+function restoreSnapshot(snapshot: FileSnapshot): void {
+	if (!snapshot.filePath) {
+		return;
+	}
+
+	if (snapshot.existed) {
+		fs.mkdirSync(path.dirname(snapshot.filePath), { recursive: true });
+		fs.writeFileSync(snapshot.filePath, snapshot.content ?? '', 'utf8');
+		return;
+	}
+
+	fs.rmSync(snapshot.filePath, { force: true });
+}
+
+suite('VS Code Host', () => {
+	test('openObserver reuses configured shared backend and configures MCP targets', async function () {
+		this.timeout(30_000);
+
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const codexConfigPath = path.join(tempHome, '.codex', 'config.toml');
+		const claudeConfigPath = path.join(tempHome, '.claude', 'settings.json');
+		const cursorConfigPath = path.join(tempHome, '.cursor', 'mcp.json');
+		const originalCodexConfigPath = originalHome ? path.join(originalHome, '.codex', 'config.toml') : '';
+		const originalClaudeConfigPath = originalHome ? path.join(originalHome, '.claude', 'settings.json') : '';
+		const originalCursorConfigPath = originalHome ? path.join(originalHome, '.cursor', 'mcp.json') : '';
+		const originalSnapshots = [
+			snapshotFile(originalCodexConfigPath),
+			snapshotFile(originalClaudeConfigPath),
+			snapshotFile(originalCursorConfigPath),
+		];
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		try {
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+
+			await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => {
+					if (!value) {
+						return false;
+					}
+					return value.sharedMode && value.observerUrl === sharedObserver.baseUrl;
+				},
+				20_000,
+			);
+
+			await vscode.commands.executeCommand('observability-studio.openObserver');
+
+			const state = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => {
+					if (!value) {
+						return false;
+					}
+					return value.panelVisible
+						&& value.sharedMode
+						&& value.observerUrl === sharedObserver.baseUrl
+						&& typeof value.panelHtml === 'string'
+						&& value.panelHtml.includes(sharedObserver.baseUrl);
+				},
+				20_000,
+			);
+
+			assert.equal(state.panelVisible, true);
+			assert.equal(state.sharedMode, true);
+			assert.equal(state.observerUrl, sharedObserver.baseUrl);
+			assert.ok(state.panelHtml?.includes('<iframe '), 'observer panel should embed the Observer UI in an iframe');
+			assert.ok(
+				state.panelHtml?.includes(sharedObserver.baseUrl),
+				'observer panel iframe should point at the shared backend',
+			);
+
+			await vscode.commands.executeCommand('observability-studio.configureCodexMCP');
+			await vscode.commands.executeCommand('observability-studio.configureClaudeCodeMCP');
+			await vscode.commands.executeCommand('observability-studio.configureCursorMCP');
+
+			await assertCodexConfigured([codexConfigPath, originalCodexConfigPath], sharedMcpUrl);
+			await assertJSONMCPConfigured([claudeConfigPath, originalClaudeConfigPath], 'obstudio', sharedMcpUrl);
+			await assertJSONMCPConfigured([cursorConfigPath, originalCursorConfigPath], 'obstudio', sharedMcpUrl);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			for (const snapshot of originalSnapshots) {
+				restoreSnapshot(snapshot);
+			}
+			fs.rmSync(tempHome, { force: true, recursive: true });
+		}
+	});
+
+	test('openObserver retries when the shared backend health check times out once', async function () {
+		this.timeout(30_000);
+
+		await getExtension();
+		const sharedObserver = await startSlowSharedObserver(750);
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+
+		try {
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await vscode.commands.executeCommand('observability-studio.openObserver');
+
+			const state = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => {
+					if (!value) {
+						return false;
+					}
+					return value.panelVisible
+						&& value.sharedMode
+						&& value.observerUrl === sharedObserver.baseUrl
+						&& typeof value.panelHtml === 'string'
+						&& value.panelHtml.includes(sharedObserver.baseUrl);
+				},
+				20_000,
+			);
+
+			assert.equal(state.sharedMode, true);
+			assert.equal(state.observerUrl, sharedObserver.baseUrl);
+			assert.ok(
+				state.panelHtml?.includes(sharedObserver.baseUrl),
+				'observer panel iframe should point at the shared backend after retrying a timeout',
+			);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+		}
+	});
+});

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -3,7 +3,12 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import test from 'node:test';
-import { resolveBackend } from '../backend';
+import {
+	buildObserverHealthUrl,
+	normalizeObserverBaseUrl,
+	observerPortFromUrl,
+	resolveBackend,
+} from '../backend';
 
 const { getBuildPaths, resetObserverOutputDirs } = require('../../build-observer.js') as {
 	getBuildPaths: (extensionRoot?: string) => {
@@ -44,6 +49,34 @@ test('resolveBackend throws when the observer binary is missing', () => {
 	withTempExtensionRoot((extensionRoot) => {
 		assert.throws(() => resolveBackend(extensionRoot), /observer binary not found/);
 	});
+});
+
+test('normalizeObserverBaseUrl accepts base URLs and /mcp URLs', () => {
+	assert.equal(normalizeObserverBaseUrl('http://127.0.0.1:3000'), 'http://127.0.0.1:3000');
+	assert.equal(normalizeObserverBaseUrl('http://127.0.0.1:3000/'), 'http://127.0.0.1:3000');
+	assert.equal(normalizeObserverBaseUrl('http://127.0.0.1:3000/mcp'), 'http://127.0.0.1:3000');
+	assert.equal(normalizeObserverBaseUrl('https://example.com/observer/mcp'), 'https://example.com/observer');
+});
+
+test('buildObserverHealthUrl uses normalized observer base URL', () => {
+	assert.equal(
+		buildObserverHealthUrl('http://127.0.0.1:3000/mcp'),
+		'http://127.0.0.1:3000/api/health',
+	);
+	assert.equal(
+		buildObserverHealthUrl('https://example.com/observer/'),
+		'https://example.com/observer/api/health',
+	);
+});
+
+test('observerPortFromUrl returns explicit and default ports', () => {
+	assert.equal(observerPortFromUrl('http://127.0.0.1:3000'), 3000);
+	assert.equal(observerPortFromUrl('https://example.com'), 443);
+	assert.equal(observerPortFromUrl('http://example.com/service/mcp'), 80);
+});
+
+test('normalizeObserverBaseUrl rejects unsupported schemes', () => {
+	assert.throws(() => normalizeObserverBaseUrl('stdio://obstudio'), /http or https/);
 });
 
 test('resetObserverOutputDirs removes stale output and recreates the directory', () => {

--- a/observer/cmd/obstudio/install.go
+++ b/observer/cmd/obstudio/install.go
@@ -2,33 +2,79 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
+type mcpConfigFormat string
+
+const (
+	mcpConfigJSON mcpConfigFormat = "json"
+	mcpConfigTOML mcpConfigFormat = "toml"
+
+	codexManagedBlockStart = "# BEGIN OBSTUDIO MCP CONFIG"
+	codexManagedBlockEnd   = "# END OBSTUDIO MCP CONFIG"
+
+	defaultSharedObserverBaseURL = "http://127.0.0.1:3000"
+	defaultSharedObserverMCPURL  = defaultSharedObserverBaseURL + "/mcp"
+	defaultSharedObserverHealth  = defaultSharedObserverBaseURL + "/api/health"
+	sharedObserverHealthTimeout  = 750 * time.Millisecond
+)
+
+type mcpConfigTarget struct {
+	format mcpConfigFormat
+	path   func() string
+}
+
 type agentTarget struct {
 	skillsDir func(string) string
-	mcpConfig func() string
+	mcpConfig mcpConfigTarget
+}
+
+type codexMCPServer struct {
+	URL     string
+	Command string
+	Args    []string
+}
+
+type sharedObserverHealth struct {
+	APIVersion string            `json:"apiVersion"`
+	Endpoints  map[string]string `json:"endpoints"`
+	Kind       string            `json:"kind"`
 }
 
 var targets = map[string]agentTarget{
 	"cursor": {
 		skillsDir: func(home string) string { return filepath.Join(home, ".cursor", "skills", "obstudio") },
-		mcpConfig: func() string { return filepath.Join(userHome(), ".cursor", "mcp.json") },
+		mcpConfig: mcpConfigTarget{
+			format: mcpConfigJSON,
+			path:   func() string { return filepath.Join(userHome(), ".cursor", "mcp.json") },
+		},
 	},
 	"claude-code": {
 		skillsDir: func(home string) string { return filepath.Join(home, ".claude", "skills", "obstudio") },
-		mcpConfig: func() string { return filepath.Join(userHome(), ".claude", "settings.json") },
+		mcpConfig: mcpConfigTarget{
+			format: mcpConfigJSON,
+			path:   func() string { return filepath.Join(userHome(), ".claude", "settings.json") },
+		},
 	},
 	"codex": {
 		skillsDir: func(home string) string { return filepath.Join(home, ".codex", "skills", "obstudio") },
-		mcpConfig: func() string { return filepath.Join(userHome(), ".codex", "mcp.json") },
+		mcpConfig: mcpConfigTarget{
+			format: mcpConfigTOML,
+			path:   func() string { return filepath.Join(userHome(), ".codex", "config.toml") },
+		},
 	},
 }
 
@@ -37,30 +83,50 @@ func supportedTargets() string {
 	for k := range targets {
 		names = append(names, k)
 	}
+	slices.Sort(names)
 	return strings.Join(names, ", ")
 }
 
 func newInstallCmd() *cobra.Command {
 	var target string
+	var sharedURL string
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Install skills and configure the MCP server for an AI coding agent",
+		Short: "Install skills and configure MCP for an AI coding agent",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runInstall(target)
+			return runInstall(target, sharedURL)
 		},
 	}
 
 	cmd.Flags().StringVar(&target, "target", "", "Agent target ("+supportedTargets()+")")
+	cmd.Flags().StringVar(&sharedURL, "shared-url", "", "Use an existing HTTP MCP endpoint instead of auto-starting a local obstudio binary")
 	cmd.MarkFlagRequired("target")
 
 	return cmd
 }
 
-func runInstall(target string) error {
+func runInstall(target, sharedURL string) error {
 	t, ok := targets[target]
 	if !ok {
 		return fmt.Errorf("unknown target: %s (supported: %s)", target, supportedTargets())
+	}
+	resolvedSharedURL := sharedURL
+	autodetectedSharedURL := false
+	if resolvedSharedURL == "" {
+		if detectedURL, ok := detectSharedObserverURL(defaultSharedObserverHealth, http.DefaultClient); ok {
+			resolvedSharedURL = detectedURL
+			autodetectedSharedURL = true
+		}
+	}
+	if resolvedSharedURL != "" {
+		source := "--shared-url"
+		if autodetectedSharedURL {
+			source = "detected shared observer URL"
+		}
+		if err := validateSharedURL(resolvedSharedURL, source); err != nil {
+			return err
+		}
 	}
 
 	home := userHome()
@@ -88,7 +154,8 @@ func runInstall(target string) error {
 	}
 	exePath, _ = filepath.EvalSymlinks(exePath)
 
-	installedBinary := filepath.Join(destDir, "obstudio")
+	installedBinaryName := "obstudio" + filepath.Ext(exePath)
+	installedBinary := filepath.Join(destDir, installedBinaryName)
 	if err := copyFile(exePath, installedBinary); err != nil {
 		return fmt.Errorf("failed to copy binary: %w", err)
 	}
@@ -97,17 +164,86 @@ func runInstall(target string) error {
 	}
 	fmt.Println("  Binary installed.")
 
-	mcpFile := t.mcpConfig()
-	if err := configureMCP(mcpFile, installedBinary); err != nil {
+	mcpFile := t.mcpConfig.path()
+	if err := configureMCP(t.mcpConfig, installedBinary, resolvedSharedURL); err != nil {
 		return fmt.Errorf("failed to configure MCP: %w", err)
 	}
-	fmt.Printf("  MCP configured in %s\n", mcpFile)
+	if resolvedSharedURL == "" {
+		fmt.Printf("  MCP configured in %s to launch a local obstudio process.\n", mcpFile)
+	} else if autodetectedSharedURL {
+		fmt.Printf("  MCP configured in %s to reuse detected shared server %s.\n", mcpFile, resolvedSharedURL)
+	} else {
+		fmt.Printf("  MCP configured in %s to reuse %s.\n", mcpFile, resolvedSharedURL)
+	}
 
-	fmt.Println("\nDone. Restart your editor to activate the MCP server.")
+	if resolvedSharedURL == "" {
+		fmt.Println("\nDone. Restart your editor to activate the MCP server.")
+		return nil
+	}
+
+	fmt.Println("\nDone. Start the shared obstudio server before opening your agent:")
+	fmt.Println("  obstudio")
 	return nil
 }
 
-func configureMCP(path, binaryPath string) error {
+func detectSharedObserverURL(healthURL string, client *http.Client) (string, bool) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	requestClient := *client
+	if requestClient.Timeout == 0 {
+		requestClient.Timeout = sharedObserverHealthTimeout
+	}
+
+	resp, err := requestClient.Get(healthURL)
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+
+	var health sharedObserverHealth
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return "", false
+	}
+	if health.Kind != "obstudio" || health.APIVersion != "v1" {
+		return "", false
+	}
+	if mcpURL := strings.TrimSpace(health.Endpoints["mcp"]); mcpURL != "" {
+		return mcpURL, true
+	}
+	return defaultSharedObserverMCPURL, true
+}
+
+func configureMCP(target mcpConfigTarget, binaryPath, sharedURL string) error {
+	switch target.format {
+	case mcpConfigJSON:
+		server := map[string]any{}
+		if sharedURL == "" {
+			server["command"] = binaryPath
+			server["args"] = []string{}
+		} else {
+			server["type"] = "http"
+			server["url"] = sharedURL
+		}
+		return upsertJSONMCPServer(target.path(), server)
+	case mcpConfigTOML:
+		server := codexMCPServer{}
+		if sharedURL == "" {
+			server.Command = binaryPath
+			server.Args = []string{}
+		} else {
+			server.URL = sharedURL
+		}
+		return upsertCodexMCPServer(target.path(), server)
+	default:
+		return fmt.Errorf("unsupported MCP config format: %s", target.format)
+	}
+}
+
+func upsertJSONMCPServer(path string, server map[string]any) error {
 	config := map[string]any{}
 
 	data, err := os.ReadFile(path)
@@ -115,28 +251,168 @@ func configureMCP(path, binaryPath string) error {
 		if err := json.Unmarshal(data, &config); err != nil {
 			return fmt.Errorf("failed to parse %s: %w", path, err)
 		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read JSON MCP config %q: %w", path, err)
 	}
 
 	servers, ok := config["mcpServers"].(map[string]any)
 	if !ok {
 		servers = map[string]any{}
 	}
-
-	servers["obstudio"] = map[string]any{
-		"command": binaryPath,
-		"args":    []string{},
-	}
+	servers["obstudio"] = server
 	config["mcpServers"] = servers
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return fmt.Errorf("create parent directory for %q: %w", path, err)
 	}
 
 	out, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal JSON MCP config %q: %w", path, err)
 	}
-	return os.WriteFile(path, append(out, '\n'), 0o644)
+	if err := os.WriteFile(path, append(out, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write JSON MCP config %q: %w", path, err)
+	}
+	return nil
+}
+
+func upsertCodexMCPServer(path string, server codexMCPServer) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read codex MCP config %q: %w", path, err)
+	}
+
+	content := string(data)
+	content = removeCodexManagedBlock(content)
+	content = removeCodexServerSections(content)
+	content = strings.TrimRight(content, "\n")
+	if strings.TrimSpace(content) != "" {
+		content += "\n\n"
+	}
+	content += renderCodexManagedBlock(server)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create parent directory for %q: %w", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write codex MCP config %q: %w", path, err)
+	}
+	return nil
+}
+
+func renderCodexManagedBlock(server codexMCPServer) string {
+	lines := []string{
+		codexManagedBlockStart,
+		"[mcp_servers.obstudio]",
+		"enabled = true",
+	}
+
+	if server.URL != "" {
+		lines = append(lines, fmt.Sprintf("url = %q", server.URL))
+	} else {
+		lines = append(lines,
+			fmt.Sprintf("command = %q", server.Command),
+			fmt.Sprintf("args = %s", renderTOMLStringArray(server.Args)),
+		)
+	}
+
+	lines = append(lines, codexManagedBlockEnd)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func renderTOMLStringArray(values []string) string {
+	if len(values) == 0 {
+		return "[]"
+	}
+
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", value))
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
+func removeCodexManagedBlock(content string) string {
+	if content == "" {
+		return content
+	}
+
+	lines := splitLines(content)
+	out := strings.Builder{}
+	skipping := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == codexManagedBlockStart:
+			skipping = true
+			continue
+		case skipping && trimmed == codexManagedBlockEnd:
+			skipping = false
+			continue
+		case skipping:
+			continue
+		default:
+			out.WriteString(line)
+		}
+	}
+
+	return out.String()
+}
+
+func removeCodexServerSections(content string) string {
+	if content == "" {
+		return content
+	}
+
+	lines := splitLines(content)
+	out := strings.Builder{}
+	skipping := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isTOMLTableHeader(trimmed) {
+			if isCodexObstudioHeader(trimmed) {
+				skipping = true
+				continue
+			}
+			if skipping {
+				skipping = false
+			}
+		}
+		if skipping {
+			continue
+		}
+		out.WriteString(line)
+	}
+
+	return out.String()
+}
+
+func isTOMLTableHeader(line string) bool {
+	return strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]")
+}
+
+func isCodexObstudioHeader(line string) bool {
+	return line == "[mcp_servers.obstudio]" || strings.HasPrefix(line, "[mcp_servers.obstudio.")
+}
+
+func splitLines(content string) []string {
+	return strings.SplitAfter(content, "\n")
+}
+
+func validateSharedURL(raw, source string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid %s: %w", source, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("invalid %s: %s must use http or https", source, raw)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("invalid %s: %s is missing a host", source, raw)
+	}
+	return nil
 }
 
 func extractFS(src fs.FS, destDir string) error {
@@ -166,12 +442,15 @@ func extractFS(src fs.FS, destDir string) error {
 func copyFile(src, dst string) error {
 	data, err := os.ReadFile(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("read %q: %w", src, err)
 	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
+		return fmt.Errorf("create parent directory for %q: %w", dst, err)
 	}
-	return os.WriteFile(dst, data, 0o644)
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("write %q: %w", dst, err)
+	}
+	return nil
 }
 
 func userHome() string {

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestClaudeCodeTargetUsesSettingsJSON(t *testing.T) {
+	t.Parallel()
+
+	target, ok := targets["claude-code"]
+	if !ok {
+		t.Fatal("expected claude-code target to exist")
+	}
+
+	path := target.mcpConfig.path()
+	if !strings.HasSuffix(path, filepath.Join(".claude", "settings.json")) {
+		t.Fatalf("expected Claude Code MCP config path to end with .claude/settings.json, got %q", path)
+	}
+}
+
+func TestCodexTargetUsesConfigTOML(t *testing.T) {
+	t.Parallel()
+
+	target, ok := targets["codex"]
+	if !ok {
+		t.Fatal("expected codex target to exist")
+	}
+
+	path := target.mcpConfig.path()
+	if !strings.HasSuffix(path, filepath.Join(".codex", "config.toml")) {
+		t.Fatalf("expected Codex MCP config path to end with .codex/config.toml, got %q", path)
+	}
+}
+
+func TestUpsertJSONMCPServerPreservesExistingEntries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	initial := map[string]any{
+		"mcpServers": map[string]any{
+			"existing": map[string]any{
+				"command": "existing-server",
+				"args":    []string{"--flag"},
+			},
+		},
+		"theme": "dark",
+	}
+	data, err := json.Marshal(initial)
+	if err != nil {
+		t.Fatalf("marshal initial config: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	if err := upsertJSONMCPServer(path, map[string]any{
+		"type": "http",
+		"url":  "http://127.0.0.1:3000/mcp",
+	}); err != nil {
+		t.Fatalf("upsertJSONMCPServer returned error: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal(out, &config); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+
+	if got := config["theme"]; got != "dark" {
+		t.Fatalf("expected theme to be preserved, got %#v", got)
+	}
+
+	servers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers missing or wrong type: %#v", config["mcpServers"])
+	}
+
+	if _, ok := servers["existing"]; !ok {
+		t.Fatalf("existing server was removed: %#v", servers)
+	}
+
+	obstudio, ok := servers["obstudio"].(map[string]any)
+	if !ok {
+		t.Fatalf("obstudio server missing or wrong type: %#v", servers["obstudio"])
+	}
+	if got := obstudio["type"]; got != "http" {
+		t.Fatalf("expected obstudio type=http, got %#v", got)
+	}
+	if got := obstudio["url"]; got != "http://127.0.0.1:3000/mcp" {
+		t.Fatalf("expected obstudio url to be preserved, got %#v", got)
+	}
+}
+
+func TestUpsertCodexMCPServerAppendsManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	initial := strings.Join([]string{
+		`model = "gpt-5.4"`,
+		``,
+		`[projects."/tmp/demo"]`,
+		`trust_level = "trusted"`,
+		``,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	if err := upsertCodexMCPServer(path, codexMCPServer{
+		URL: "http://127.0.0.1:3000/mcp",
+	}); err != nil {
+		t.Fatalf("upsertCodexMCPServer returned error: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(out)
+
+	for _, want := range []string{
+		`model = "gpt-5.4"`,
+		`[projects."/tmp/demo"]`,
+		`trust_level = "trusted"`,
+		codexManagedBlockStart,
+		`[mcp_servers.obstudio]`,
+		`enabled = true`,
+		`url = "http://127.0.0.1:3000/mcp"`,
+		codexManagedBlockEnd,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected config to contain %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestUpsertCodexMCPServerReplacesLegacySection(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	initial := strings.Join([]string{
+		`model = "gpt-5.4"`,
+		``,
+		`[mcp_servers.obstudio]`,
+		`command = "/tmp/old-obstudio"`,
+		`args = ["--stdio"]`,
+		``,
+		`[mcp_servers.other]`,
+		`url = "http://example.com/mcp"`,
+		``,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	if err := upsertCodexMCPServer(path, codexMCPServer{
+		Command: "/tmp/new-obstudio",
+		Args:    []string{},
+	}); err != nil {
+		t.Fatalf("upsertCodexMCPServer returned error: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(out)
+
+	if strings.Contains(text, `/tmp/old-obstudio`) {
+		t.Fatalf("legacy obstudio section was not removed:\n%s", text)
+	}
+	if strings.Count(text, `[mcp_servers.obstudio]`) != 1 {
+		t.Fatalf("expected exactly one obstudio section, got:\n%s", text)
+	}
+	if !strings.Contains(text, `command = "/tmp/new-obstudio"`) {
+		t.Fatalf("new obstudio command missing:\n%s", text)
+	}
+	if !strings.Contains(text, `[mcp_servers.other]`) {
+		t.Fatalf("other MCP section was removed:\n%s", text)
+	}
+}
+
+func TestValidateSharedURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "http", raw: "http://127.0.0.1:3000/mcp"},
+		{name: "https", raw: "https://example.com/mcp"},
+		{name: "missing scheme", raw: "127.0.0.1:3000/mcp", wantErr: true},
+		{name: "missing host", raw: "http:///mcp", wantErr: true},
+		{name: "wrong scheme", raw: "stdio://obstudio", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateSharedURL(tc.raw, "--shared-url")
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q", tc.raw)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.raw, err)
+			}
+		})
+	}
+}
+
+func TestValidateSharedURLIncludesSourceLabel(t *testing.T) {
+	t.Parallel()
+
+	err := validateSharedURL("stdio://obstudio", "detected shared observer URL")
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "invalid detected shared observer URL") {
+		t.Fatalf("expected source label in error, got %q", err.Error())
+	}
+}
+
+func TestDetectSharedObserverURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sharedObserverHealth{
+			Kind:       "obstudio",
+			APIVersion: "v1",
+			Endpoints: map[string]string{
+				"mcp": "http://127.0.0.1:3000/mcp",
+			},
+		})
+	}))
+	defer server.Close()
+
+	detected, ok := detectSharedObserverURL(server.URL, server.Client())
+	if !ok {
+		t.Fatal("expected shared observer to be detected")
+	}
+	if detected != "http://127.0.0.1:3000/mcp" {
+		t.Fatalf("unexpected detected URL: %s", detected)
+	}
+}
+
+func TestDetectSharedObserverURLRejectsMismatchedService(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kind":       "other-service",
+			"apiVersion": "v1",
+			"endpoints": map[string]string{
+				"mcp": "http://127.0.0.1:3000/mcp",
+			},
+		})
+	}))
+	defer server.Close()
+
+	if detected, ok := detectSharedObserverURL(server.URL, server.Client()); ok {
+		t.Fatalf("expected no detection, got %s", detected)
+	}
+}
+
+func TestUpsertCodexMCPServerWrapsWriteErrors(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based write error assertion is not reliable on Windows")
+	}
+
+	parentDir := filepath.Join(t.TempDir(), "readonly")
+	if err := os.Mkdir(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent dir: %v", err)
+	}
+	if err := os.Chmod(parentDir, 0o555); err != nil {
+		t.Fatalf("chmod parent dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(parentDir, 0o755)
+	})
+
+	path := filepath.Join(parentDir, "config.toml")
+
+	err := upsertCodexMCPServer(path, codexMCPServer{URL: "http://127.0.0.1:3000/mcp"})
+	if err == nil {
+		t.Fatal("expected upsertCodexMCPServer to fail when parent directory is not writable")
+	}
+	if !strings.Contains(err.Error(), "write codex MCP config") {
+		t.Fatalf("expected wrapped write error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected error to include path %q, got %v", path, err)
+	}
+}
+
+func TestCopyFileWrapsSourcePathErrors(t *testing.T) {
+	t.Parallel()
+
+	dst := filepath.Join(t.TempDir(), "copy", "target")
+	err := copyFile(filepath.Join(t.TempDir(), "missing"), dst)
+	if err == nil {
+		t.Fatal("expected copyFile to fail for missing source")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected missing source path in error, got %v", err)
+	}
+}

--- a/observer/internal/api/handler.go
+++ b/observer/internal/api/handler.go
@@ -6,14 +6,31 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/signalfx/obstudio/observer/internal/store"
 )
 
+type serverInfo struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Mode       string    `json:"mode"`
+	Owner      string    `json:"owner"`
+	StartedAt  time.Time `json:"startedAt"`
+	Version    string    `json:"version"`
+}
+
+type healthResponse struct {
+	serverInfo
+	Endpoints map[string]string `json:"endpoints"`
+}
+
 // Register adds the REST API routes to the given mux.
 // It registers handlers for querying traces, metrics, logs, and stats.
 func Register(mux *http.ServeMux, s *store.Store) {
+	startedAt := time.Now().UTC()
 	mux.HandleFunc("OPTIONS /api/", corsPreflightHandler())
+	mux.HandleFunc("GET /api/health", queryHealth(s, startedAt))
 	mux.HandleFunc("GET /api/query/traces", queryTraces(s))
 	mux.HandleFunc("GET /api/query/traces/{traceId}", queryTraceDetail(s))
 	mux.HandleFunc("GET /api/query/metrics", queryMetrics(s))
@@ -55,6 +72,37 @@ func queryLogs(s *store.Store) http.HandlerFunc {
 func queryStats(s *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, s.Stats())
+	}
+}
+
+func queryHealth(s *store.Store, startedAt time.Time) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var endpoints store.Endpoints
+		if s != nil {
+			endpoints = s.Endpoints()
+		}
+
+		mcpEndpoint := ""
+		if endpoints.REST != "" {
+			mcpEndpoint = endpoints.REST + "/mcp"
+		}
+
+		writeJSON(w, healthResponse{
+			serverInfo: serverInfo{
+				APIVersion: "v1",
+				Kind:       "obstudio",
+				Mode:       "standalone",
+				Owner:      "unknown",
+				StartedAt:  startedAt,
+				Version:    "dev",
+			},
+			Endpoints: map[string]string{
+				"mcp":      mcpEndpoint,
+				"otlpGrpc": endpoints.OTLPgRPC,
+				"otlpHttp": endpoints.OTLPHTTP,
+				"rest":     endpoints.REST,
+			},
+		})
 	}
 }
 

--- a/observer/internal/api/handler_test.go
+++ b/observer/internal/api/handler_test.go
@@ -275,6 +275,85 @@ func TestQueryMetricsSuccess(t *testing.T) {
 	}
 }
 
+func TestQueryHealthReturnsServerMetadataAndEndpoints(t *testing.T) {
+	s := store.New()
+	s.SetEndpoints(store.Endpoints{
+		REST:     "http://127.0.0.1:3000",
+		OTLPHTTP: "http://127.0.0.1:4318",
+		OTLPgRPC: "127.0.0.1:4317",
+	})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/health")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var health map[string]any
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &health); err != nil {
+		t.Fatalf("failed to decode health response: %v", err)
+	}
+
+	if got := health["kind"]; got != "obstudio" {
+		t.Fatalf("expected kind obstudio, got %#v", got)
+	}
+	if got := health["apiVersion"]; got != "v1" {
+		t.Fatalf("expected apiVersion v1, got %#v", got)
+	}
+
+	endpoints, ok := health["endpoints"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected endpoints object, got %#v", health["endpoints"])
+	}
+	if got := endpoints["rest"]; got != "http://127.0.0.1:3000" {
+		t.Fatalf("expected rest endpoint, got %#v", got)
+	}
+	if got := endpoints["mcp"]; got != "http://127.0.0.1:3000/mcp" {
+		t.Fatalf("expected mcp endpoint, got %#v", got)
+	}
+	if got := endpoints["otlpHttp"]; got != "http://127.0.0.1:4318" {
+		t.Fatalf("expected otlpHttp endpoint, got %#v", got)
+	}
+	if got := endpoints["otlpGrpc"]; got != "127.0.0.1:4317" {
+		t.Fatalf("expected otlpGrpc endpoint, got %#v", got)
+	}
+}
+
+func TestQueryHealthHandlesNilStore(t *testing.T) {
+	mux := http.NewServeMux()
+	Register(mux, nil)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/health")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var health map[string]any
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &health); err != nil {
+		t.Fatalf("failed to decode health response: %v", err)
+	}
+
+	endpoints, ok := health["endpoints"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected endpoints object, got %#v", health["endpoints"])
+	}
+	if got := endpoints["rest"]; got != "" {
+		t.Fatalf("expected empty rest endpoint, got %#v", got)
+	}
+}
+
 func TestQueryLogsSuccess(t *testing.T) {
 	s := store.New()
 	log := store.LogRecord{


### PR DESCRIPTION
## Summary
Add shared Observer backend integration across the installer and VS Code extension.

## What Changed
- add `/api/health` metadata used for shared-backend detection
- let `obstudio install` autodetect and configure an existing shared backend
- support explicit `--shared-url` MCP configuration
- configure Codex, Claude Code, and Cursor MCP settings for shared HTTP mode
- let the VS Code extension reuse an existing shared backend instead of always spawning a local process
- retry shared-backend health probe timeouts instead of treating them as fatal mismatches
- improve install-time validation messaging for autodetected shared URLs
- stabilize VS Code host tests by waiting for generated MCP config files before asserting their contents

## Tests
- `cd extension && npm run test:all`
- browser shell smoke against `http://127.0.0.1:3700`
- shared-backend installer/config host flow verified through the VS Code host suite

## Verification
- rebuilt client assets
- rebuilt the VSIX
- force-installed the extension locally
- verified the observer shell renders from the branch build
- verified shared-backend MCP config generation for Codex, Claude Code, and Cursor
