### PR TITLE
Improve the Telemetry Explorer experience

### DIFF
--- a/observer/client/src/AppView.test.tsx
+++ b/observer/client/src/AppView.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppView } from "./AppView";
+import type { TelemetryHandle } from "./telemetry";
+
+function makeTelemetryHandle(): TelemetryHandle {
+  return {
+    state: {
+      error: null,
+      traces: [],
+      metrics: [],
+      logs: [],
+      stats: {
+        spanCount: 12,
+        dataPointCount: 8,
+        metricNameCount: 3,
+        logCount: 5,
+        traceCount: 2,
+        serviceNames: ["checkout"],
+      },
+    },
+    paused: false,
+    hasNewUpdates: false,
+    pause: vi.fn(),
+    resume: vi.fn(),
+    toggle: vi.fn(),
+    flush: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AppView", () => {
+  it("renders summary cards and the telemetry stream pill", () => {
+    const { container } = render(<AppView telemetry={makeTelemetryHandle()} />);
+    const summary = container.querySelector(".metric-summary");
+
+    expect(summary).toBeTruthy();
+    expect(within(summary as HTMLElement).getByText("Traces")).toBeTruthy();
+    expect(within(summary as HTMLElement).getByText("Metrics")).toBeTruthy();
+    expect(within(summary as HTMLElement).getByText("Logs")).toBeTruthy();
+    expect(within(summary as HTMLElement).getByText("Services")).toBeTruthy();
+    expect(screen.getByText("Telemetry stream")).toBeTruthy();
+  });
+
+  it("renders plain tab labels without letter badges", () => {
+    const { container } = render(<AppView telemetry={makeTelemetryHandle()} />);
+
+    expect(screen.getByRole("tab", { name: "Metrics" }).textContent).toBe("Metrics");
+    expect(screen.getByRole("tab", { name: "Traces" }).textContent).toBe("Traces");
+    expect(screen.getByRole("tab", { name: "Logs" }).textContent).toBe("Logs");
+    expect(container.querySelector(".tab-button__glyph")).toBeNull();
+  });
+});

--- a/observer/client/src/AppView.tsx
+++ b/observer/client/src/AppView.tsx
@@ -117,7 +117,6 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             className={activeTab === "metrics" ? "tab-button is-active" : "tab-button"}
             onClick={() => switchTab("metrics")}
           >
-            <span className="tab-button__glyph" aria-hidden="true">M</span>
             Metrics
           </button>
           <button
@@ -127,7 +126,6 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             className={activeTab === "traces" ? "tab-button is-active" : "tab-button"}
             onClick={() => switchTab("traces")}
           >
-            <span className="tab-button__glyph" aria-hidden="true">T</span>
             Traces
           </button>
           <button
@@ -137,7 +135,6 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             className={activeTab === "logs" ? "tab-button is-active" : "tab-button"}
             onClick={() => switchTab("logs")}
           >
-            <span className="tab-button__glyph" aria-hidden="true">L</span>
             Logs
           </button>
         </div>

--- a/observer/client/src/layout/DetailPanel.tsx
+++ b/observer/client/src/layout/DetailPanel.tsx
@@ -1,26 +1,42 @@
-import React, { type ReactNode } from "react";
+import React, { type ReactNode, useEffect, useRef } from "react";
 
 interface DetailPanelProps {
-  title: string;
+  title?: string;
   subtitle?: string;
+  headerMode?: "default" | "close-only";
   onClose: () => void;
   children: ReactNode;
 }
 
 /** Closeable side panel for displaying detail views. */
-export function DetailPanel({ title, subtitle, onClose, children }: DetailPanelProps): React.ReactElement {
+export function DetailPanel({
+  title,
+  subtitle,
+  headerMode = "default",
+  onClose,
+  children,
+}: DetailPanelProps): React.ReactElement {
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const showTitles = headerMode === "default" && Boolean(title || subtitle);
+
+  useEffect(() => {
+    bodyRef.current?.scrollTo(0, 0);
+  }, [title, subtitle, headerMode, children]);
+
   return (
-    <div className="detail-panel">
-      <div className="detail-panel__header">
-        <div className="detail-panel__titles">
-          <h3 className="detail-panel__title">{title}</h3>
-          {subtitle ? <span className="detail-panel__subtitle">{subtitle}</span> : null}
-        </div>
-        <button className="detail-panel__close" onClick={onClose} type="button">
+    <div className={headerMode === "close-only" ? "detail-panel detail-panel--close-only" : "detail-panel"}>
+      <div className={headerMode === "close-only" ? "detail-panel__header detail-panel__header--close-only" : "detail-panel__header"}>
+        {showTitles ? (
+          <div className="detail-panel__titles">
+            {title ? <h3 className="detail-panel__title">{title}</h3> : null}
+            {subtitle ? <span className="detail-panel__subtitle">{subtitle}</span> : null}
+          </div>
+        ) : null}
+        <button className="detail-panel__close" onClick={onClose} type="button" aria-label="Close panel">
           &times;
         </button>
       </div>
-      <div className="detail-panel__body">{children}</div>
+      <div ref={bodyRef} className={headerMode === "close-only" ? "detail-panel__body detail-panel__body--close-only" : "detail-panel__body"}>{children}</div>
     </div>
   );
 }

--- a/observer/client/src/logs/LogsTab.test.tsx
+++ b/observer/client/src/logs/LogsTab.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LogsTab } from "./LogsTab";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 36,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 36,
+        end: (index + 1) * 36,
+        size: 36,
+      })),
+    measureElement: () => undefined,
+  }),
+}));
+
+describe("LogsTab", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 1200,
+    });
+    HTMLElement.prototype.getBoundingClientRect = () =>
+      ({
+        width: 1200,
+        height: 400,
+        top: 0,
+        left: 0,
+        right: 1200,
+        bottom: 400,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+  });
+
+  it("filters logs from the compact explorer toolbar", () => {
+    const { container } = render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityText: "INFO",
+            body: "checkout started",
+            attributes: {},
+            resource: { serviceName: "checkout", attributes: {} },
+            scope: { name: "otel" },
+          },
+          {
+            id: "2",
+            timeUnixNano: "1712700000000000001",
+            severityText: "ERROR",
+            body: "payment failed",
+            attributes: {},
+            resource: { serviceName: "payments", attributes: {} },
+            scope: { name: "otel" },
+          },
+        ]}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2 logs")).toBeTruthy();
+    expect(container.querySelector(".data-table__head--left-cluster-logs")).toBeTruthy();
+    expect(container.querySelector(".data-table__body-inner--logs")).toBeTruthy();
+    expect(container.querySelector(".data-table__td--timestamp .explorer-row__secondary")).toBeTruthy();
+    expect(container.querySelector(".data-table__td--service .explorer-row__secondary")).toBeTruthy();
+    expect(container.querySelector(".data-table__td--message .explorer-row__primary")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("Search message, service, or trace ID"), {
+      target: { value: "does-not-match" },
+    });
+
+    expect(screen.getByText("No logs match the current filters.")).toBeTruthy();
+  });
+
+  it("renders the selected log detail without validation overlays", () => {
+    const { container } = render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityText: "INFO",
+            body: "checkout started",
+            attributes: {},
+            resource: { serviceName: "checkout", attributes: {} },
+            scope: { name: "otel" },
+            traceId: "trace-1",
+            spanId: "span-1",
+          },
+        ]}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(container.querySelector(".data-table__row--logs") as HTMLElement);
+
+    expect(screen.getByRole("heading", { name: "Message" })).toBeTruthy();
+    expect(screen.queryByText("Validation")).toBeNull();
+    expect(screen.getByRole("button", { name: "Close panel" })).toBeTruthy();
+    expect(screen.getAllByRole("combobox", { name: "Filter logs by severity" }).length).toBeGreaterThan(0);
+  });
+});

--- a/observer/client/src/logs/LogsTab.tsx
+++ b/observer/client/src/logs/LogsTab.tsx
@@ -25,11 +25,32 @@ function logKey(r: LogRecord): string {
 
 /** Logs tab with virtualized table and detail panel for selected log records. */
 export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement {
+  const [query, setQuery] = useState("");
+  const [severityFilter, setSeverityFilter] = useState("");
   const [selectedLog, setSelectedLog] = useState<LogRecord | null>(null);
   const [detailTab, setDetailTab] = useState<DetailTab>("overview");
   const tableRef = useRef<HTMLDivElement>(null);
 
   const selectedKey = useMemo(() => selectedLog ? logKey(selectedLog) : null, [selectedLog]);
+  const filteredLogs = useMemo(() => {
+    const trimmedQuery = query.trim().toLowerCase();
+    return logs.filter((record) => {
+      const severity = record.severityText ?? "";
+      if (severityFilter && !severity.toLowerCase().includes(severityFilter)) {
+        return false;
+      }
+      if (!trimmedQuery) {
+        return true;
+      }
+      const haystack = [
+        severity,
+        record.body,
+        record.resource?.serviceName ?? "",
+        record.traceId ?? "",
+      ].join(" ").toLowerCase();
+      return haystack.includes(trimmedQuery);
+    });
+  }, [logs, query, severityFilter]);
   const handleInteract = useCallback(() => {
     onInteract?.();
   }, [onInteract]);
@@ -42,8 +63,14 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
     }
   }, [logs, selectedKey]);
 
+  useEffect(() => {
+    if (selectedKey && !filteredLogs.some((record) => logKey(record) === selectedKey)) {
+      setSelectedLog(null);
+    }
+  }, [filteredLogs, selectedKey]);
+
   const virtualizer = useVirtualizer({
-    count: logs.length,
+    count: filteredLogs.length,
     getScrollElement: () => tableRef.current,
     estimateSize: () => 36,
     overscan: 10,
@@ -57,16 +84,37 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
       >
         <div className="signal-view__content">
           {logs.length > 0 ? (
-            <div className="explorer__toolbar">
-              <span className="explorer__count">{logs.length} logs</span>
+            <div className="explorer__toolbar explorer__toolbar--controls">
+              <span className="explorer__count">{filteredLogs.length} logs</span>
+              <select
+                className="explorer__select"
+                value={severityFilter}
+                onChange={(event) => setSeverityFilter(event.target.value)}
+                aria-label="Filter logs by severity"
+              >
+                <option value="">All levels</option>
+                <option value="error">Error</option>
+                <option value="warn">Warn</option>
+                <option value="info">Info</option>
+                <option value="debug">Debug</option>
+              </select>
+              <input
+                className="explorer__input"
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search message, service, or trace ID"
+              />
             </div>
           ) : null}
 
           {logs.length === 0 ? (
             <p className="explorer__status">Waiting for logs... Send OTLP data to port 4318.</p>
+          ) : filteredLogs.length === 0 ? (
+            <p className="explorer__status">No logs match the current filters.</p>
           ) : (
             <>
-          <div className="data-table__head data-table__head--logs">
+          <div className="data-table__head data-table__head--logs data-table__head--left-cluster data-table__head--left-cluster-logs">
             <span className="data-table__th data-table__th--severity">Level</span>
             <span className="data-table__th data-table__th--timestamp">Timestamp</span>
             <span className="data-table__th data-table__th--service">Service</span>
@@ -74,9 +122,9 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
           </div>
 
           <div className="data-table__body" ref={tableRef}>
-            <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+            <div className="data-table__body-inner data-table__body-inner--logs" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
               {virtualizer.getVirtualItems().map((vi) => {
-                const r = logs[vi.index];
+                const r = filteredLogs[vi.index];
                 if (!r) return null;
                 const active = selectedKey !== null && logKey(r) === selectedKey;
                 const cls = severityClass(r.severityText ?? "");
@@ -104,12 +152,14 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
                       {r.severityText ?? "--"}
                     </span>
                     <span className="data-table__td data-table__td--timestamp">
-                      {formatTimestamp(r.timeUnixNano)}
+                      <span className="explorer-row__secondary">{formatTimestamp(r.timeUnixNano)}</span>
                     </span>
                     <span className="data-table__td data-table__td--service">
-                      {r.resource?.serviceName ?? "unknown"}
+                      <span className="explorer-row__secondary">{r.resource?.serviceName ?? "unknown"}</span>
                     </span>
-                    <span className="data-table__td data-table__td--message">{r.body}</span>
+                    <span className="data-table__td data-table__td--message">
+                      <span className="explorer-row__primary">{r.body}</span>
+                    </span>
                   </button>
                 );
               })}

--- a/observer/client/src/metrics/MetricsTab.test.tsx
+++ b/observer/client/src/metrics/MetricsTab.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment happy-dom
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MetricsTab } from "./MetricsTab";
+
+afterEach(() => cleanup());
+
+describe("MetricsTab", () => {
+  it("filters metrics from the compact explorer toolbar using the visible columns", () => {
+    render(
+      <MetricsTab
+        metrics={[
+          {
+            name: "http.server.request.count",
+            description: "Request count",
+            unit: "requests",
+            type: "sum",
+            serviceName: "checkout",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+          {
+            name: "http.server.duration",
+            description: "Request duration",
+            unit: "ms",
+            type: "histogram",
+            serviceName: "checkout",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+          {
+            name: "db.client.connections.usage",
+            description: "Open connections",
+            unit: "connections",
+            type: "gauge",
+            serviceName: "db",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("3 metrics")).toBeTruthy();
+    expect(screen.getByText("Type / Unit")).toBeTruthy();
+    expect(screen.getByText("Description")).toBeTruthy();
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.queryByText("Type")).toBeNull();
+    expect(screen.queryByText("Unit")).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText("Search metric, description, type, unit, or service"), {
+      target: { value: "duration" },
+    });
+
+    expect(screen.getByText("1 metrics")).toBeTruthy();
+    expect(screen.queryByText("http.server.request.count")).toBeNull();
+    expect(screen.getByText("http.server.duration")).toBeTruthy();
+    expect(screen.queryByText("db.client.connections.usage")).toBeNull();
+  });
+
+  it("renders metrics in alphabetical order and pauses live updates on interaction", () => {
+    const onInteract = vi.fn();
+    const { container } = render(
+      <MetricsTab
+        metrics={[
+          {
+            name: "zeta.metric",
+            description: "Zeta metric",
+            unit: "ms",
+            type: "gauge",
+            serviceName: "checkout",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+          {
+            name: "alpha.metric",
+            description: "Alpha metric",
+            unit: "ms",
+            type: "gauge",
+            serviceName: "checkout",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+        ]}
+        telemetryError={null}
+        onInteract={onInteract}
+      />,
+    );
+
+    const names = Array.from(container.querySelectorAll(".metric-card__name")).map((node) => node.textContent);
+    expect(names).toEqual(["alpha.metric", "zeta.metric"]);
+    expect(container.querySelector(".metric-card__header")?.classList.contains("data-table__row--metrics")).toBe(true);
+    expect(container.querySelector(".metric-card__name")?.classList.contains("explorer-row__primary")).toBe(true);
+    expect(container.querySelector(".metric-card__description")?.textContent).toBe("Alpha metric");
+    expect(container.querySelector(".metric-card__glyph")).toBeNull();
+    expect(container.querySelector(".metric-card__meta")).toBeTruthy();
+    expect(container.querySelector(".metric-card__meta")?.classList.contains("data-table__cell-content")).toBe(true);
+    expect(container.querySelector(".data-table__td--metric-description")).toBeTruthy();
+    expect(container.querySelector(".data-table__td--metric-meta")).toBeTruthy();
+    expect(container.querySelector(".metric-card__meta-separator")?.textContent).toBe("/");
+    expect(container.querySelector(".validation-badge")).toBeNull();
+    expect(container.querySelector(".metric-card__disclosure")).toBeNull();
+    expect(container.textContent).toContain("gauge/ms");
+    expect(container.textContent).not.toContain("svc");
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: /alpha\.metric/i }));
+    expect(onInteract).toHaveBeenCalled();
+  });
+
+  it("renders expanded series rows with separate service and dimension text", () => {
+    const { container } = render(
+      <MetricsTab
+        metrics={[
+          {
+            name: "http.server.duration",
+            description: "Request duration",
+            unit: "ms",
+            type: "histogram",
+            serviceName: "api-gateway",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [
+              {
+                name: "http.server.duration",
+                type: "histogram",
+                unit: "ms",
+                timeUnixNano: "1",
+                attributes: { "http.route": "/api/orders/{id}" },
+                resource: { serviceName: "api-gateway", attributes: {} },
+                scope: { name: "otel" },
+                value: 8.18,
+              },
+            ],
+          },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /http\.server\.duration/i }));
+
+    expect(container.querySelector(".metrics-explorer__series-service")?.textContent).toBe("api-gateway");
+    expect(container.querySelector(".metrics-explorer__series-attr")?.textContent).toBe("http.route=/api/orders/{id}");
+    expect(container.querySelector(".metrics-explorer__series-value")?.textContent).toBe("8.18");
+    expect(container.querySelector(".metrics-explorer__series-points")?.textContent).toBe("1 pts");
+    expect(container.querySelector(".metric-card__description")?.classList.contains("explorer-row__secondary")).toBe(true);
+  });
+
+  it("keeps the shared row separator on metric rows", async () => {
+    const css = await readFile(resolve(process.cwd(), "src/styles.css"), "utf8");
+    const style = document.createElement("style");
+    style.textContent = css;
+    document.head.appendChild(style);
+
+    const { container } = render(
+      <MetricsTab
+        metrics={[
+          {
+            name: "http.server.request.count",
+            description: "Request count",
+            unit: "requests",
+            type: "sum",
+            serviceName: "checkout",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    const row = container.querySelector(".metric-card__header");
+    expect(row).toBeTruthy();
+
+    const rowStyles = window.getComputedStyle(row as Element);
+    expect(rowStyles.borderBottomStyle).toBe("solid");
+    expect(rowStyles.borderBottomWidth).not.toBe("0px");
+
+    style.remove();
+  });
+});

--- a/observer/client/src/metrics/MetricsTab.tsx
+++ b/observer/client/src/metrics/MetricsTab.tsx
@@ -1,30 +1,46 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 import { useMetricTimeSeries } from "./useMetricTimeSeries";
 import type { MetricGroup } from "../api/types";
+import { TELEMETRY_SERIES_COLORS } from "../palette";
 
 interface MetricsTabProps {
   metrics: MetricGroup[];
   telemetryError: string | null;
+  onInteract?: () => void;
 }
 
 type DisplayType = "lines" | "bars" | "area";
 
-const TYPE_GLYPHS: Record<string, string> = {
-  counter: "\u2191",
-  gauge: "\u25CC",
-  histogram: "\u25EB",
-  summary: "\u2726",
-  exponential_histogram: "\u25EB",
-};
-
 /** Metrics tab with expandable metric cards and time series charts. */
-export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.ReactElement {
+export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabProps): React.ReactElement {
+  const [query, setQuery] = useState("");
   const [expandedMetric, setExpandedMetric] = useState<string | null>(null);
   const [selectedSeriesKey, setSelectedSeriesKey] = useState<string | null>(null);
   const [displayType, setDisplayType] = useState<DisplayType>("lines");
+  const handleInteract = useCallback(() => {
+    onInteract?.();
+  }, [onInteract]);
 
   const { allSeries, metricList } = useMetricTimeSeries(metrics);
+  const visibleMetricList = useMemo(() => {
+    const trimmedQuery = query.trim().toLowerCase();
+    return [...metricList]
+      .filter((metric) => {
+        if (!trimmedQuery) {
+          return true;
+        }
+        const haystack = [
+          metric.name,
+          metric.description ?? "",
+          metric.serviceName ?? "",
+          metric.type,
+          metric.unit ?? "",
+        ].join(" ").toLowerCase();
+        return haystack.includes(trimmedQuery);
+      })
+      .sort((left, right) => left.name.localeCompare(right.name));
+  }, [metricList, query]);
 
   const expandedSeries = useMemo(() => {
     if (!expandedMetric) return [];
@@ -48,20 +64,53 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
     };
   }, [selectedDetail]);
 
+  useEffect(() => {
+    if (!expandedMetric) return;
+    if (!visibleMetricList.some((metric) => metric.name === expandedMetric)) {
+      setExpandedMetric(null);
+      setSelectedSeriesKey(null);
+    }
+  }, [expandedMetric, visibleMetricList]);
+
   return (
-    <section className="tab-panel" role="tabpanel">
+    <section className="tab-panel" role="tabpanel" onPointerDownCapture={handleInteract}>
       {telemetryError ? (
         <p className="explorer__status explorer__status--error">{telemetryError}</p>
+      ) : null}
+
+      {metricList.length > 0 ? (
+        <div className="explorer__toolbar explorer__toolbar--controls">
+          <span className="explorer__count">{visibleMetricList.length} metrics</span>
+          <input
+            className="explorer__input"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search metric, description, type, unit, or service"
+          />
+        </div>
       ) : null}
 
       {metricList.length === 0 && metrics.length === 0 ? (
         <p className="metrics-explorer__empty" style={{ padding: "40px 20px" }}>
           Waiting for metrics... Send OTLP data to port 4318.
         </p>
+      ) : visibleMetricList.length === 0 ? (
+        <p className="metrics-explorer__empty" style={{ padding: "24px 20px" }}>
+          No metrics match the current filters.
+        </p>
+      ) : null}
+
+      {visibleMetricList.length > 0 ? (
+        <div className="data-table__head data-table__head--metrics metrics-card-list__head">
+          <span className="data-table__th">Metric</span>
+          <span className="data-table__th">Description</span>
+          <span className="data-table__th">Type / Unit</span>
+        </div>
       ) : null}
 
       <div className="metrics-card-list">
-        {metricList.map((m) => {
+        {visibleMetricList.map((m) => {
           const isExpanded = expandedMetric === m.name;
           const series = isExpanded ? expandedSeries : [];
           const expandedMeta = isExpanded ? m : null;
@@ -69,22 +118,26 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
           return (
             <div key={m.name} className="metric-card">
               <button
-                className={`metric-card__header ${isExpanded ? "metric-card__header--active" : ""}`}
+                className={`data-table__row data-table__row--metrics metric-card__header ${isExpanded ? "metric-card__header--active" : ""}`}
                 onClick={() => {
                   setExpandedMetric(isExpanded ? null : m.name);
                   setSelectedSeriesKey(null);
                 }}
                 type="button"
               >
-                <span className="metric-card__glyph">{TYPE_GLYPHS[m.type] ?? "\u25CF"}</span>
-                <span className="metric-card__info">
-                  <span className="metric-card__name">{m.name}</span>
-                  {m.description ? <span className="metric-card__desc">{m.description}</span> : null}
+                <span className="data-table__td data-table__td--metric-name metric-card__info">
+                  <span className="metric-card__name explorer-row__primary">{m.name}</span>
                 </span>
-                <span className={`metric-card__badge metric-type metric-type--${m.type}`}>{m.type}</span>
-                {m.unit ? <span className="metric-card__unit">{m.unit}</span> : null}
-                {m.serviceCount > 1 ? <span className="metric-card__services">{m.serviceCount} svc</span> : null}
-                <span className="metric-card__chevron">{isExpanded ? "\u25B2" : "\u25BC"}</span>
+                <span className="data-table__td data-table__td--metric-description">
+                  <span className="metric-card__description explorer-row__secondary">{m.description || "--"}</span>
+                </span>
+                <span className="data-table__td data-table__td--metric-meta">
+                  <span className="data-table__cell-content data-table__cell-content--meta metric-card__meta">
+                    <span className={`metric-card__badge metric-type metric-type--${m.type}`}>{m.type}</span>
+                    <span className="metric-card__meta-separator explorer-row__secondary">/</span>
+                    <span className="metric-card__unit explorer-row__secondary">{m.unit || "--"}</span>
+                  </span>
+                </span>
               </button>
 
               {isExpanded && expandedMeta ? (
@@ -134,12 +187,18 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
                             type="button"
                             style={{ width: "100%", border: 0, background: selectedSeriesKey === s.key ? "var(--accent-soft)" : "transparent", cursor: "pointer", textAlign: "left", font: "inherit" }}
                           >
-                            <span className="metrics-explorer__series-dot" style={{ background: COLORS[i % COLORS.length] }} />
+                            <span className="metrics-explorer__series-dot" style={{ background: TELEMETRY_SERIES_COLORS[i % TELEMETRY_SERIES_COLORS.length] }} />
                             <span className="metrics-explorer__series-attrs">
-                              {svcName ? <span>{svcName}</span> : null}
-                              {attrs.length > 0
-                                ? attrs.map(([k, v]) => <span key={k}>{k}={String(v)}</span>)
-                                : !svcName ? <span className="metrics-explorer__series-no-attrs">(no dimensions)</span> : null}
+                              {svcName ? <span className="metrics-explorer__series-service">{svcName}</span> : null}
+                              {attrs.length > 0 ? (
+                                <span className="metrics-explorer__series-dimensions">
+                                  {attrs.map(([k, v]) => (
+                                    <span key={k} className="metrics-explorer__series-attr">
+                                      {k}={String(v)}
+                                    </span>
+                                  ))}
+                                </span>
+                              ) : !svcName ? <span className="metrics-explorer__series-no-attrs">(no dimensions)</span> : null}
                             </span>
                             <span className="metrics-explorer__series-value">{formatNumber(s.latest)}</span>
                             <span className="metrics-explorer__series-points">{s.points.length} pts</span>
@@ -201,8 +260,6 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
     </section>
   );
 }
-
-const COLORS = ["#4fc1ff", "#4ec9b0", "#c586c0", "#dcdcaa", "#ce9178", "#569cd6", "#d16969"];
 
 function formatNumber(v: number): string {
   if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;

--- a/observer/client/src/metrics/TimeSeriesChart.tsx
+++ b/observer/client/src/metrics/TimeSeriesChart.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { MetricSeries } from "./useMetricTimeSeries";
+import { TELEMETRY_SERIES_COLORS } from "../palette";
 
 type DisplayType = "lines" | "bars" | "area";
 
@@ -10,7 +11,6 @@ interface TimeSeriesChartProps {
   onSelectSeries: (key: string) => void;
 }
 
-const COLORS = ["#4fc1ff", "#4ec9b0", "#c586c0", "#dcdcaa", "#ce9178", "#569cd6", "#d16969"];
 const CHART_W = 800;
 const CHART_H = 240;
 const PAD = { top: 10, right: 10, bottom: 30, left: 60 };
@@ -65,7 +65,7 @@ export function TimeSeriesChart({ series, displayType, selectedKey, onSelectSeri
 
         {/* Series */}
         {series.map((s, si) => {
-          const color = COLORS[si % COLORS.length];
+          const color = TELEMETRY_SERIES_COLORS[si % TELEMETRY_SERIES_COLORS.length];
           const opacity = selectedKey === null || selectedKey === s.key ? 1 : 0.2;
           const sorted = [...s.points]
             .map((p) => ({ x: x(new Date(p.timestamp).getTime()), y: y(p.value) }))
@@ -111,7 +111,7 @@ export function TimeSeriesChart({ series, displayType, selectedKey, onSelectSeri
       {/* Series annotations */}
       <div className="ts-chart__annotations">
         {series.map((s, si) => {
-          const color = COLORS[si % COLORS.length];
+          const color = TELEMETRY_SERIES_COLORS[si % TELEMETRY_SERIES_COLORS.length];
           const attrs = Object.entries(s.attributes);
           const svcName = s.resource?.serviceName;
           const attrStr = attrs.length > 0 ? attrs.map(([k, v]) => `${k}=${v}`).join(", ") : "";

--- a/observer/client/src/palette.ts
+++ b/observer/client/src/palette.ts
@@ -1,0 +1,12 @@
+export const TELEMETRY_SERIES_COLORS = [
+  "#4fc1ff",
+  "#4ec9b0",
+  "#c586c0",
+  "#dcdcaa",
+  "#ce9178",
+  "#569cd6",
+  "#d16969",
+  "#89d185",
+  "#b5cea8",
+  "#d7ba7d",
+];

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -20,6 +20,15 @@
   --purple: #c586c0;
   --orange: #ce9178;
   --surface-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  --font-label: 10px;
+  --font-meta: 11px;
+  --font-body: 12px;
+  --font-title-sm: 13px;
+  --font-row-primary: 12px;
+  --weight-row-primary: 400;
+  --row-primary-text: #e2e7eb;
+  --row-secondary-text: var(--text-soft);
+  --row-numeric-text: var(--text);
 }
 
 * {
@@ -27,28 +36,35 @@
 }
 
 html {
+  height: 100%;
+  overflow: hidden;
   background: #111111;
 }
 
 body {
   margin: 0;
-  min-height: 100vh;
+  height: 100%;
+  overflow: hidden;
   background:
     radial-gradient(circle at top left, rgba(0, 122, 204, 0.14), transparent 32%),
     linear-gradient(180deg, #141414 0%, #101010 100%);
 }
 
 #root {
-  min-height: 100vh;
+  height: 100%;
+  overflow: hidden;
 }
 
 .app-shell {
-  min-height: 100vh;
-  padding: 24px;
+  height: 100vh;
+  min-height: 0;
+  overflow: hidden;
+  padding: 16px;
 }
 
 .app-frame {
-  min-height: calc(100vh - 48px);
+  height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -63,7 +79,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 16px 18px;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--border);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent),
@@ -73,20 +89,20 @@ body {
 .title-bar__brand {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
 }
 
 .title-bar__dot {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 999px;
   background: var(--accent);
-  box-shadow: 0 0 0 6px rgba(0, 122, 204, 0.16);
+  box-shadow: 0 0 0 5px rgba(0, 122, 204, 0.16);
 }
 
 .title-bar__eyebrow {
   margin: 0 0 3px;
-  font-size: 11px;
+  font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--text-dim);
@@ -94,7 +110,7 @@ body {
 
 .title-bar__title {
   margin: 0;
-  font-size: clamp(1.25rem, 2vw, 1.6rem);
+  font-size: clamp(1.05rem, 1.45vw, 1.25rem);
   font-weight: 600;
   line-height: 1.2;
 }
@@ -117,15 +133,14 @@ body {
 .tab-button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  min-height: 40px;
+  min-height: 36px;
   border: 0;
   border-bottom: 2px solid transparent;
   background: transparent;
   color: var(--text-dim);
   padding: 0 14px;
   font: inherit;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   cursor: pointer;
   transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
@@ -140,19 +155,6 @@ body {
   background: rgba(255, 255, 255, 0.03);
 }
 
-.tab-button__glyph {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text-soft);
-  font-size: 10px;
-  font-weight: 700;
-}
-
 .tab-panel {
   display: flex;
   flex: 1;
@@ -163,8 +165,8 @@ body {
 }
 
 .status {
-  margin: 18px;
-  padding: 14px 16px;
+  margin: 12px;
+  padding: 11px 13px;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--chrome);
@@ -178,11 +180,11 @@ body {
 }
 
 .pill {
-  padding: 5px 10px;
+  padding: 4px 9px;
   border: 1px solid var(--border);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.04);
-  font-size: 12px;
+  font-size: var(--font-meta);
   color: var(--text);
 }
 
@@ -967,11 +969,13 @@ code {
 
 @media (max-width: 720px) {
   .app-shell {
+    height: 100vh;
     padding: 0;
   }
 
   .app-frame {
-    min-height: 100vh;
+    height: 100%;
+    min-height: 0;
     border-radius: 0;
     border-left: 0;
     border-right: 0;
@@ -2136,15 +2140,58 @@ code {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 6px 14px;
+  gap: 10px;
+  padding: 7px 12px;
   border-bottom: 1px solid var(--border);
   background: var(--chrome);
-  font-size: 12px;
+  font-size: 11px;
+  flex-wrap: wrap;
+}
+
+.tab-panel > .explorer__toolbar,
+.signal-view__content > .explorer__toolbar {
+  width: 100%;
 }
 
 .explorer__count {
   color: var(--text-soft);
+  white-space: nowrap;
+}
+
+.explorer__toolbar--controls {
+  justify-content: flex-start;
+}
+
+.explorer__input,
+.explorer__select {
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--chrome-2);
+  color: var(--text);
+  font: inherit;
+  font-size: 11px;
+}
+
+.explorer__input {
+  min-width: min(360px, 100%);
+  flex: 1 1 240px;
+  padding: 0 10px;
+}
+
+.explorer__select {
+  min-width: 112px;
+  padding: 0 8px;
+}
+
+.explorer__input:focus,
+.explorer__select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.explorer__input::placeholder {
+  color: var(--text-dim);
 }
 
 .explorer__live {
@@ -2349,6 +2396,7 @@ code {
    ====================================== */
 
 .detail-panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -2365,13 +2413,23 @@ code {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
 }
 
+.detail-panel__header--close-only {
+  align-items: center;
+  justify-content: flex-end;
+  min-height: 36px;
+  padding: 8px 8px 0;
+  gap: 0;
+  border-bottom: none;
+  background: transparent;
+}
+
 .detail-panel__titles {
   min-width: 0;
 }
 
 .detail-panel__title {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--font-title-sm);
   font-weight: 600;
   color: #fff;
   word-break: break-all;
@@ -2380,7 +2438,7 @@ code {
 .detail-panel__subtitle {
   display: block;
   margin-top: 3px;
-  font-size: 12px;
+  font-size: var(--font-meta);
   color: var(--text-soft);
 }
 
@@ -2410,17 +2468,21 @@ code {
   padding: 0;
 }
 
+.detail-panel__body--close-only {
+  padding: 0;
+}
+
 /* ======================================
    Data Table (shared: traces, logs, metrics)
    ====================================== */
 
 .data-table__head {
   display: grid;
-  grid-template-columns: 32px 100px 120px minmax(0, 1fr) 80px 60px;
+  grid-template-columns: var(--table-columns, 32px 100px 120px minmax(0, 1fr) 80px 60px);
   align-items: center;
   gap: 0;
   padding: 0 14px;
-  min-height: 32px;
+  min-height: 30px;
   border-bottom: 1px solid var(--border);
   background: var(--chrome);
   position: sticky;
@@ -2428,21 +2490,29 @@ code {
   z-index: 2;
 }
 
-.data-table__head--logs {
-  grid-template-columns: 80px 120px 120px minmax(0, 1fr);
+.data-table__head--left-cluster {
+  width: 100%;
 }
 
-.data-table__head--metrics {
-  grid-template-columns: 90px minmax(0, 1fr) 120px 100px 60px;
+.data-table__head--left-cluster-logs {
+  width: 100%;
 }
 
 .data-table__th {
-  font-size: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  font-size: var(--font-label);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-dim);
   padding: 0 6px;
+  width: 100%;
+  box-sizing: border-box;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -2454,17 +2524,17 @@ code {
 
 .data-table__row {
   display: grid;
-  grid-template-columns: 32px 100px 120px minmax(0, 1fr) 80px 60px;
+  grid-template-columns: var(--table-columns, 32px 100px 120px minmax(0, 1fr) 80px 60px);
   align-items: center;
   gap: 0;
   padding: 0 14px;
-  min-height: 36px;
+  min-height: 34px;
   border: 0;
   border-bottom: 1px solid var(--border-soft);
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-meta);
   text-align: left;
   cursor: pointer;
   width: 100%;
@@ -2479,20 +2549,88 @@ code {
   background: var(--accent-soft);
 }
 
+.data-table__head--logs,
 .data-table__row--logs {
-  grid-template-columns: 80px 120px 120px minmax(0, 1fr);
+  --table-columns: 64px 156px 140px minmax(0, 1fr);
 }
 
+.data-table__head--traces,
+.data-table__row--traces {
+  --table-columns: 220px 240px 140px 96px 88px 56px 1fr;
+}
+
+.data-table__row--traces {
+  align-items: center;
+  min-height: 34px;
+}
+
+.data-table__body-inner--traces {
+  width: 100%;
+}
+
+.data-table__body-inner--logs {
+  width: 100%;
+}
+
+.data-table__head--metrics,
 .data-table__row--metrics {
-  grid-template-columns: 90px minmax(0, 1fr) 120px 100px 60px;
+  --table-columns: 220px 220px 140px 1fr;
 }
 
 .data-table__td {
-  padding: 4px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 3px 6px;
+  width: 100%;
+  box-sizing: border-box;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.data-table__cell-content {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  min-width: 0;
+}
+
+.data-table__cell-content--meta {
+  gap: 8px;
+}
+
+.data-table__th--numeric,
+.data-table__td--numeric {
+  justify-self: stretch;
+  text-align: right;
+  justify-content: flex-end;
+}
+
+.explorer-row__primary {
+  font-family: inherit;
+  font-size: var(--font-row-primary);
+  font-weight: var(--weight-row-primary);
+  color: var(--row-primary-text);
+  line-height: 1.2;
+}
+
+.explorer-row__secondary {
+  font-family: inherit;
+  font-size: var(--font-meta);
+  font-weight: 400;
+  color: var(--row-secondary-text);
+  line-height: 1.2;
+}
+
+.explorer-row__numeric {
+  font-family: inherit;
+  font-size: var(--font-meta);
+  font-weight: 400;
+  color: var(--row-numeric-text);
+  font-variant-numeric: tabular-nums;
 }
 
 /* Trace table columns */
@@ -2500,7 +2638,7 @@ code {
 .data-table__td--status {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .data-table__td--id {
@@ -2510,80 +2648,111 @@ code {
 }
 
 .data-table__td--service {
-  color: var(--text-soft);
+  min-width: 0;
 }
 
 .data-table__td--operation {
-  color: #fff;
-  font-weight: 500;
+  min-width: 0;
+}
+
+.data-table__td--trace-id {
+  min-width: 0;
+}
+
+.trace-row__operation {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trace-row__service {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trace-row__trace-id {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trace-row__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.data-table__row--traces .data-table__td {
+  padding-top: 3px;
+  padding-bottom: 3px;
 }
 
 .data-table__td--duration {
-  font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 11px;
-  color: var(--text);
+  justify-content: flex-end;
   text-align: right;
 }
 
 .data-table__td--spans {
-  text-align: center;
-  color: var(--text-dim);
-}
-
-/* Status dots */
-
-.status-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--text-dim);
-}
-
-.status-dot--ok {
-  background: var(--green);
-}
-
-.status-dot--error {
-  background: #f48771;
-}
-
-.status-dot--unset {
-  background: var(--yellow);
-}
-
-.status-dot--mixed {
-  background: var(--yellow);
+  justify-content: flex-end;
+  text-align: right;
 }
 
 /* Log table columns */
 
 .data-table__td--severity {
-  font-size: 11px;
+  font-size: var(--font-meta);
   font-weight: 600;
   text-transform: uppercase;
 }
 
 .data-table__td--timestamp {
-  font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 11px;
-  color: var(--text-dim);
 }
 
-.data-table__td--message {
-  color: var(--text);
+.data-table__td--metric-type {
+  display: flex;
+  align-items: center;
+}
+
+.data-table__td--metric-meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-width: 0;
+}
+
+.data-table__td--message-with-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.data-table__td--message-with-badge > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Severity badges */
 
 .sev-badge {
   display: inline-block;
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: 10px;
+  min-width: 54px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: var(--font-label);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  text-align: center;
 }
 
 .sev-badge--error {
@@ -2613,16 +2782,10 @@ code {
 
 /* Severity row coloring */
 
-.data-table__row--sev-error {
-  border-left: 3px solid #f48771;
-}
-
-.data-table__row--sev-warn {
-  border-left: 3px solid var(--yellow);
-}
-
+.data-table__row--sev-error,
+.data-table__row--sev-warn,
 .data-table__row--sev-info {
-  border-left: 3px solid var(--green);
+  border-left: 0;
 }
 
 /* Metric table columns */
@@ -2639,13 +2802,16 @@ code {
 }
 
 .data-table__td--metric-name {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding: 6px 6px;
+  padding: 3px 6px;
+}
+
+.data-table__td--metric-description {
+  min-width: 0;
 }
 
 .metric-name {
+  display: inline-block;
+  max-width: 100%;
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
   font-size: 12px;
   font-weight: 500;
@@ -2656,6 +2822,8 @@ code {
 }
 
 .metric-desc {
+  display: inline-block;
+  max-width: 100%;
   font-size: 11px;
   color: var(--text-dim);
   overflow: hidden;
@@ -2689,7 +2857,7 @@ code {
 
 .log-detail__heading {
   margin: 0 0 8px;
-  font-size: 11px;
+  font-size: var(--font-label);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -2699,7 +2867,7 @@ code {
 .log-detail__body {
   margin: 0;
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 12px;
+  font-size: var(--font-meta);
   color: var(--text);
   white-space: pre-wrap;
   word-break: break-all;
@@ -2709,7 +2877,7 @@ code {
 .log-detail__attrs {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--font-meta);
 }
 
 .log-detail__attrs td {
@@ -2719,7 +2887,7 @@ code {
 
 .log-detail__attr-key {
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 11px;
+  font-size: var(--font-meta);
   color: #9cdcfe;
   padding-right: 12px;
   white-space: nowrap;
@@ -2727,14 +2895,14 @@ code {
 
 .log-detail__attr-val {
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 11px;
+  font-size: var(--font-meta);
   color: var(--orange);
   word-break: break-all;
 }
 
 .log-detail__empty {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--font-meta);
   color: var(--text-dim);
 }
 
@@ -2825,12 +2993,25 @@ code {
 }
 
 @media (max-width: 900px) {
+  .signal-view--with-panel {
+    flex-direction: column;
+  }
+
+  .signal-view--with-panel .signal-view__content {
+    min-width: 0;
+    min-height: 0;
+    flex: 1 1 auto;
+  }
+
   .signal-view__panel {
-    position: fixed;
-    inset: 0;
+    position: static;
+    inset: auto;
     width: auto;
-    z-index: 50;
+    height: clamp(240px, 42vh, 420px);
+    flex: 0 0 clamp(240px, 42vh, 420px);
+    z-index: auto;
     border-left: 0;
+    border-top: 1px solid var(--border);
   }
 
   .explorer {
@@ -2854,27 +3035,39 @@ code {
 
   .data-table__head,
   .data-table__row {
-    grid-template-columns: 32px minmax(0, 1fr) 80px;
+    --table-columns: 32px minmax(0, 1fr) 80px;
+  }
+
+  .data-table__head--traces,
+  .data-table__row--traces {
+    --table-columns: 220px 240px 88px 1fr;
   }
 
   .data-table__head--logs,
   .data-table__row--logs {
-    grid-template-columns: 70px minmax(0, 1fr);
+    --table-columns: 70px minmax(0, 1fr);
   }
 
   .data-table__head--metrics,
   .data-table__row--metrics {
-    grid-template-columns: 70px minmax(0, 1fr) 80px;
+    --table-columns: 220px 100px 1fr;
   }
 
   .data-table__td--service,
+  .data-table__td--trace-id,
   .data-table__td--spans,
   .data-table__td--timestamp,
   .data-table__td--metric-points,
   .data-table__th--service,
+  .data-table__th--trace-id,
   .data-table__th--spans,
   .data-table__th--timestamp,
   .data-table__th--metric-points {
+    display: none;
+  }
+
+  .data-table__head--traces .data-table__th--service,
+  .data-table__row--traces .data-table__td--service {
     display: none;
   }
 }
@@ -3212,9 +3405,9 @@ code {
 }
 
 .metrics-explorer__detail-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
+  font-size: var(--font-meta);
+  font-weight: 500;
+  color: var(--text-soft);
 }
 
 .metrics-explorer__detail-body {
@@ -3226,9 +3419,10 @@ code {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 14px;
+  padding: 7px 14px;
   border-bottom: 1px solid var(--border-soft);
-  font-size: 11px;
+  font-size: var(--font-meta);
+  line-height: 1.35;
 }
 
 .metrics-explorer__series-dot {
@@ -3241,9 +3435,33 @@ code {
 .metrics-explorer__series-attrs {
   flex: 1;
   display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  min-width: 0;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.metrics-explorer__series-service {
+  color: var(--text);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.metrics-explorer__series-dimensions {
+  display: flex;
   flex-wrap: wrap;
   gap: 4px 8px;
   min-width: 0;
+  color: var(--text-soft);
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+.metrics-explorer__series-attr {
+  color: inherit;
 }
 
 .metrics-explorer__series-no-attrs {
@@ -3253,14 +3471,16 @@ code {
 
 .metrics-explorer__series-value {
   flex-shrink: 0;
-  font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 11px;
-  color: #fff;
+  font-size: var(--font-meta);
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  color: var(--text);
 }
 
 .metrics-explorer__series-points {
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: var(--font-label);
   color: var(--text-dim);
 }
 
@@ -3436,7 +3656,7 @@ code {
 
 .series-detail__title {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--font-meta);
   font-weight: 600;
   color: var(--text);
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
@@ -3483,7 +3703,7 @@ code {
 }
 
 .stat-card__label {
-  font-size: 9px;
+  font-size: var(--font-label);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -3492,7 +3712,7 @@ code {
 }
 
 .stat-card__value {
-  font-size: 13px;
+  font-size: var(--font-body);
   font-weight: 700;
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
   color: #fff;
@@ -3510,7 +3730,7 @@ code {
   display: inline-block;
   padding: 2px 8px;
   border-radius: 3px;
-  font-size: 10px;
+  font-size: var(--font-label);
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
   background: rgba(255, 255, 255, 0.06);
   color: var(--text-dim);
@@ -3528,7 +3748,7 @@ code {
   display: inline-block;
   padding: 3px 8px;
   border-radius: 3px;
-  font-size: 11px;
+  font-size: var(--font-meta);
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
   background: rgba(79, 193, 255, 0.08);
   color: var(--accent);
@@ -3548,7 +3768,7 @@ code {
 .series-detail__desc {
   margin: 0;
   padding: 6px 14px 0;
-  font-size: 11px;
+  font-size: var(--font-meta);
   color: var(--text-dim);
   line-height: 1.4;
   font-style: italic;
@@ -3565,7 +3785,7 @@ code {
 }
 
 .series-detail__section-title {
-  font-size: 9px;
+  font-size: var(--font-label);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -3604,7 +3824,7 @@ code {
 .kv-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 11px;
+  font-size: var(--font-meta);
 }
 
 .kv-table__row {
@@ -3619,7 +3839,7 @@ code {
   padding: 3px 12px 3px 0;
   white-space: nowrap;
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 11px;
+  font-size: var(--font-meta);
   color: #9cdcfe;
   vertical-align: top;
   width: 1%;
@@ -3628,7 +3848,7 @@ code {
 .kv-table__val {
   padding: 3px 0;
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 11px;
+  font-size: var(--font-meta);
   color: var(--orange);
   word-break: break-word;
   max-width: 0;
@@ -3641,33 +3861,39 @@ code {
 .metrics-card-list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 8px 0;
+  gap: 0;
+  padding: 0;
   overflow-y: auto;
   flex: 1;
+  min-height: 0;
+  width: 100%;
+  overscroll-behavior: contain;
+}
+
+.metrics-card-list__head {
+  width: 100%;
+  position: static;
+  min-height: 24px;
+  margin-top: 6px;
+  padding: 0 14px;
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  background: transparent;
 }
 
 .metric-card {
-  border: 1px solid var(--border-soft);
-  border-radius: 6px;
-  overflow: hidden;
-  margin: 0 8px;
+  border: 0;
+  overflow: visible;
+  margin: 0;
 }
 
 .metric-card__header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   width: 100%;
-  padding: 10px 14px;
-  border: 0;
-  background: var(--chrome);
-  color: var(--text);
-  font: inherit;
-  font-size: 12px;
-  text-align: left;
-  cursor: pointer;
-  transition: background 60ms ease;
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  border-bottom: 1px solid var(--border-soft);
+  background: transparent;
 }
 
 .metric-card__header:hover {
@@ -3675,38 +3901,34 @@ code {
 }
 
 .metric-card__header--active {
-  background: var(--accent-soft);
+  background: rgba(255, 255, 255, 0.03);
   border-bottom: 1px solid var(--border-soft);
 }
 
-.metric-card__glyph {
-  flex-shrink: 0;
-  width: 18px;
-  text-align: center;
-  font-size: 14px;
-}
-
 .metric-card__info {
-  flex: 1;
+  max-width: 42rem;
   min-width: 0;
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+}
+
+.metric-card__meta {
+  justify-self: start;
+  flex-wrap: nowrap;
 }
 
 .metric-card__name {
-  font-family: "Cascadia Code", "SFMono-Regular", monospace;
-  font-size: 12px;
-  font-weight: 500;
-  color: #e2e7eb;
+  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  letter-spacing: 0;
 }
 
-.metric-card__desc {
-  font-size: 10px;
-  color: var(--text-dim);
+.metric-card__description {
+  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3715,36 +3937,43 @@ code {
 .metric-card__badge {
   flex-shrink: 0;
   padding: 1px 6px;
-  border-radius: 8px;
+  border-radius: 999px;
   background: rgba(255, 255, 255, 0.06);
-  font-size: 10px;
-  color: var(--text-dim);
+  font-size: var(--font-meta);
+  color: var(--row-secondary-text);
 }
 
 .metric-card__unit {
-  font-size: 10px;
-  color: var(--text-soft);
+  font-size: var(--font-meta);
+  color: var(--row-secondary-text);
+  flex-shrink: 0;
 }
 
 .metric-card__services {
-  font-size: 10px;
-  color: var(--text-dim);
-}
-
-.metric-card__chevron {
+  font-size: var(--font-meta);
+  color: var(--row-secondary-text);
   flex-shrink: 0;
-  font-size: 10px;
-  color: var(--text-dim);
 }
 
 .metric-card__body {
-  padding: 8px 14px 14px;
+  padding: 8px 12px 12px;
   background: var(--panel);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  overflow: visible;
 }
 
 /* Responsive */
 
 @media (max-width: 900px) {
+  .metrics-card-list__head,
+  .metric-card__header {
+    --table-columns: minmax(0, 1fr) minmax(0, 1fr) fit-content(10rem);
+  }
+
+  .metric-card__info {
+    max-width: 100%;
+  }
+
   .series-detail__stats {
     flex-wrap: wrap;
   }
@@ -3891,4 +4120,787 @@ code {
 
 .mono {
   font-family: "Cascadia Code", "SFMono-Regular", monospace;
+}
+
+.validation-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.validation-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.validation-badge--violation {
+  background: rgba(244, 135, 113, 0.18);
+  color: #f48771;
+}
+
+.validation-badge--improvement {
+  background: rgba(220, 220, 170, 0.16);
+  color: var(--yellow);
+}
+
+.validation-badge--information {
+  background: rgba(79, 193, 255, 0.16);
+  color: var(--blue);
+}
+
+.validation-inline-list,
+.span-details__validation {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.validation-inline {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 8px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 12px;
+}
+
+.validation-inline--violation {
+  border-color: rgba(244, 135, 113, 0.32);
+}
+
+.validation-inline--improvement {
+  border-color: rgba(220, 220, 170, 0.28);
+}
+
+.validation-inline--information {
+  border-color: rgba(79, 193, 255, 0.28);
+}
+
+.validation-inline__rule {
+  flex-shrink: 0;
+  font-family: "Cascadia Code", "SFMono-Regular", monospace;
+  color: var(--text-soft);
+}
+
+.validation-panel__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(3px);
+}
+
+.validation-panel {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  bottom: 24px;
+  width: min(560px, calc(100vw - 48px));
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--app-bg);
+  box-shadow: var(--surface-shadow);
+  overflow: hidden;
+}
+
+.validation-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--chrome);
+}
+
+.validation-panel__eyebrow {
+  margin: 0 0 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+
+.validation-panel__title {
+  margin: 0;
+  font-size: 20px;
+}
+
+.validation-panel__subtitle {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--text-soft);
+}
+
+.validation-panel__close {
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.validation-panel__filters {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.validation-panel__input,
+.validation-panel__select {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--chrome);
+  color: var(--text);
+  padding: 9px 10px;
+  font: inherit;
+  font-size: 12px;
+}
+
+.validation-panel__input--wide {
+  grid-column: 1 / -1;
+}
+
+.validation-panel__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0 18px 14px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.validation-panel__body {
+  flex: 1;
+  overflow: auto;
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.validation-item {
+  border: 0;
+  border-top: 1px solid var(--border-soft);
+  border-radius: 0;
+  padding: 8px 0 0;
+  background: transparent;
+}
+
+.validation-item--violation {
+  border-top-color: rgba(244, 135, 113, 0.18);
+}
+
+.validation-item--improvement {
+  border-top-color: rgba(220, 220, 170, 0.18);
+}
+
+.validation-item--information {
+  border-top-color: rgba(79, 193, 255, 0.18);
+}
+
+.validation-item__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.validation-item__severity,
+.validation-item__rule,
+.validation-item__signal {
+  font-size: var(--font-label);
+  line-height: 1;
+}
+
+.validation-item__severity {
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.validation-item__severity--violation {
+  color: #f48771;
+}
+
+.validation-item__severity--improvement {
+  color: var(--yellow);
+}
+
+.validation-item__severity--information {
+  color: var(--blue);
+}
+
+.validation-item__rule {
+  font-family: "Cascadia Code", "SFMono-Regular", monospace;
+  color: var(--text-soft);
+}
+
+.validation-item__signal {
+  color: var(--text-dim);
+}
+
+.validation-item__message {
+  margin: 8px 0 0;
+  font-size: var(--font-meta);
+  line-height: 1.4;
+  color: var(--text);
+}
+
+.validation-item__meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.findings-tab__open-panel {
+  cursor: pointer;
+}
+
+.findings-tab__filters {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 8px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.015);
+  width: 100%;
+}
+
+.findings-tab__header .panel-toolbar__meta {
+  justify-content: flex-end;
+}
+
+.findings-tab__header {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  width: 100%;
+}
+
+.findings-tab__header-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.findings-tab__header-count {
+  color: #ffffff;
+  font-size: var(--font-row-primary);
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.findings-tab__header-separator {
+  color: var(--text-dim);
+  font-size: var(--font-meta);
+  line-height: 1;
+}
+
+.findings-tab__header-timestamp {
+  color: var(--text-dim);
+  font-size: var(--font-meta);
+  line-height: 1.2;
+}
+
+.findings-tab__summary-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.findings-tab__content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.findings-tab__content > .status,
+.findings-tab__content > .explorer__status {
+  width: 100%;
+}
+
+.findings-tab__list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0;
+  min-height: 0;
+  overflow: auto;
+  width: 100%;
+}
+
+.findings-tab__layout {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.findings-tab__layout--with-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 420px;
+  flex: 1;
+  gap: 0;
+  align-items: stretch;
+  min-height: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.findings-tab__master {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.findings-tab__master--metric,
+.findings-tab__master--span,
+.findings-tab__master--resource {
+  --findings-tab-grid: 220px 140px 88px 88px 88px 1fr;
+}
+
+.findings-tab__master--log {
+  --findings-tab-grid: 220px 140px 88px 88px 88px 1fr;
+}
+
+.findings-tab__detail-panel {
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  min-width: 0;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--border);
+  background: var(--app-bg);
+}
+
+.findings-tab__detail-body {
+  padding: 8px 14px 14px;
+}
+
+.findings-tab__detail-heading {
+  margin: 0;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.findings-tab__detail-note {
+  margin: 8px 0 0;
+  color: var(--text-dim);
+  font-size: var(--font-meta);
+  line-height: 1.35;
+}
+
+.findings-tab__variant-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.findings-tab__context {
+  margin-top: 14px;
+}
+
+.findings-tab__context--first {
+  margin-top: 0;
+}
+
+.findings-tab__eyebrow {
+  margin: 0 0 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+
+.findings-tab__summary-card {
+  padding: 7px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.findings-tab__summary-card span {
+  display: block;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.findings-tab__summary-card strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 14px;
+  color: #ffffff;
+}
+
+.findings-tab__item {
+  width: 100%;
+  text-align: left;
+}
+
+.findings-tab__item-trigger {
+  width: 100%;
+  border: 0;
+  padding: 0 14px;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.findings-tab__item-grid {
+  display: grid;
+  grid-template-columns: var(--findings-tab-grid);
+  gap: 0;
+  align-items: center;
+  min-height: 34px;
+}
+
+.findings-tab__item-title {
+  display: flex;
+  align-items: center;
+  margin: 0;
+  padding: 3px 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.findings-tab__item-rule {
+  display: flex;
+  align-items: center;
+  padding: 3px 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.findings-tab__item-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.findings-tab__item-pill {
+  padding: 2px 6px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-dim);
+  font-size: var(--font-label);
+  line-height: 1;
+}
+
+.findings-tab__item-pill--mono {
+  font-family: "Cascadia Code", "SFMono-Regular", monospace;
+}
+
+.findings-tab__item-pill--severity {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.findings-tab__item-pill--severity-violation {
+  border-color: rgba(244, 135, 113, 0.28);
+  color: #f8a998;
+}
+
+.findings-tab__item-pill--severity-improvement {
+  border-color: rgba(220, 220, 170, 0.24);
+  color: #dcdca9;
+}
+
+.findings-tab__item-pill--severity-information {
+  border-color: rgba(79, 193, 255, 0.24);
+  color: #84d4ff;
+}
+
+.findings-tab__item,
+.findings-tab__action {
+  font: inherit;
+}
+
+.findings-tab__item {
+  border: 0;
+  border-top: 1px solid var(--border-soft);
+  padding: 0;
+}
+
+.findings-tab__item.is-selected {
+  box-shadow: none;
+  background: var(--accent-soft);
+}
+
+.findings-tab__item-detail {
+  padding: 0 12px 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.findings-tab__head {
+  width: 100%;
+  grid-template-columns: var(--findings-tab-grid);
+  position: static;
+  min-height: 24px;
+  margin-top: 6px;
+  padding: 0 14px;
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  background: transparent;
+}
+
+.findings-tab__head .data-table__th {
+  padding: 0 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.findings-tab__th-count {
+  justify-self: stretch;
+  text-align: right;
+}
+
+.findings-tab__item-count {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  padding: 3px 6px;
+  text-align: right;
+  box-sizing: border-box;
+}
+
+.findings-tab__item-count {
+  justify-self: end;
+  font-variant-numeric: tabular-nums;
+}
+
+.findings-tab__item-count.is-zero {
+  color: var(--text-dim);
+}
+
+.findings-tab__sample-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.findings-tab__sample-item {
+  padding: 6px 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-soft);
+  font-size: var(--font-meta);
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.findings-tab__empty {
+  margin: auto;
+  max-width: 420px;
+  text-align: center;
+  padding: 18px;
+}
+
+.findings-tab__empty--detail {
+  margin: 0;
+  padding: 32px 8px;
+  text-align: left;
+}
+
+.findings-tab__empty-title {
+  margin: 0;
+  font-size: var(--font-title-sm);
+  color: #ffffff;
+}
+
+.findings-tab__detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.findings-tab__action {
+  padding: 6px 9px;
+  border: 1px solid rgba(0, 122, 204, 0.35);
+  border-radius: 8px;
+  background: rgba(0, 122, 204, 0.12);
+  color: var(--blue);
+  cursor: pointer;
+  font-size: var(--font-meta);
+}
+
+.findings-tab__action--secondary {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.findings-tab__signal-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.findings-tab__signal-tab {
+  padding: 6px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-dim);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-meta);
+  white-space: nowrap;
+}
+
+.findings-tab__signal-tab[data-has-issues="false"] {
+  opacity: 0.68;
+}
+
+.findings-tab__signal-tab.is-active {
+  border-color: rgba(0, 122, 204, 0.3);
+  background: rgba(0, 122, 204, 0.12);
+  color: var(--text);
+}
+
+.findings-tab__detail-grid {
+  margin: 10px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.findings-tab__detail-row {
+  display: grid;
+  grid-template-columns: 108px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.findings-tab__detail-row dt {
+  font-size: var(--font-label);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.findings-tab__detail-row dd {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--font-meta);
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.findings-tab__rule-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.findings-tab__rule-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-dim);
+  font-family: "Cascadia Code", "SFMono-Regular", monospace;
+  font-size: var(--font-label);
+  line-height: 1;
+}
+
+@media (max-width: 900px) {
+  .findings-tab__layout--with-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .findings-tab__detail-panel {
+    position: static;
+  }
+
+  .findings-tab__filters {
+    grid-template-columns: 1fr;
+  }
+
+  .findings-tab__summary-strip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .validation-panel {
+    top: 12px;
+    right: 12px;
+    left: 12px;
+    bottom: 12px;
+    width: auto;
+  }
+
+  .validation-panel__filters {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .findings-tab__head,
+  .findings-tab__item-grid {
+    grid-template-columns: minmax(0, 1.35fr) minmax(92px, 0.8fr) 52px 64px 64px 1fr;
+    gap: 8px;
+  }
+
+  .findings-tab__filters {
+    grid-template-columns: 1fr;
+  }
+
+  .findings-tab__summary-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }

--- a/observer/client/src/traces/TraceWaterfall.tsx
+++ b/observer/client/src/traces/TraceWaterfall.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from "react";
 import type { Span } from "../api/types";
 import { buildWaterfallTree, flattenTree, type WaterfallSpan } from "./waterfall-layout";
+import { TELEMETRY_SERIES_COLORS } from "../palette";
 
 interface TraceWaterfallProps {
   spans: Span[];
@@ -10,18 +11,13 @@ interface TraceWaterfallProps {
 }
 
 // Consistent service colors — same service always gets same color
-const SERVICE_COLORS = [
-  "#4fc1ff", "#4ec9b0", "#c586c0", "#dcdcaa", "#ce9178",
-  "#569cd6", "#d16969", "#89d185", "#b5cea8", "#d7ba7d",
-];
-
 function getServiceColorMap(spans: Span[]): Map<string, string> {
   const map = new Map<string, string>();
   let idx = 0;
   for (const s of spans) {
     const svc = s.resource?.serviceName ?? "unknown";
     if (!map.has(svc)) {
-      map.set(svc, SERVICE_COLORS[idx % SERVICE_COLORS.length]);
+      map.set(svc, TELEMETRY_SERIES_COLORS[idx % TELEMETRY_SERIES_COLORS.length]);
       idx++;
     }
   }
@@ -89,9 +85,8 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
           const widthPct = traceDurationMs > 0 ? Math.max((s.durationMs / traceDurationMs) * 100, 0.5) : 100;
           const isError = s.status.code === "ERROR";
           const hasChildren = s.children.length > 0;
-          const svcColor = serviceColors.get(s.resource?.serviceName ?? "unknown") ?? SERVICE_COLORS[0];
+          const svcColor = serviceColors.get(s.resource?.serviceName ?? "unknown") ?? TELEMETRY_SERIES_COLORS[0];
           const childCount = countDescendants(s);
-
           return (
             <div
               key={s.spanId}

--- a/observer/client/src/traces/TracesTab.style.test.tsx
+++ b/observer/client/src/traces/TracesTab.style.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TracesTab, traceStatusLabel } from "./TracesTab";
+import { SpanDetailsPanel } from "./SpanDetailsPanel";
+
+declare const require: (id: string) => any;
+declare const process: { cwd(): string };
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 36,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 36,
+        end: (index + 1) * 36,
+        size: 36,
+      })),
+    measureElement: () => undefined,
+  }),
+}));
+
+afterEach(() => cleanup());
+
+describe("TracesTab row layout", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 1200,
+    });
+    HTMLElement.prototype.getBoundingClientRect = () =>
+      ({
+        width: 1200,
+        height: 400,
+        top: 0,
+        left: 0,
+        right: 1200,
+        bottom: 400,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+  });
+
+  it("renders trace id as a dedicated table column", () => {
+    const { container } = render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1234567890ab", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "error" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("1 traces")).toBeTruthy();
+    expect(screen.getByText("Trace ID")).toBeTruthy();
+    expect(screen.getByText("Service")).toBeTruthy();
+    expect(screen.getByText("Status")).toBeTruthy();
+    expect(screen.getByText("Duration")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Search operation, trace ID, service, or status")).toBeTruthy();
+    expect(container.querySelector(".status-dot")).toBeNull();
+    expect(container.querySelector(".data-table__head--left-cluster")).toBeTruthy();
+    expect(container.querySelector(".data-table__body-inner--traces")).toBeTruthy();
+    expect(container.querySelector(".trace-row__stack")).toBeNull();
+    expect(container.querySelector(".trace-row__operation")?.classList.contains("explorer-row__primary")).toBe(true);
+    expect(container.querySelector(".data-table__td--trace-id .trace-row__trace-id")?.classList.contains("explorer-row__secondary")).toBe(true);
+    expect(container.querySelector(".trace-row__trace-id")?.classList.contains("mono")).toBe(false);
+    expect(container.querySelector(".trace-row__trace-id")?.textContent).toBe("trace-1234567890ab");
+    expect(container.querySelector(".trace-row__service")?.classList.contains("explorer-row__secondary")).toBe(true);
+    expect(container.querySelector(".data-table__td--service")?.textContent).toBe("checkout");
+    expect(container.querySelector(".data-table__td--status")?.textContent).toContain("error");
+    expect(container.querySelector(".data-table__td--duration .explorer-row__numeric")).toBeTruthy();
+  });
+
+  it("filters traces by the dedicated status and trace id columns", () => {
+    const view = render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-error-123", rootSpanName: "POST /payments", serviceName: "api-gateway", spanCount: 2, durationMs: 42, status: "error" },
+          { traceId: "trace-ok-456", rootSpanName: "GET /health", serviceName: "api-gateway", spanCount: 1, durationMs: 5, status: "ok" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    const input = view.getByPlaceholderText("Search operation, trace ID, service, or status");
+    expect(view.getByText("2 traces")).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: "error" } });
+    expect(view.getByText("1 traces")).toBeTruthy();
+    expect(view.getByText("POST /payments")).toBeTruthy();
+    expect(view.queryByText("GET /health")).toBeNull();
+
+    fireEvent.change(input, { target: { value: "trace-ok-456" } });
+    expect(view.getByText("1 traces")).toBeTruthy();
+    expect(view.getByText("GET /health")).toBeTruthy();
+    expect(view.queryByText("POST /payments")).toBeNull();
+  });
+
+  it("shows explicit labels for all trace statuses", () => {
+    expect(traceStatusLabel("ok")).toBe("ok");
+    expect(traceStatusLabel("error")).toBe("error");
+    expect(traceStatusLabel("mixed")).toBe("mixed");
+    expect(traceStatusLabel("unset")).toBe("unset");
+    expect(traceStatusLabel("weird")).toBe("unknown");
+  });
+
+  it("renders span detail info without validation overlays", () => {
+    render(
+      <SpanDetailsPanel
+        span={{
+          traceId: "trace-1",
+          spanId: "span-1",
+          parentSpanId: "",
+          name: "GET /orders",
+          kind: "SERVER",
+          startTimeUnixNano: "2026-04-11T12:00:00Z",
+          endTimeUnixNano: "2026-04-11T12:00:01Z",
+          durationMs: 1,
+          status: { code: "ERROR", message: "" },
+          attributes: {},
+          events: [],
+          links: [],
+          resource: { serviceName: "checkout", attributes: {} },
+          scope: { name: "otel", version: "" },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Kind")).toBeTruthy();
+    expect(screen.queryByText("Validation")).toBeNull();
+  });
+
+  it("uses bounded per-tab column caps with trailing spacer tracks", () => {
+    const { readFileSync } = require("fs");
+    const { resolve } = require("path");
+    const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+
+    expect(css).toContain(".data-table__head--metrics,\n.data-table__row--metrics {\n  --table-columns: 220px 220px 140px 1fr;\n}");
+    expect(css).toContain("--table-columns: 220px 240px 140px 96px 88px 56px 1fr;");
+    expect(css).toContain("--findings-tab-grid: 220px 140px 88px 88px 88px 1fr;");
+    expect(css).toContain("--findings-tab-grid: 220px 140px 88px 88px 88px 1fr;");
+    expect(css).toContain("--table-columns: 220px 240px 88px 1fr;");
+    expect(css).toContain(".data-table__head--metrics,\n  .data-table__row--metrics {\n    --table-columns: 220px 100px 1fr;\n  }");
+  });
+
+  it("uses the same compact row shell height as logs for master rows", () => {
+    const { readFileSync } = require("fs");
+    const { resolve } = require("path");
+    const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+
+    expect(css).toContain(".data-table__head--traces,\n.data-table__row--traces {\n  --table-columns: 220px 240px 140px 96px 88px 56px 1fr;\n}");
+    expect(css).toContain(".data-table__row--traces {\n  align-items: center;\n  min-height: 34px;\n}");
+    expect(css).toContain(".data-table__row--traces .data-table__td {\n  padding-top: 3px;\n  padding-bottom: 3px;\n}");
+  });
+
+  it("left-aligns stacked trace and metric values so content does not stretch across the cell", () => {
+    const { readFileSync } = require("fs");
+    const { resolve } = require("path");
+    const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+
+    expect(css).toContain(".data-table__td--operation {\n  min-width: 0;\n}");
+    expect(css).toContain(".trace-row__operation {\n  display: inline-block;\n  max-width: 100%;\n  overflow: hidden;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n}");
+    expect(css).toContain(".data-table__td--trace-id {\n  min-width: 0;\n}");
+    expect(css).toContain(".trace-row__trace-id {\n  display: inline-block;\n  max-width: 100%;\n  overflow: hidden;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n}");
+    expect(css).toContain(".metric-card__description {\n  display: block;\n  min-width: 0;\n  overflow: hidden;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n}");
+  });
+
+  it("constrains table headers so narrow count columns do not bleed into neighbors", () => {
+    const { readFileSync } = require("fs");
+    const { resolve } = require("path");
+    const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+
+    expect(css).toContain(".data-table__th {\n  display: flex;\n  align-items: center;\n  justify-content: flex-start;\n  font-size: var(--font-label);");
+    expect(css).toContain(".data-table__td {\n  display: flex;\n  align-items: center;\n  justify-content: flex-start;\n  padding: 3px 6px;");
+    expect(css).toContain(".data-table__th--numeric,\n.data-table__td--numeric {\n  justify-self: stretch;\n  text-align: right;\n  justify-content: flex-end;\n}");
+    expect(css).toContain(".findings-tab__head .data-table__th {\n  padding: 0 6px;\n  min-width: 0;\n  overflow: hidden;\n  text-overflow: ellipsis;\n}");
+  });
+
+  it("uses the same vertical centering model for metric master cells", () => {
+    const { readFileSync } = require("fs");
+    const { resolve } = require("path");
+    const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+
+    expect(css).toContain(".data-table__cell-content {\n  display: flex;\n  align-items: center;\n  justify-content: flex-start;\n  width: 100%;\n  min-width: 0;\n}");
+    expect(css).toContain(".data-table__cell-content--meta {\n  gap: 8px;\n}");
+    expect(css).toContain(".data-table__td--metric-meta {\n  display: flex;\n  align-items: center;\n  justify-content: flex-start;\n  min-width: 0;\n}");
+  });
+});

--- a/observer/client/src/traces/TracesTab.test.tsx
+++ b/observer/client/src/traces/TracesTab.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TracesTab } from "./TracesTab";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 36,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 36,
+        end: (index + 1) * 36,
+        size: 36,
+      })),
+    measureElement: () => undefined,
+  }),
+}));
+
+describe("TracesTab", () => {
+  it("filters traces from the compact explorer toolbar", () => {
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "ok" },
+          { traceId: "trace-2", rootSpanName: "POST /charge", serviceName: "payments", spanCount: 5, durationMs: 88, status: "error" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2 traces")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("Search operation, trace ID, service, or status"), {
+      target: { value: "missing-service" },
+    });
+
+    expect(screen.getByText("No traces match the current search.")).toBeTruthy();
+  });
+
+  it("renders zero-duration traces as 0.0ms instead of dashes", () => {
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-0", rootSpanName: "GET /health", serviceName: "api", spanCount: 1, durationMs: 0, status: "ok" },
+          { traceId: "trace-missing", rootSpanName: "GET /ready", serviceName: "api", spanCount: 1, status: "ok" } as any,
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("0.0ms")).toHaveLength(2);
+    expect(screen.queryByText("--")).toBeNull();
+  });
+
+  it("stacks the detail panel below the list on narrow widths", async () => {
+    const [{ Window }, { readFile }, { resolve }] = await Promise.all([
+      import("happy-dom"),
+      import("node:fs/promises"),
+      import("node:path"),
+    ]);
+    const css = await readFile(resolve(process.cwd(), "src/styles.css"), "utf8");
+    const window = new Window({ width: 800, height: 700, url: "http://localhost" });
+    const style = window.document.createElement("style");
+    style.textContent = css;
+    window.document.head.appendChild(style);
+    window.document.body.innerHTML =
+      "<div class=\"signal-view signal-view--with-panel\"><div class=\"signal-view__content\"></div><div class=\"signal-view__panel\"></div></div>";
+
+    const layout = window.document.querySelector(".signal-view");
+    const panel = window.document.querySelector(".signal-view__panel");
+    const content = window.document.querySelector(".signal-view__content");
+    expect(layout).toBeTruthy();
+    expect(panel).toBeTruthy();
+    expect(content).toBeTruthy();
+    if (!layout || !panel || !content) {
+      throw new Error("expected responsive layout shell");
+    }
+
+    const layoutStyles = window.getComputedStyle(layout);
+    const panelStyles = window.getComputedStyle(panel);
+    const contentStyles = window.getComputedStyle(content);
+
+    expect(layoutStyles.flexDirection).toBe("column");
+    expect(panelStyles.position).toBe("static");
+    expect(panelStyles.borderTopWidth).toBe("1px");
+    expect(panelStyles.borderTopStyle).toBe("solid");
+    expect(panelStyles.borderLeftWidth).toBe("0px");
+    expect(contentStyles.minHeight).toBe("0");
+  });
+});

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -15,6 +15,7 @@ interface TracesTabProps {
 
 /** Traces tab with virtualized table and waterfall detail panel. */
 export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps): React.ReactElement {
+  const [query, setQuery] = useState("");
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
   const [traceDetail, setTraceDetail] = useState<TraceDetail | null>(null);
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
@@ -77,10 +78,21 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
 
   useKeyboardShortcuts(shortcuts);
 
+  const filteredTraces = useMemo(() => {
+    const trimmedQuery = query.trim().toLowerCase();
+    if (!trimmedQuery) {
+      return traces;
+    }
+    return traces.filter((trace) => {
+      const haystack = [trace.traceId, trace.serviceName ?? "", trace.rootSpanName, trace.status].join(" ").toLowerCase();
+      return haystack.includes(trimmedQuery);
+    });
+  }, [query, traces]);
+
   // Invalidate detail when the selected trace is no longer in the list
   // (e.g., after live updates or store clear).
   // Re-fetch detail when the trace's span count changes (new spans arrived).
-  const selectedSummary = traces.find((t) => t.traceId === selectedTraceId);
+  const selectedSummary = filteredTraces.find((t) => t.traceId === selectedTraceId) ?? traces.find((t) => t.traceId === selectedTraceId);
   useEffect(() => {
     if (!selectedTraceId) return;
     if (!selectedSummary) {
@@ -99,8 +111,15 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
     }
   }, [loadTraceDetail, selectedTraceId, selectedSummary, traces]);
 
+  useEffect(() => {
+    if (!selectedTraceId) return;
+    if (!filteredTraces.some((trace) => trace.traceId === selectedTraceId)) {
+      selectTrace(null);
+    }
+  }, [filteredTraces, selectTrace, selectedTraceId]);
+
   const virtualizer = useVirtualizer({
-    count: traces.length,
+    count: filteredTraces.length,
     getScrollElement: () => tableRef.current,
     estimateSize: () => 36,
     overscan: 10,
@@ -119,8 +138,15 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
       >
         <div className="signal-view__content">
           {traces.length > 0 ? (
-            <div className="explorer__toolbar">
-              <span className="explorer__count">{traces.length} traces</span>
+            <div className="explorer__toolbar explorer__toolbar--controls">
+              <span className="explorer__count">{filteredTraces.length} traces</span>
+              <input
+                className="explorer__input"
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search operation, trace ID, service, or status"
+              />
             </div>
           ) : null}
 
@@ -130,21 +156,23 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
 
           {traces.length === 0 ? (
             <p className="explorer__status">Waiting for traces... Send OTLP data to port 4318.</p>
+          ) : filteredTraces.length === 0 ? (
+            <p className="explorer__status">No traces match the current search.</p>
           ) : (
             <>
-          <div className="data-table__head data-table__head--traces">
-            <span className="data-table__th data-table__th--status" />
-            <span className="data-table__th data-table__th--traceid">Trace ID</span>
-            <span className="data-table__th data-table__th--service">Service</span>
+          <div className="data-table__head data-table__head--traces data-table__head--left-cluster">
             <span className="data-table__th data-table__th--operation">Operation</span>
-            <span className="data-table__th data-table__th--duration">Duration</span>
-            <span className="data-table__th data-table__th--spans">Spans</span>
+            <span className="data-table__th data-table__th--trace-id">Trace ID</span>
+            <span className="data-table__th data-table__th--service">Service</span>
+            <span className="data-table__th data-table__th--status">Status</span>
+            <span className="data-table__th data-table__th--duration data-table__th--numeric">Duration</span>
+            <span className="data-table__th data-table__th--spans data-table__th--numeric">Spans</span>
           </div>
 
           <div className="data-table__body" ref={tableRef}>
-            <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+            <div className="data-table__body-inner data-table__body-inner--traces" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
               {virtualizer.getVirtualItems().map((vi) => {
-                const t = traces[vi.index];
+                const t = filteredTraces[vi.index];
                 if (!t) return null;
                 const active = t.traceId === selectedTraceId;
                 return (
@@ -163,18 +191,26 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
                     data-index={vi.index}
                     ref={virtualizer.measureElement}
                   >
-                    <span className={`data-table__td data-table__td--status status-dot status-dot--${t.status}`} />
-                    <span className="data-table__td data-table__td--traceid mono">
-                      {t.traceId.slice(-12)}
+                    <span className="data-table__td data-table__td--operation">
+                      <span className="trace-row__operation explorer-row__primary">{t.rootSpanName}</span>
+                    </span>
+                    <span className="data-table__td data-table__td--trace-id">
+                      <span className="trace-row__trace-id explorer-row__secondary">{t.traceId}</span>
                     </span>
                     <span className="data-table__td data-table__td--service">
-                      {t.serviceName ?? "unknown"}
+                      <span className="trace-row__service explorer-row__secondary">{t.serviceName ?? "unknown"}</span>
                     </span>
-                    <span className="data-table__td data-table__td--operation">{t.rootSpanName}</span>
-                    <span className="data-table__td data-table__td--duration">
-                      {t.durationMs != null ? `${t.durationMs.toFixed(1)}ms` : "--"}
+                    <span className="data-table__td data-table__td--status">
+                      <span className="trace-row__status">
+                        <span className={`trace-status trace-status--plain trace-status--${normalizeTraceStatusClass(t.status)}`}>{traceStatusLabel(t.status)}</span>
+                      </span>
                     </span>
-                    <span className="data-table__td data-table__td--spans">{t.spanCount}</span>
+                    <span className="data-table__td data-table__td--duration data-table__td--numeric">
+                      <span className="explorer-row__numeric">{formatTraceDuration(t.durationMs)}</span>
+                    </span>
+                    <span className="data-table__td data-table__td--spans data-table__td--numeric">
+                      <span className="explorer-row__numeric">{t.spanCount}</span>
+                    </span>
                   </button>
                 );
               })}
@@ -189,7 +225,7 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
           <div className="signal-view__panel">
             <DetailPanel
               title={traceDetail.rootSpanName}
-              subtitle={`${traceDetail.spanCount} spans${errorSpanCount > 0 ? ` \u00B7 ${errorSpanCount} error${errorSpanCount > 1 ? "s" : ""}` : ""} \u00B7 ${traceDetail.durationMs?.toFixed(1) ?? "--"}ms`}
+              subtitle={`${traceDetail.spanCount} spans${errorSpanCount > 0 ? ` \u00B7 ${errorSpanCount} error${errorSpanCount > 1 ? "s" : ""}` : ""} \u00B7 ${formatTraceDuration(traceDetail.durationMs)}`}
               onClose={() => selectTrace(null)}
             >
               <TraceWaterfall
@@ -228,4 +264,35 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
       </div>
     </section>
   );
+}
+
+function formatTraceDuration(durationMs?: number): string {
+  return `${(durationMs ?? 0).toFixed(1)}ms`;
+}
+
+export function traceStatusLabel(status: string): string | null {
+  switch (status) {
+    case "ok":
+      return "ok";
+    case "error":
+      return "error";
+    case "mixed":
+      return "mixed";
+    case "unset":
+      return "unset";
+    default:
+      return "unknown";
+  }
+}
+
+function normalizeTraceStatusClass(status: string): string {
+  switch (status) {
+    case "ok":
+    case "error":
+    case "mixed":
+    case "unset":
+      return status;
+    default:
+      return "unset";
+  }
 }

--- a/observer/client/src/traces/waterfall-layout.test.ts
+++ b/observer/client/src/traces/waterfall-layout.test.ts
@@ -3,11 +3,12 @@ import { buildWaterfallTree, flattenTree } from "./waterfall-layout";
 import type { Span } from "../api/types";
 
 function makeSpan(overrides: Partial<Span> & { spanId: string }): Span {
+  const { spanId, ...rest } = overrides;
   return {
     traceId: "abc123",
-    spanId: overrides.spanId,
+    spanId,
     parentSpanId: overrides.parentSpanId ?? "",
-    name: overrides.name ?? `span-${overrides.spanId}`,
+    name: overrides.name ?? `span-${spanId}`,
     kind: "INTERNAL",
     startTimeUnixNano: "1000000000",
     endTimeUnixNano: "2000000000",
@@ -18,7 +19,7 @@ function makeSpan(overrides: Partial<Span> & { spanId: string }): Span {
     links: [],
     resource: { attributes: {} },
     scope: { name: "test" },
-    ...overrides,
+    ...rest,
   };
 }
 

--- a/observer/go.mod
+++ b/observer/go.mod
@@ -16,11 +16,12 @@ require (
 	github.com/evanw/esbuild v0.28.0
 	github.com/gorilla/websocket v1.5.3
 	go.opentelemetry.io/collector/config/configgrpc v0.149.0
-	go.opentelemetry.io/collector/config/confighttp v0.149.0
 	go.opentelemetry.io/collector/config/confignet v1.55.0
 	go.opentelemetry.io/collector/config/configoptional v1.55.0
 	go.opentelemetry.io/otel/metric v1.42.0
 	go.opentelemetry.io/otel/trace v1.42.0
+	golang.org/x/sys v0.42.0
+	google.golang.org/grpc v1.79.3
 )
 
 require (
@@ -55,6 +56,7 @@ require (
 	go.opentelemetry.io/collector/component/componentstatus v0.149.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v1.55.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.55.0 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.149.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v1.55.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.55.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.55.0 // indirect
@@ -80,9 +82,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
-	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/observer/internal/store/store.go
+++ b/observer/internal/store/store.go
@@ -141,7 +141,7 @@ type TraceSummary struct {
 	RootSpanName string        `json:"rootSpanName"`
 	ServiceName  string        `json:"serviceName,omitempty"`
 	SpanCount    int           `json:"spanCount"`
-	DurationMs   float64       `json:"durationMs,omitempty"`
+	DurationMs   float64       `json:"durationMs"`
 	Status       string        `json:"status"`
 	Spans        []SpanPreview `json:"spans,omitempty"`
 }
@@ -161,7 +161,7 @@ type TraceDetail struct {
 	RootSpanName string  `json:"rootSpanName"`
 	ServiceName  string  `json:"serviceName,omitempty"`
 	SpanCount    int     `json:"spanCount"`
-	DurationMs   float64 `json:"durationMs,omitempty"`
+	DurationMs   float64 `json:"durationMs"`
 	Status       string  `json:"status"`
 	Spans        []Span  `json:"spans"`
 }
@@ -761,7 +761,7 @@ func (s *Store) notify(sig Signal) {
 	for _, ch := range s.subscribers {
 		select {
 		case ch <- sig:
-		default:
+			default:
 		}
 	}
 }
@@ -1001,7 +1001,7 @@ func computeTraceDuration(spans []Span) float64 {
 			maxEnd = sp.EndTime
 		}
 	}
-	return float64(maxEnd.Sub(minStart).Milliseconds())
+	return float64(maxEnd.Sub(minStart)) / float64(time.Millisecond)
 }
 
 func anySpanNameMatches(spans []Span, name string) bool {

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -690,6 +692,46 @@ func TestQueryTraces_RootSpanDetection(t *testing.T) {
 	}
 }
 
+func TestQueryTraces_ZeroDurationIsIncludedInJSON(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	span := newTestSpan("trace-1", "span-1", "root", now, 0)
+	s.AddSpansForConnection("conn-1", []Span{span})
+
+	results := s.QueryTraces(10)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 trace summary, got %d", len(results))
+	}
+	if results[0].DurationMs != 0 {
+		t.Fatalf("expected zero duration in summary, got %f", results[0].DurationMs)
+	}
+
+	summaryJSON, err := json.Marshal(results[0])
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	if !strings.Contains(string(summaryJSON), `"durationMs":0`) {
+		t.Fatalf("expected summary JSON to include zero duration, got %s", summaryJSON)
+	}
+
+	detail := s.Trace("trace-1", 10)
+	if detail == nil {
+		t.Fatal("expected trace detail")
+	}
+	if detail.DurationMs != 0 {
+		t.Fatalf("expected zero duration in detail, got %f", detail.DurationMs)
+	}
+
+	detailJSON, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	}
+	if !strings.Contains(string(detailJSON), `"durationMs":0`) {
+		t.Fatalf("expected detail JSON to include zero duration, got %s", detailJSON)
+	}
+}
+
 // ============================================================================
 // Trace Tests
 // ============================================================================
@@ -826,6 +868,17 @@ func TestComputeTraceDuration_Empty(t *testing.T) {
 	duration := computeTraceDuration([]Span{})
 	if duration != 0 {
 		t.Errorf("expected 0ms for empty slice, got %f", duration)
+	}
+}
+
+func TestComputeTraceDuration_PreservesSubMillisecondPrecision(t *testing.T) {
+	now := time.Now()
+	span := newTestSpan("trace-1", "span-1", "test", now, 0)
+	span.EndTime = span.StartTime.Add(700 * time.Microsecond)
+
+	duration := computeTraceDuration([]Span{span})
+	if duration != 0.7 {
+		t.Errorf("expected 0.7ms, got %f", duration)
 	}
 }
 


### PR DESCRIPTION
## Summary
Improve the Telemetry Explorer experience across metrics, traces, and logs.

## What Changed
- add the node OTel demo used to exercise live explorer data
- stabilize metric ordering so expanded metric views stop jumping
- fix metric row styling, typography, and shared palette usage
- show `0.0ms` for zero-duration traces instead of `--`
- improve narrow-width traces layout by stacking the detail panel below the list
- simplify tab labels and keep the active underline/spacing treatment
- tighten store and OTLP handling needed for the updated explorer views

## Fixes
- Fixes #28 by stabilizing metric ordering
- Fixes #29 by correcting metric row typography
- Fixes #30 by rendering zero-duration traces as `0.0ms`
- Fixes #31 by fixing the narrow-width traces detail layout
