### PR TITLE
Add validation workflows 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ The collector starts on:
 | OTLP/gRPC | localhost:4317 |
 | MCP endpoint | http://localhost:3000/mcp |
 
+When telemetry is flowing, open the Telemetry Explorer and use the
+**Validation** tab to run semantic validation against the current
+in-memory snapshot. Validation findings are retained, grouped into
+issues, and surfaced through the dedicated validation workflow.
+
 ### Use the Skills
 
 In your AI coding agent, navigate to a service directory and run:
@@ -84,6 +89,22 @@ Or use individual skills:
 ```
 
 See [docs/examples.md](docs/examples.md) for more prompt examples.
+
+### Run Validation
+
+Validation is available through the Explorer UI, the REST API, and MCP.
+
+1. Start `obstudio`
+2. Send traces, metrics, and logs to the OTLP receiver
+3. Open the **Validation** tab and run validation
+4. Use the findings to jump back to the affected telemetry rows
+
+Programmatic entry points:
+
+| Surface | Entry points |
+|---|---|
+| REST | `/api/query/validation/summary`, `/api/query/validation/latest`, `/api/validation/run`, `/api/validation/refresh` |
+| MCP | `observer_validation_status`, `observer_validation_analyze`, `observer_validation_refresh` |
 
 ---
 

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -32,7 +32,7 @@ Skills are embedded in the binary -- a single file is all you need.
 |--------|-----------------|------------|
 | `cursor` | `~/.cursor/skills/obstudio/` | `~/.cursor/mcp.json` |
 | `claude-code` | `~/.claude/skills/obstudio/` | `~/.claude/settings.json` |
-| `codex` | `~/.codex/skills/obstudio/` | `~/.codex/mcp.json` |
+| `codex` | `~/.codex/skills/obstudio/` | `~/.codex/config.toml` |
 
 The installer:
 1. Extracts skills and references from the binary to the agent's skill directory
@@ -105,6 +105,25 @@ Configure your app to send telemetry:
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 export OTEL_SERVICE_NAME=my-service
 ```
+
+## Validation
+
+When telemetry is flowing, open the **Validation** tab in the Telemetry
+Explorer to run semantic validation against the current in-memory
+snapshot. The latest retained result is summarized in the tab and
+surfaced through the dedicated validation workflow.
+
+Validation is also available programmatically:
+
+| Surface | Entry points |
+|---------|--------------|
+| REST | `GET /api/query/validation/summary`, `GET /api/query/validation/latest`, `POST /api/validation/run`, `POST /api/validation/refresh` |
+| MCP | `observer_validation_status`, `observer_validation_analyze`, `observer_validation_refresh` |
+
+Use `observer_validation_analyze` for most questions about missing
+telemetry or semantic convention issues. Use
+`observer_validation_refresh` only when you explicitly want to rerun
+validation against the current snapshot.
 
 ## Environment Variables
 

--- a/extension/build-observer.js
+++ b/extension/build-observer.js
@@ -54,6 +54,17 @@ function buildObserverGo(paths) {
 	console.log(`Built observer binary to ${paths.observerOutBinary}`);
 }
 
+function bundleWeaverRuntime(paths) {
+	console.log("Bundling Weaver validator runtime...");
+
+	execFileSync("go", ["run", "./cmd/fetch-weaver", "-output", paths.observerOutDir], {
+		cwd: paths.observerRoot,
+		stdio: "inherit",
+	});
+
+	console.log(`Bundled Weaver runtime into ${paths.observerOutDir}`);
+}
+
 if (require.main === module) {
 	(async () => {
 		const paths = getBuildPaths();
@@ -61,10 +72,18 @@ if (require.main === module) {
 		stageSkills(paths);
 		buildClientAssets(paths);
 		buildObserverGo(paths);
+		bundleWeaverRuntime(paths);
 	})().catch((error) => {
 		console.error(error);
 		process.exit(1);
 	});
 }
 
-module.exports = { getBuildPaths, resetObserverOutputDirs, stageSkills, buildClientAssets, buildObserverGo };
+module.exports = {
+	getBuildPaths,
+	resetObserverOutputDirs,
+	stageSkills,
+	buildClientAssets,
+	buildObserverGo,
+	bundleWeaverRuntime,
+};

--- a/extension/src/backend.ts
+++ b/extension/src/backend.ts
@@ -38,6 +38,10 @@ export function normalizeObserverBaseUrl(raw: string): string {
 	return parsed.toString().replace(/\/$/, '');
 }
 
+export function buildObserverValidatorSummaryUrl(baseUrl: string): string {
+	return `${normalizeObserverBaseUrl(baseUrl)}/api/query/validation/summary`;
+}
+
 export function buildObserverHealthUrl(baseUrl: string): string {
 	return `${normalizeObserverBaseUrl(baseUrl)}/api/health`;
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -5,6 +5,7 @@ import * as net from 'node:net';
 import * as vscode from 'vscode';
 import {
 	buildObserverHealthUrl,
+	buildObserverValidatorSummaryUrl,
 	type ObserverHealth,
 	normalizeObserverBaseUrl,
 	observerPortFromUrl,
@@ -63,6 +64,7 @@ type InternalRuntimeState = {
 	panelHtml?: string;
 	panelVisible: boolean;
 	sharedMode: boolean;
+	validatorSummaryUrl?: string;
 };
 
 type ObserverProbeOptions = {
@@ -251,6 +253,9 @@ export async function activate(context: vscode.ExtensionContext) {
 			panelHtml: observerPanel?.webview.html,
 			panelVisible: observerPanel !== undefined,
 			sharedMode: observerUsesSharedServer,
+			validatorSummaryUrl: observerBaseUrl === undefined
+				? undefined
+				: buildObserverValidatorSummaryUrl(observerBaseUrl),
 		}),
 	);
 

--- a/extension/src/test/extension-vscode.test.ts
+++ b/extension/src/test/extension-vscode.test.ts
@@ -14,6 +14,7 @@ type RuntimeState = {
 	panelHtml?: string;
 	panelVisible: boolean;
 	sharedMode: boolean;
+	validatorSummaryUrl?: string;
 };
 
 type SharedObserverHandle = {
@@ -206,6 +207,10 @@ async function waitForFileText(filePath: string): Promise<string> {
 	);
 }
 
+async function fetchJson(url: string): Promise<any> {
+	return requestJson(url, 'GET');
+}
+
 async function assertCodexConfigured(filePaths: string[], mcpUrl: string): Promise<void> {
 	for (const filePath of filePaths) {
 		try {
@@ -260,6 +265,31 @@ function restoreSnapshot(snapshot: FileSnapshot): void {
 	}
 
 	fs.rmSync(snapshot.filePath, { force: true });
+}
+
+async function postJson(url: string): Promise<any> {
+	return requestJson(url, 'POST');
+}
+
+async function requestJson(url: string, method: 'GET' | 'POST'): Promise<any> {
+	return new Promise((resolve, reject) => {
+		const request = http.request(url, { method }, (response) => {
+			let body = '';
+			response.setEncoding('utf8');
+			response.on('data', (chunk) => {
+				body += chunk;
+			});
+			response.on('end', () => {
+				try {
+					resolve(JSON.parse(body));
+				} catch (error) {
+					reject(error);
+				}
+			});
+		});
+		request.on('error', reject);
+		request.end();
+	});
 }
 
 suite('VS Code Host', () => {
@@ -344,6 +374,64 @@ suite('VS Code Host', () => {
 				restoreSnapshot(snapshot);
 			}
 			fs.rmSync(tempHome, { force: true, recursive: true });
+		}
+	});
+
+	test('openObserver exposes validator summary for a shared backend', async function () {
+		this.timeout(30_000);
+
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+
+		try {
+			await config.update('sharedObserverUrl', `${sharedObserver.baseUrl}/mcp`, vscode.ConfigurationTarget.Global);
+			await vscode.commands.executeCommand('observability-studio.openObserver');
+
+			const state = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => {
+					if (!value) {
+						return false;
+					}
+					return value.panelVisible
+						&& value.sharedMode
+						&& value.observerUrl === sharedObserver.baseUrl
+						&& typeof value.panelHtml === 'string'
+						&& value.panelHtml.includes(sharedObserver.baseUrl)
+						&& typeof value.validatorSummaryUrl === 'string';
+				},
+				20_000,
+			);
+
+			assert.ok(state.panelHtml?.includes('<iframe '), 'observer panel should embed the Observer UI in an iframe');
+			assert.ok(
+				state.panelHtml?.includes(sharedObserver.baseUrl),
+				'observer panel iframe should point at the shared backend',
+			);
+
+			const idleSummary = await waitFor(
+				() => fetchJson(state.validatorSummaryUrl!),
+				(value) => value?.enabled === true && value?.status === 'idle',
+				20_000,
+			);
+			assert.equal(idleSummary.enabled, true);
+			assert.equal(idleSummary.hasResult, false);
+
+			const runUrl = state.validatorSummaryUrl!.replace('/api/query/validation/summary', '/api/validation/run');
+			const runSummary = await postJson(runUrl);
+			assert.equal(runSummary.enabled, true);
+
+			const readySummary = await waitFor(
+				() => fetchJson(state.validatorSummaryUrl!),
+				(value) => value?.enabled === true && value?.hasResult === true,
+				20_000,
+			);
+			assert.equal(readySummary.enabled, true);
+			assert.equal(readySummary.hasResult, true);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
 		}
 	});
 

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import test from 'node:test';
 import {
 	buildObserverHealthUrl,
+	buildObserverValidatorSummaryUrl,
 	normalizeObserverBaseUrl,
 	observerPortFromUrl,
 	resolveBackend,
@@ -18,6 +19,7 @@ const { getBuildPaths, resetObserverOutputDirs } = require('../../build-observer
 	};
 	resetObserverOutputDirs: (paths: ReturnType<typeof getBuildPaths>) => void;
 };
+const weaverBinaryName = 'weaver';
 
 function withTempExtensionRoot(run: (extensionRoot: string) => void) {
 	const extensionRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-extension-'));
@@ -45,6 +47,14 @@ test('resolveBackend returns observer binary when it exists', () => {
 	});
 });
 
+test('build output layout reserves the bundled weaver runtime path', () => {
+	withTempExtensionRoot((extensionRoot) => {
+		const paths = getBuildPaths(extensionRoot);
+		const expected = path.join(paths.observerOutDir, weaverBinaryName);
+
+		assert.equal(expected.startsWith(paths.observerOutDir), true);
+	});
+});
 test('resolveBackend throws when the observer binary is missing', () => {
 	withTempExtensionRoot((extensionRoot) => {
 		assert.throws(() => resolveBackend(extensionRoot), /observer binary not found/);
@@ -56,6 +66,17 @@ test('normalizeObserverBaseUrl accepts base URLs and /mcp URLs', () => {
 	assert.equal(normalizeObserverBaseUrl('http://127.0.0.1:3000/'), 'http://127.0.0.1:3000');
 	assert.equal(normalizeObserverBaseUrl('http://127.0.0.1:3000/mcp'), 'http://127.0.0.1:3000');
 	assert.equal(normalizeObserverBaseUrl('https://example.com/observer/mcp'), 'https://example.com/observer');
+});
+
+test('buildObserverValidatorSummaryUrl uses normalized observer base URL', () => {
+	assert.equal(
+		buildObserverValidatorSummaryUrl('http://127.0.0.1:3000/mcp'),
+		'http://127.0.0.1:3000/api/query/validation/summary',
+	);
+	assert.equal(
+		buildObserverValidatorSummaryUrl('https://example.com/observer/'),
+		'https://example.com/observer/api/query/validation/summary',
+	);
 });
 
 test('buildObserverHealthUrl uses normalized observer base URL', () => {

--- a/observer/client/src/AppView.test.tsx
+++ b/observer/client/src/AppView.test.tsx
@@ -1,12 +1,52 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ValidationFinding, ValidationSummary } from "./api/types";
 import { AppView } from "./AppView";
 import type { TelemetryHandle } from "./telemetry";
+import { buildValidationIssues } from "./validation/utils";
 
-function makeTelemetryHandle(): TelemetryHandle {
+function makeFinding(overrides: Partial<ValidationFinding>): ValidationFinding {
+  return {
+    entityKey: "span:trace-1:span-1",
+    source: "weaver",
+    ruleId: "missing_http_method",
+    severity: "violation",
+    message: "missing http.method",
+    signal: {
+      type: "span",
+      serviceName: "checkout",
+      traceId: "trace-1",
+      spanId: "span-1",
+      spanName: "GET /orders",
+    },
+    updatedAt: "2026-04-09T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSummary(): ValidationSummary {
+  return {
+    enabled: true,
+    ready: true,
+    status: "ready",
+    message: "Weaver validator connected",
+    hasResult: true,
+    stale: false,
+    needsRun: false,
+    totalEntities: 3,
+    totalAdvisories: 3,
+    noAdviceCount: 0,
+    severityCounts: { violation: 3, improvement: 0, information: 0 },
+    highestSeverityCounts: { violation: 3, improvement: 0, information: 0 },
+    signalCounts: { span: 3 },
+    updatedAt: "2026-04-09T00:01:00Z",
+  };
+}
+
+function makeTelemetryHandle(findings: ValidationFinding[]): TelemetryHandle {
   return {
     state: {
       error: null,
@@ -21,6 +61,11 @@ function makeTelemetryHandle(): TelemetryHandle {
         traceCount: 2,
         serviceNames: ["checkout"],
       },
+      validation: {
+        summary: makeSummary(),
+        findings,
+        issues: buildValidationIssues(findings),
+      },
     },
     paused: false,
     hasNewUpdates: false,
@@ -33,23 +78,85 @@ function makeTelemetryHandle(): TelemetryHandle {
 
 afterEach(() => {
   cleanup();
+  window.history.replaceState({}, "", "/");
 });
 
-describe("AppView", () => {
-  it("renders summary cards and the telemetry stream pill", () => {
-    const { container } = render(<AppView telemetry={makeTelemetryHandle()} />);
-    const summary = container.querySelector(".metric-summary");
+describe("AppView validation tab", () => {
+  it("supports opening directly to the validation tab from the location query", () => {
+    window.history.replaceState({}, "", "/?tab=validation");
+    const telemetry = makeTelemetryHandle([makeFinding({})]);
 
-    expect(summary).toBeTruthy();
-    expect(within(summary as HTMLElement).getByText("Traces")).toBeTruthy();
-    expect(within(summary as HTMLElement).getByText("Metrics")).toBeTruthy();
-    expect(within(summary as HTMLElement).getByText("Logs")).toBeTruthy();
-    expect(within(summary as HTMLElement).getByText("Services")).toBeTruthy();
+    const { container } = render(<AppView telemetry={telemetry} />);
+
+    expect(screen.getByRole("tab", { name: /validation/i }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getAllByText("Validation").length).toBeGreaterThan(0);
+  });
+
+  it("renders a dedicated Validation tab with compact explorer chrome and issue-based validation counts", () => {
+    const telemetry = makeTelemetryHandle([
+      makeFinding({}),
+      makeFinding({
+        entityKey: "span:trace-2:span-2",
+        signal: {
+          type: "span",
+          serviceName: "checkout",
+          traceId: "trace-2",
+          spanId: "span-2",
+          spanName: "GET /orders",
+        },
+        updatedAt: "2026-04-09T00:01:00Z",
+      }),
+      makeFinding({
+        entityKey: "metric:checkout:http.server.duration",
+        ruleId: "missing_metric_unit",
+        signal: {
+          type: "metric",
+          serviceName: "checkout",
+          scopeName: "otel",
+          metricName: "http.server.duration",
+        },
+      }),
+    ]);
+
+    const { container } = render(<AppView telemetry={telemetry} />);
+
+    const validationTab = screen.getByRole("tab", { name: /validation/i });
+    expect(validationTab.querySelector(".validation-badge")).toBeNull();
+
+    fireEvent.click(validationTab);
+
+    expect(screen.getAllByText("Validation").length).toBeGreaterThan(0);
+    expect(screen.getByText("1 issues")).toBeTruthy();
+    expect(screen.getByText("Services")).toBeTruthy();
+    expect(screen.getByText("Telemetry stream")).toBeTruthy();
+    expect(screen.queryByText(/occurrences/i)).toBeNull();
+    expect(container.querySelector(".metric-summary")).toBeTruthy();
+    expect(screen.queryByText("Aggregate Validation")).toBeNull();
+    expect(screen.queryByText("Group By")).toBeNull();
+    expect(screen.queryByText(/^Validator ready/i)).toBeNull();
+    expect(screen.queryByText("Open Side Panel")).toBeNull();
+    expect(screen.getAllByText("http.server.duration").length).toBeGreaterThan(0);
+
+    const tablist = screen.getByRole("tablist", { name: "Validation signals" });
+    fireEvent.click(within(tablist).getByRole("tab", { name: "Spans" }));
+    expect(screen.getAllByText("GET /orders").length).toBeGreaterThan(0);
+  });
+
+  it("renders summary cards on non-validation tabs", () => {
+    const telemetry = makeTelemetryHandle([makeFinding({})]);
+
+    const { container } = render(<AppView telemetry={telemetry} />);
+
+    expect(screen.getByRole("tab", { name: /metrics/i }).getAttribute("aria-selected")).toBe("true");
+    expect(container.querySelector(".metric-summary")).toBeTruthy();
+    expect(screen.getByText("Services")).toBeTruthy();
     expect(screen.getByText("Telemetry stream")).toBeTruthy();
   });
 
   it("renders plain tab labels without letter badges", () => {
-    const { container } = render(<AppView telemetry={makeTelemetryHandle()} />);
+    const telemetry = makeTelemetryHandle([makeFinding({})]);
+
+    const { container } = render(<AppView telemetry={telemetry} />);
 
     expect(screen.getByRole("tab", { name: "Metrics" }).textContent).toBe("Metrics");
     expect(screen.getByRole("tab", { name: "Traces" }).textContent).toBe("Traces");

--- a/observer/client/src/AppView.tsx
+++ b/observer/client/src/AppView.tsx
@@ -4,23 +4,34 @@ import { MetricsTab } from "./metrics";
 import type { TelemetryHandle } from "./telemetry";
 import { TracesTab } from "./traces";
 import { KeyboardHelp } from "./components/KeyboardHelp";
+import { FindingsTab } from "./components/FindingsTab";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { buildValidationIndex, buildValidationIssues } from "./validation/utils";
 
 interface AppViewProps {
   telemetry: TelemetryHandle;
 }
 
+type AppTab = "metrics" | "traces" | "logs" | "validation";
+
 /** Main application view with tab navigation, summary cards, and live/paused toggle. */
 export function AppView({ telemetry }: AppViewProps): React.ReactElement {
-  const [activeTab, setActiveTab] = useState<"metrics" | "traces" | "logs">("metrics");
+  const [activeTab, setActiveTab] = useState<AppTab>(() => initialTabFromLocation());
   const [showHelp, setShowHelp] = useState(false);
 
   const { state, paused, hasNewUpdates, pause, resume, toggle } = telemetry;
+  const validationSummary = state.validation?.summary ?? null;
+  const validationFindings = state.validation?.findings ?? [];
+  const backendValidationIssues = state.validation?.issues ?? [];
+  const validationIndex = useMemo(() => buildValidationIndex(validationFindings), [validationFindings]);
+  const validationIssues = useMemo(
+    () => (backendValidationIssues.length > 0 || validationFindings.length === 0
+      ? backendValidationIssues
+      : buildValidationIssues(validationFindings)),
+    [backendValidationIssues, validationFindings],
+  );
 
-  // pause() is already idempotent (no-op when already paused)
-  // so pass it directly — no wrapper needed.
-
-  const switchTab = useCallback((tab: "metrics" | "traces" | "logs") => {
+  const switchTab = useCallback((tab: AppTab) => {
     setActiveTab(tab);
   }, []);
 
@@ -30,6 +41,7 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
     "1": () => switchTab("metrics"),
     "2": () => switchTab("traces"),
     "3": () => switchTab("logs"),
+    "4": () => switchTab("validation"),
   }), [toggle, switchTab]);
 
   useKeyboardShortcuts(shortcuts);
@@ -78,7 +90,6 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
           </div>
         </header>
 
-        {/* Summary cards — hidden when no data */}
         {(state.stats?.traceCount || state.stats?.metricNameCount || state.stats?.logCount) ? (
           <div className="metric-summary">
             {state.stats.traceCount ? (
@@ -137,14 +148,63 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
           >
             Logs
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "validation"}
+            className={activeTab === "validation" ? "tab-button is-active" : "tab-button"}
+            onClick={() => switchTab("validation")}
+          >
+            Validation
+          </button>
         </div>
 
-        {activeTab === "metrics" ? <MetricsTab metrics={state.metrics ?? []} telemetryError={state.error} /> : null}
-        {activeTab === "traces" ? <TracesTab telemetryError={state.error} traces={state.traces ?? []} onInteract={pause} /> : null}
-        {activeTab === "logs" ? <LogsTab logs={state.logs ?? []} onInteract={pause} /> : null}
+        {activeTab === "metrics" ? (
+          <MetricsTab
+            metrics={state.metrics ?? []}
+            telemetryError={state.error}
+            onInteract={pause}
+          />
+        ) : null}
+        {activeTab === "traces" ? (
+          <TracesTab
+            telemetryError={state.error}
+            traces={state.traces ?? []}
+            onInteract={pause}
+            validationFindings={validationFindings}
+            validationIndex={validationIndex}
+          />
+        ) : null}
+        {activeTab === "logs" ? (
+          <LogsTab
+            logs={state.logs ?? []}
+            onInteract={pause}
+          />
+        ) : null}
+        {activeTab === "validation" ? (
+          <FindingsTab
+            issues={validationIssues}
+            summary={validationSummary}
+          />
+        ) : null}
       </section>
 
       {showHelp ? <KeyboardHelp onClose={() => setShowHelp(false)} /> : null}
     </main>
   );
+}
+
+function initialTabFromLocation(): AppTab {
+  if (typeof window === "undefined") return "metrics";
+  const params = new URLSearchParams(window.location.search);
+  const tab = params.get("tab");
+  switch (tab) {
+    case "metrics":
+    case "traces":
+    case "logs":
+    case "validation":
+      return tab;
+    default:
+      return "metrics";
+  }
 }

--- a/observer/client/src/api/types.ts
+++ b/observer/client/src/api/types.ts
@@ -149,3 +149,74 @@ export interface Stats {
   traceCount: number;
   serviceNames: string[];
 }
+
+export type ValidationSeverity = "information" | "improvement" | "violation";
+
+export interface ValidationSignalRef {
+  type: string;
+  serviceName?: string;
+  traceId?: string;
+  spanId?: string;
+  spanName?: string;
+  metricName?: string;
+  scopeName?: string;
+  logBody?: string;
+}
+
+export interface ValidationFinding {
+  entityKey: string;
+  source: string;
+  ruleId: string;
+  severity: ValidationSeverity;
+  message: string;
+  context?: Record<string, unknown>;
+  signal: ValidationSignalRef;
+  updatedAt: string;
+}
+
+export interface ValidationIssue {
+  key: string;
+  severity: ValidationSeverity;
+  message: string;
+  signalType: string;
+  targetLabel: string;
+  serviceName: string;
+  scopeName: string;
+  count: number;
+  violationCount: number;
+  improvementCount: number;
+  informationCount: number;
+  affectedEntityCount: number;
+  firstSeen: string;
+  lastSeen: string;
+  findings: ValidationFinding[];
+}
+
+export interface ValidationSummary {
+  enabled: boolean;
+  ready: boolean;
+  status: "disabled" | "idle" | "running" | "ready" | "error";
+  message?: string;
+  lastError?: string;
+  hasResult: boolean;
+  stale: boolean;
+  needsRun: boolean;
+  activeRunId?: string;
+  resultRunId?: string;
+  lastRunStartedAt?: string;
+  lastRunCompletedAt?: string;
+  lastTelemetryAt?: string;
+  totalEntities: number;
+  totalAdvisories: number;
+  noAdviceCount: number;
+  severityCounts: Record<string, number>;
+  highestSeverityCounts: Record<string, number>;
+  signalCounts: Record<string, number>;
+  updatedAt: string;
+}
+
+export interface ValidationSnapshot {
+  summary: ValidationSummary;
+  findings: ValidationFinding[];
+  issues: ValidationIssue[];
+}

--- a/observer/client/src/components/FindingsTab.test.tsx
+++ b/observer/client/src/components/FindingsTab.test.tsx
@@ -1,0 +1,417 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ValidationFinding, ValidationSummary } from "../api/types";
+import { buildValidationIssues } from "../validation/utils";
+import { FindingsTab } from "./FindingsTab";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeFinding(overrides: Partial<ValidationFinding>): ValidationFinding {
+  return {
+    entityKey: "span:trace-1:span-1",
+    source: "weaver",
+    ruleId: "missing_http_method",
+    severity: "violation",
+    message: "missing http.method",
+    signal: {
+      type: "span",
+      serviceName: "checkout",
+      traceId: "trace-1",
+      spanId: "span-1",
+      spanName: "GET /orders",
+    },
+    updatedAt: "2026-04-09T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSummary(): ValidationSummary {
+  return {
+    enabled: true,
+    ready: true,
+    status: "ready",
+    message: "Weaver validator connected",
+    hasResult: true,
+    stale: false,
+    needsRun: false,
+    totalEntities: 3,
+    totalAdvisories: 3,
+    noAdviceCount: 0,
+    severityCounts: { violation: 3, improvement: 0, information: 0 },
+    highestSeverityCounts: { violation: 3, improvement: 0, information: 0 },
+    signalCounts: { span: 2, metric: 1 },
+    updatedAt: "2026-04-09T00:01:00Z",
+  };
+}
+
+describe("FindingsTab", () => {
+  it("renders signal mini-tabs and defaults to the first available signal with no detail selection", () => {
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "metric:checkout:http.server.duration",
+            ruleId: "unit_mismatch",
+            message: "Unit should be s.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "otel",
+              metricName: "http.server.duration",
+            },
+          }),
+          makeFinding({
+            entityKey: "metric:checkout:http.server.duration",
+            severity: "improvement",
+            ruleId: "missing_description",
+            message: "Metric needs a description.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "otel",
+              metricName: "http.server.duration",
+            },
+            updatedAt: "2026-04-09T00:01:00Z",
+          }),
+          makeFinding({
+            entityKey: "metric:checkout:http.server.duration",
+            severity: "information",
+            ruleId: "naming",
+            message: "Metric naming can be tightened.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "otel",
+              metricName: "http.server.duration",
+            },
+            updatedAt: "2026-04-09T00:02:00Z",
+          }),
+          makeFinding({}),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    const tablist = view.getByRole("tablist", { name: "Validation signals" });
+    expect(within(tablist).getByRole("tab", { name: "Metrics" }).getAttribute("aria-selected")).toBe("true");
+    expect(within(tablist).getByRole("tab", { name: "Spans" }).getAttribute("aria-selected")).toBe("false");
+
+    const head = view.container.querySelector(".findings-tab__head");
+    expect(head).toBeTruthy();
+    expect(within(head as HTMLElement).getByText("Metric")).toBeTruthy();
+    expect(within(head as HTMLElement).getByText("Rule")).toBeTruthy();
+    expect(within(head as HTMLElement).getByText("Violations")).toBeTruthy();
+    expect(within(head as HTMLElement).getByText("Improvements")).toBeTruthy();
+    expect(within(head as HTMLElement).getByText("Information")).toBeTruthy();
+
+    const master = view.container.querySelector(".findings-tab__master");
+    expect(master?.classList.contains("findings-tab__master--metric")).toBe(true);
+    const rowButton = within(master as HTMLElement).getByText("http.server.duration").closest("button");
+    expect(rowButton).toBeTruthy();
+    expect(within(rowButton as HTMLElement).getByText("unit_mismatch +2 more")).toBeTruthy();
+    const counts = Array.from((rowButton as HTMLElement).querySelectorAll(".findings-tab__item-count")).map((node) => node.textContent?.trim());
+    expect(counts).toEqual(["1", "1", "1"]);
+    expect((rowButton as HTMLElement).querySelector(".findings-tab__item-title")?.classList.contains("explorer-row__primary")).toBe(true);
+    expect((rowButton as HTMLElement).querySelector(".findings-tab__item-rule")?.classList.contains("explorer-row__secondary")).toBe(true);
+    expect((rowButton as HTMLElement).querySelector(".findings-tab__item-rule")?.classList.contains("mono")).toBe(false);
+    expect(Array.from((rowButton as HTMLElement).querySelectorAll(".findings-tab__item-count")).every((node) => node.classList.contains("explorer-row__numeric"))).toBe(true);
+    expect(view.container.querySelector("#validation-issue-detail")).toBeNull();
+  });
+
+  it("does not show a validated timestamp before validation has produced a real result", () => {
+    const idleSummary: ValidationSummary = {
+      ...makeSummary(),
+      hasResult: false,
+      status: "idle",
+      lastRunCompletedAt: "0001-01-01T00:00:00Z",
+    };
+
+    const view = render(
+      <FindingsTab
+        issues={[]}
+        summary={idleSummary}
+      />,
+    );
+
+    expect(view.queryByText(/Validated /)).toBeNull();
+    expect(view.getByText("Validation has not been run yet. Run validation to analyze the current telemetry snapshot.")).toBeTruthy();
+  });
+
+  it("switches tabs and uses signal-specific fields for spans, logs, and resources", () => {
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "span:trace-1:span-1",
+            signal: {
+              type: "span",
+              serviceName: "checkout",
+              traceId: "trace-1",
+              spanId: "span-1",
+              spanName: "GET /orders",
+            },
+          }),
+          makeFinding({
+            entityKey: "log:1",
+            ruleId: "missing_attribute",
+            message: "Attribute 'traceId' does not exist in the registry.",
+            signal: {
+              type: "log",
+              serviceName: "order-service",
+              logBody: "Cache hit for order ORD-1781",
+            },
+          }),
+          makeFinding({
+            entityKey: "resource:1",
+            ruleId: "not_stable",
+            message: "Attribute 'deployment.environment.name' is not stable; stability = development.",
+            signal: { type: "resource", serviceName: "order-service" },
+            context: {
+              attribute_name: "deployment.environment.name",
+              stability: "development",
+            },
+          }),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    const tablist = view.getByRole("tablist", { name: "Validation signals" });
+
+    fireEvent.click(within(tablist).getByRole("tab", { name: "Spans" }));
+    let head = view.container.querySelector(".findings-tab__head");
+    expect(within(head as HTMLElement).getByText("Span")).toBeTruthy();
+    let master = view.container.querySelector(".findings-tab__master");
+    expect(master?.classList.contains("findings-tab__master--span")).toBe(true);
+    expect(within(master as HTMLElement).getByText("GET /orders")).toBeTruthy();
+
+    fireEvent.click(within(tablist).getByRole("tab", { name: "Logs" }));
+    head = view.container.querySelector(".findings-tab__head");
+    expect(within(head as HTMLElement).getByText("Example")).toBeTruthy();
+    master = view.container.querySelector(".findings-tab__master");
+    expect(master?.classList.contains("findings-tab__master--log")).toBe(true);
+    expect(within(master as HTMLElement).getByText("Cache hit for order ORD-1781")).toBeTruthy();
+    expect(within(master as HTMLElement).getByText("missing_attribute")).toBeTruthy();
+
+    fireEvent.click(within(tablist).getByRole("tab", { name: "Resources" }));
+    head = view.container.querySelector(".findings-tab__head");
+    expect(within(head as HTMLElement).getByText("Attribute")).toBeTruthy();
+    master = view.container.querySelector(".findings-tab__master");
+    expect(master?.classList.contains("findings-tab__master--resource")).toBe(true);
+    expect(within(master as HTMLElement).getByText("deployment.environment.name")).toBeTruthy();
+    expect(within(master as HTMLElement).getByText("not_stable")).toBeTruthy();
+  });
+
+  it("does not render generic detail titles or subtitles in any validation subtab", () => {
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "span:trace-1:span-1",
+            signal: {
+              type: "span",
+              serviceName: "checkout",
+              traceId: "trace-1",
+              spanId: "span-1",
+              spanName: "GET /orders",
+            },
+          }),
+          makeFinding({
+            entityKey: "log:1",
+            ruleId: "missing_attribute",
+            message: "Attribute 'traceId' does not exist in the registry.",
+            signal: {
+              type: "log",
+              serviceName: "order-service",
+              logBody: "Cache hit for order ORD-1781",
+            },
+          }),
+          makeFinding({
+            entityKey: "resource:1",
+            ruleId: "not_stable",
+            message: "Attribute 'deployment.environment.name' is not stable; stability = development.",
+            signal: { type: "resource", serviceName: "order-service" },
+            context: {
+              attribute_name: "deployment.environment.name",
+              stability: "development",
+            },
+          }),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    let master = view.container.querySelector(".findings-tab__master");
+    fireEvent.click(within(master as HTMLElement).getByText("GET /orders").closest("button") as HTMLElement);
+    let detailPanel = view.container.querySelector("#validation-issue-detail") as HTMLElement;
+    expect(detailPanel.querySelector(".detail-panel__title")).toBeNull();
+    expect(detailPanel.querySelector(".detail-panel__subtitle")).toBeNull();
+    expect(detailPanel.querySelector(".findings-tab__detail-heading")?.textContent).toBe("GET /orders");
+
+    const tablist = view.getByRole("tablist", { name: "Validation signals" });
+    fireEvent.click(within(tablist).getByRole("tab", { name: "Logs" }));
+    master = view.container.querySelector(".findings-tab__master");
+    fireEvent.click(within(master as HTMLElement).getByText("Cache hit for order ORD-1781").closest("button") as HTMLElement);
+    detailPanel = view.container.querySelector("#validation-issue-detail") as HTMLElement;
+    expect(detailPanel.querySelector(".detail-panel__title")).toBeNull();
+    expect(detailPanel.querySelector(".detail-panel__subtitle")).toBeNull();
+    expect(detailPanel.querySelector(".findings-tab__detail-heading")?.textContent).toBe("Cache hit for order ORD-1781");
+
+    fireEvent.click(within(tablist).getByRole("tab", { name: "Resources" }));
+    master = view.container.querySelector(".findings-tab__master");
+    fireEvent.click(within(master as HTMLElement).getByText("deployment.environment.name").closest("button") as HTMLElement);
+    detailPanel = view.container.querySelector("#validation-issue-detail") as HTMLElement;
+    expect(detailPanel.querySelector(".detail-panel__title")).toBeNull();
+    expect(detailPanel.querySelector(".detail-panel__subtitle")).toBeNull();
+    expect(detailPanel.querySelector(".findings-tab__detail-heading")?.textContent).toBe("deployment.environment.name");
+  });
+
+  it("shows the clicked row in the shared side detail panel", () => {
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "metric:checkout:jvm.thread.count",
+            ruleId: "unexpected_instrument",
+            message: "Instrument should be 'updowncounter', but found 'gauge'.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "",
+              metricName: "jvm.thread.count",
+            },
+          }),
+          makeFinding({
+            entityKey: "metric:checkout:jvm.thread.count",
+            ruleId: "unit_mismatch",
+            message: "Unit should be '{thread}', but found ''.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "",
+              metricName: "jvm.thread.count",
+            },
+            updatedAt: "2026-04-09T00:01:00Z",
+          }),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    const layout = view.container.querySelector(".findings-tab__layout");
+    expect(layout?.classList.contains("findings-tab__layout--with-panel")).toBe(false);
+
+    const master = view.container.querySelector(".findings-tab__master");
+    const rowButton = within(master as HTMLElement).getByText("jvm.thread.count").closest("button");
+    expect(view.container.querySelector("#validation-issue-detail")).toBeNull();
+
+    fireEvent.click(rowButton as HTMLElement);
+
+    const detailPanel = view.container.querySelector("#validation-issue-detail");
+    expect(detailPanel).toBeTruthy();
+    expect(view.container.querySelector(".findings-tab__layout--with-panel")).toBeTruthy();
+    expect((detailPanel as HTMLElement).querySelector(".detail-panel__title")).toBeNull();
+    expect((detailPanel as HTMLElement).querySelector(".detail-panel__subtitle")).toBeNull();
+    expect((detailPanel as HTMLElement).querySelector(".findings-tab__detail-heading")?.textContent).toBe("jvm.thread.count");
+    expect((detailPanel as HTMLElement).querySelector(".findings-tab__detail-grid")).toBeNull();
+    expect(within(detailPanel as HTMLElement).queryByText("Target")).toBeNull();
+    expect(within(detailPanel as HTMLElement).queryByText("Signal")).toBeNull();
+    expect(within(detailPanel as HTMLElement).queryByText("Service")).toBeNull();
+    expect(within(detailPanel as HTMLElement).queryByText("Entities")).toBeNull();
+    expect(within(detailPanel as HTMLElement).queryByText("Last Seen")).toBeNull();
+    expect(within(detailPanel as HTMLElement).getByText("Findings")).toBeTruthy();
+    expect(within(detailPanel as HTMLElement).getAllByText("unexpected_instrument").length).toBeGreaterThan(0);
+    expect(within(detailPanel as HTMLElement).getAllByText("unit_mismatch").length).toBeGreaterThan(0);
+  });
+
+  it("shows resource context and hides empty service metadata in the detail panel", () => {
+    const view = render(
+      <FindingsTab
+        issues={[
+          {
+            key: "resource:not_stable",
+            severity: "violation",
+            message: "Attribute 'deployment.environment.name' is not stable; stability = development.",
+            signalType: "resource",
+            targetLabel: "deployment.environment.name",
+            serviceName: "",
+            scopeName: "",
+            count: 1,
+            violationCount: 1,
+            improvementCount: 0,
+            informationCount: 0,
+            affectedEntityCount: 1,
+            firstSeen: "2026-04-10T00:00:00Z",
+            lastSeen: "2026-04-10T00:00:00Z",
+            findings: [
+              makeFinding({
+                entityKey: "resource:",
+                ruleId: "not_stable",
+                message: "Attribute 'deployment.environment.name' is not stable; stability = development.",
+                signal: { type: "resource" },
+                context: {
+                  attribute_name: "deployment.environment.name",
+                  stability: "development",
+                },
+              }),
+            ],
+          },
+        ]}
+        summary={makeSummary()}
+      />,
+    );
+
+    const tablist = view.getByRole("tablist", { name: "Validation signals" });
+    fireEvent.click(within(tablist).getByRole("tab", { name: "Resources" }));
+
+    const master = view.container.querySelector(".findings-tab__master");
+    fireEvent.click(within(master as HTMLElement).getByText("deployment.environment.name").closest("button") as HTMLElement);
+
+    const detailPanel = view.container.querySelector("#validation-issue-detail");
+    expect(within(detailPanel as HTMLElement).getByText("Stability")).toBeTruthy();
+    expect(within(detailPanel as HTMLElement).getByText("development")).toBeTruthy();
+    expect(within(detailPanel as HTMLElement).queryByText("Service")).toBeNull();
+    expect(within(detailPanel as HTMLElement).queryByText("Scope")).toBeNull();
+    expect(within(detailPanel as HTMLElement).getByText("Resource attributes apply across traces, metrics, and logs emitted by the same service.")).toBeTruthy();
+  });
+
+  it("renders the selected issue in a split view with the compact close-only detail header", () => {
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "metric:checkout:jvm.thread.count",
+            ruleId: "unit_mismatch",
+            message: "Metric unit should be {thread}.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "otel",
+              metricName: "jvm.thread.count",
+            },
+          }),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    const row = view.getByText("jvm.thread.count").closest("button");
+    const item = row?.closest(".findings-tab__item");
+    fireEvent.click(row as HTMLElement);
+
+    const layout = view.container.querySelector(".findings-tab__layout");
+    const detailPanel = view.container.querySelector("#validation-issue-detail");
+    const selected = view.container.querySelector(".findings-tab__item.is-selected");
+
+    expect(layout?.classList.contains("findings-tab__layout--with-panel")).toBe(true);
+    expect(detailPanel).toBeTruthy();
+    expect(detailPanel?.querySelector(".detail-panel__header--close-only")).toBeTruthy();
+    expect(selected).toBe(item);
+    expect(detailPanel?.querySelector(".findings-tab__detail-heading")?.textContent).toBe("jvm.thread.count");
+  });
+});

--- a/observer/client/src/components/FindingsTab.tsx
+++ b/observer/client/src/components/FindingsTab.tsx
@@ -1,0 +1,533 @@
+import React, { useEffect, useMemo, useState } from "react";
+import type { ValidationFinding, ValidationIssue, ValidationSeverity, ValidationSummary } from "../api/types";
+import { DetailPanel } from "../layout";
+import {
+  filterValidationIssues,
+  issueVariantKey,
+  stableContextEntries,
+  validationSeverityRank,
+  type ValidationFilters,
+} from "../validation/utils";
+
+interface IssueVariant {
+  key: string;
+  message: string;
+  ruleId: string;
+  severity: ValidationSeverity;
+}
+
+interface SeverityTotals {
+  violation: number;
+  improvement: number;
+  information: number;
+}
+
+type ValidationSignalTab = "metric" | "span" | "log" | "resource";
+
+interface SignalTabDefinition {
+  key: ValidationSignalTab;
+  label: string;
+  issueLabel: string;
+}
+
+const signalTabs: SignalTabDefinition[] = [
+  { key: "metric", label: "Metrics", issueLabel: "Metric" },
+  { key: "span", label: "Spans", issueLabel: "Span" },
+  { key: "log", label: "Logs", issueLabel: "Example" },
+  { key: "resource", label: "Resources", issueLabel: "Attribute" },
+];
+
+interface ValidationTabProps {
+  issues: ValidationIssue[];
+  summary: ValidationSummary | null;
+}
+
+const defaultFilters: ValidationFilters = {
+  signalType: "",
+  severity: "",
+  query: "",
+};
+
+export function FindingsTab({ issues, summary }: ValidationTabProps): React.ReactElement {
+  const [filters, setFilters] = useState<ValidationFilters>(defaultFilters);
+  const [activeSignalTab, setActiveSignalTab] = useState<ValidationSignalTab>(() => firstAvailableSignal(issues));
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const availableSignalTabs = useMemo(
+    () => signalTabs.filter((tab) => issues.some((issue) => normalizeSignalType(issue.signalType) === tab.key)),
+    [issues],
+  );
+  const activeSignalDefinition = signalTabs.find((tab) => tab.key === activeSignalTab) ?? signalTabs[0];
+
+  const filteredIssues = useMemo(
+    () => filterValidationIssues(issues, { ...filters, signalType: activeSignalTab }),
+    [issues, filters, activeSignalTab],
+  );
+  const hasResult = summary?.hasResult ?? false;
+  const isRunning = summary?.status === "running";
+  const showResultState = hasResult;
+  const completedAt = hasResult && isMeaningfulTimestamp(summary?.lastRunCompletedAt)
+    ? summary?.lastRunCompletedAt
+    : null;
+  const actionLabel = hasResult ? "Re-run Validation" : "Run Validation";
+
+  useEffect(() => {
+    if (availableSignalTabs.length === 0) {
+      return;
+    }
+    if (!availableSignalTabs.some((tab) => tab.key === activeSignalTab)) {
+      setActiveSignalTab(availableSignalTabs[0]?.key ?? "metric");
+    }
+  }, [activeSignalTab, availableSignalTabs]);
+
+  useEffect(() => {
+    if (filteredIssues.length === 0) {
+      setSelectedKey(null);
+      return;
+    }
+    if (selectedKey !== null && !filteredIssues.some((issue) => issue.key === selectedKey)) {
+      setSelectedKey(null);
+    }
+  }, [filteredIssues, selectedKey]);
+
+  useEffect(() => {
+    if (summary?.status !== "error") {
+      setRunError(null);
+    }
+  }, [summary?.status]);
+
+  const selectedIssue = useMemo(
+    () => filteredIssues.find((issue) => issue.key === selectedKey) ?? null,
+    [filteredIssues, selectedKey],
+  );
+
+  const triggerValidation = async (): Promise<void> => {
+    setIsSubmitting(true);
+    setRunError(null);
+    try {
+      const response = await fetch("/api/validation/run", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      if (!response.ok) {
+        let message = `Validation request failed with status ${response.status}`;
+        try {
+          const payload = await response.json() as { error?: string };
+          if (payload.error) {
+            message = payload.error;
+          }
+        } catch {
+          // Keep the HTTP status fallback.
+        }
+        throw new Error(message);
+      }
+    } catch (error) {
+      setRunError(error instanceof Error ? error.message : "Validation request failed");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="tab-panel findings-tab">
+      <div className="panel-toolbar findings-tab__header">
+        <div className="findings-tab__header-meta">
+          {showResultState ? <span className="findings-tab__header-count">{filteredIssues.length} issues</span> : null}
+          {showResultState && completedAt ? <span className="findings-tab__header-separator" aria-hidden="true">·</span> : null}
+          {completedAt ? <span className="findings-tab__header-timestamp">Validated {formatTimestamp(completedAt)}</span> : null}
+        </div>
+        <div className="panel-toolbar__meta">
+          <button
+            type="button"
+            className="findings-tab__action"
+            onClick={() => {
+              void triggerValidation();
+            }}
+            disabled={isRunning || isSubmitting || !summary?.enabled}
+          >
+            {isRunning || isSubmitting ? "Running..." : actionLabel}
+          </button>
+        </div>
+      </div>
+
+      <div className="findings-tab__filters">
+        <select className="validation-panel__select" value={filters.severity} onChange={(event) => setFilters((current) => ({ ...current, severity: event.target.value }))}>
+          <option value="">All severities</option>
+          <option value="violation">Violation</option>
+          <option value="improvement">Improvement</option>
+          <option value="information">Information</option>
+        </select>
+        <div className="findings-tab__signal-tabs" role="tablist" aria-label="Validation signals">
+          {signalTabs.map((tab) => {
+            const hasIssues = issues.some((issue) => normalizeSignalType(issue.signalType) === tab.key);
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                role="tab"
+                className={tab.key === activeSignalTab ? "findings-tab__signal-tab is-active" : "findings-tab__signal-tab"}
+                aria-selected={tab.key === activeSignalTab}
+                data-has-issues={hasIssues ? "true" : "false"}
+                onClick={() => setActiveSignalTab(tab.key)}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <section className="findings-tab__content">
+        {summary?.status === "disabled" ? (
+          <p className="explorer__status">{summary.message ?? "Validator unavailable."}</p>
+        ) : (
+          <>
+            {summary?.status === "idle" && !summary.hasResult ? (
+              <div className="status">
+                Validation has not been run yet. Run validation to analyze the current telemetry snapshot.
+              </div>
+            ) : null}
+            {summary?.status === "running" ? (
+              <div className="status">
+                Validation is running{summary.lastRunStartedAt ? ` since ${formatTimestamp(summary.lastRunStartedAt)}` : ""}.
+              </div>
+            ) : null}
+            {summary?.status === "error" ? (
+              <div className="status error">
+                {summary.lastError ?? summary.message ?? "Validation failed."}
+              </div>
+            ) : null}
+            {runError ? (
+              <div className="status error">{runError}</div>
+            ) : null}
+            {!summary?.hasResult ? null : filteredIssues.length === 0 ? (
+              <div className="findings-tab__empty">
+                <p className="findings-tab__empty-title">No {activeSignalDefinition.label.toLowerCase()} validation issues match the current filters.</p>
+              </div>
+            ) : (
+              <div className={selectedIssue ? "findings-tab__layout findings-tab__layout--with-panel" : "findings-tab__layout"}>
+                <div className={`findings-tab__master findings-tab__master--${activeSignalTab}`}>
+                  <div className="data-table__head findings-tab__head">
+                    <span className="data-table__th">{activeSignalDefinition.issueLabel}</span>
+                    <span className="data-table__th">Rule</span>
+                    <span className="data-table__th data-table__th--numeric findings-tab__th-count">Violations</span>
+                    <span className="data-table__th data-table__th--numeric findings-tab__th-count">Improvements</span>
+                    <span className="data-table__th data-table__th--numeric findings-tab__th-count">Information</span>
+                  </div>
+                  <div className="findings-tab__list">
+                    {filteredIssues.map((issue) => {
+                      const isSelected = issue.key === selectedKey;
+                      const issueVariants = groupIssueVariants(issue.findings);
+                      const totals = issueSeverityTotals(issue, issueVariants);
+                      const row = issueListRow(issue, issueVariants);
+                      return (
+                        <article
+                          key={issue.key}
+                          className={isSelected ? `validation-item validation-item--${issue.severity} findings-tab__item is-selected` : `validation-item validation-item--${issue.severity} findings-tab__item`}
+                        >
+                          <button
+                            type="button"
+                            className="findings-tab__item-trigger"
+                            onClick={() => setSelectedKey(issue.key)}
+                            aria-pressed={isSelected}
+                            aria-controls="validation-issue-detail"
+                            aria-label={`${row.issue} ${row.rule} ${totals.violation} violations ${totals.improvement} improvements ${totals.information} information`}
+                          >
+                            <div className="findings-tab__item-grid">
+                              <span className="findings-tab__item-title explorer-row__primary">{row.issue}</span>
+                              <span className="findings-tab__item-rule explorer-row__secondary">{row.rule}</span>
+                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.violation === 0 ? "is-zero" : ""}`}>{totals.violation}</span>
+                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.improvement === 0 ? "is-zero" : ""}`}>{totals.improvement}</span>
+                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.information === 0 ? "is-zero" : ""}`}>{totals.information}</span>
+                            </div>
+                          </button>
+                        </article>
+                      );
+                    })}
+                  </div>
+                </div>
+                {selectedIssue ? (
+                  <aside id="validation-issue-detail" className="findings-tab__detail-panel">
+                    <IssueDetailPanel key={selectedIssue.key} issue={selectedIssue} onClose={() => setSelectedKey(null)} />
+                  </aside>
+                ) : null}
+              </div>
+            )}
+          </>
+        )}
+      </section>
+    </section>
+  );
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <div className="findings-tab__detail-row">
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </div>
+  );
+}
+
+function signalTypeLabel(signalType: string): string {
+  switch (signalType) {
+    case "metric":
+      return "Metric";
+    case "log":
+      return "Log";
+    case "span":
+      return "Span";
+    case "resource":
+      return "Resource";
+    default:
+      return signalType || "Signal";
+  }
+}
+
+function groupIssueVariants(findings: ValidationFinding[]): IssueVariant[] {
+  const variants = new Map<string, IssueVariant>();
+
+  for (const finding of findings) {
+    const key = issueVariantKey(finding);
+    if (variants.has(key)) continue;
+    variants.set(key, {
+      key,
+      message: finding.message,
+      ruleId: finding.ruleId,
+      severity: finding.severity,
+    });
+  }
+
+  return Array.from(variants.values()).sort((left, right) => {
+    const severityDelta = validationSeverityRank(right.severity) - validationSeverityRank(left.severity);
+    if (severityDelta !== 0) return severityDelta;
+    const ruleDelta = left.ruleId.localeCompare(right.ruleId);
+    if (ruleDelta !== 0) return ruleDelta;
+    return left.message.localeCompare(right.message);
+  });
+}
+
+function uniqueRuleIds(variants: IssueVariant[]): string[] {
+  return Array.from(new Set(variants.map((variant) => variant.ruleId)));
+}
+
+function isGenericLogTarget(issue: ValidationIssue): boolean {
+  if (issue.signalType !== "log") return false;
+  return issue.targetLabel === "Log records" || issue.targetLabel.endsWith(" logs");
+}
+
+function issueListRow(issue: ValidationIssue, variants: IssueVariant[]): { issue: string; rule: string } {
+  return {
+    issue: issuePrimaryLabel(issue),
+    rule: issueRuleLabel(variants),
+  };
+}
+
+function issuePrimaryLabel(issue: ValidationIssue): string {
+  switch (normalizeSignalType(issue.signalType)) {
+    case "metric":
+      return uniqueSignalValue(issue.findings, (finding) => finding.signal.metricName) || issue.targetLabel || signalTypeLabel(issue.signalType);
+    case "span":
+      return uniqueSignalValue(issue.findings, (finding) => finding.signal.spanName) || issue.targetLabel || signalTypeLabel(issue.signalType);
+    case "log":
+      return sampleLogBodies(issue.findings)[0] || issue.targetLabel || signalTypeLabel(issue.signalType);
+    case "resource":
+      return uniqueContextValue(issue.findings, "attribute_name") || issue.targetLabel || signalTypeLabel(issue.signalType);
+    default:
+      return issue.targetLabel || signalTypeLabel(issue.signalType);
+  }
+}
+
+function issueResolvedServiceLabel(issue: ValidationIssue): string | null {
+  if (issue.serviceName) {
+    return issue.serviceName;
+  }
+  return uniqueSignalValue(issue.findings, (finding) => finding.signal.serviceName);
+}
+
+function issueRuleLabel(variants: IssueVariant[]): string {
+  const rules = uniqueRuleIds(variants);
+  if (rules.length === 0) return "—";
+  if (rules.length === 1) return rules[0];
+  return `${rules[0]} +${rules.length - 1} more`;
+}
+
+function issueSeverityTotals(issue: ValidationIssue, variants: IssueVariant[]): SeverityTotals {
+  const fallbackCounts: SeverityTotals = {
+    violation: 0,
+    improvement: 0,
+    information: 0,
+  };
+
+  for (const variant of variants) {
+    fallbackCounts[variant.severity] += 1;
+  }
+
+  return {
+    violation: issue.violationCount || fallbackCounts.violation,
+    improvement: issue.improvementCount || fallbackCounts.improvement,
+    information: issue.informationCount || fallbackCounts.information,
+  };
+}
+
+function sampleLogBodies(findings: ValidationFinding[]): string[] {
+  const samples = new Set<string>();
+  for (const finding of findings) {
+    const body = formatLogSample(finding.signal.logBody);
+    if (!body) continue;
+    samples.add(body);
+    if (samples.size >= 5) {
+      break;
+    }
+  }
+  return Array.from(samples);
+}
+
+function uniqueContextValue(findings: ValidationFinding[], key: string): string | null {
+  let value: string | null = null;
+  for (const finding of findings) {
+    const raw = finding.context?.[key];
+    if (raw === undefined || raw === null) {
+      continue;
+    }
+    const next = String(raw);
+    if (!next) {
+      continue;
+    }
+    if (value === null) {
+      value = next;
+      continue;
+    }
+    if (value !== next) {
+      return null;
+    }
+  }
+  return value;
+}
+
+function uniqueSignalValue(findings: ValidationFinding[], getValue: (finding: ValidationFinding) => string | undefined): string | null {
+  let value: string | null = null;
+  for (const finding of findings) {
+    const next = getValue(finding)?.trim();
+    if (!next) {
+      continue;
+    }
+    if (value === null) {
+      value = next;
+      continue;
+    }
+    if (value !== next) {
+      return null;
+    }
+  }
+  return value;
+}
+
+function firstAvailableSignal(issues: ValidationIssue[]): ValidationSignalTab {
+  for (const tab of signalTabs) {
+    if (issues.some((issue) => normalizeSignalType(issue.signalType) === tab.key)) {
+      return tab.key;
+    }
+  }
+  return "metric";
+}
+
+function normalizeSignalType(signalType: string): ValidationSignalTab | "" {
+  switch (signalType) {
+    case "metric":
+    case "span":
+    case "log":
+    case "resource":
+      return signalType;
+    default:
+      return "";
+  }
+}
+
+function formatLogSample(value: string | undefined): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) return "";
+  const match = trimmed.match(/^StringValue\("(.*)"\)$/);
+  return match?.[1] ?? trimmed;
+}
+
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+}
+
+function isMeaningfulTimestamp(value: string | undefined): value is string {
+  return Boolean(value && value !== "0001-01-01T00:00:00Z");
+}
+
+function IssueDetailPanel({ issue, onClose }: { issue: ValidationIssue; onClose: () => void }): React.ReactElement {
+  const issueVariants = groupIssueVariants(issue.findings);
+  const showScope = Boolean(issue.scopeName) && issue.scopeName !== issue.serviceName;
+  const logSamples = issue.signalType === "log" ? sampleLogBodies(issue.findings) : [];
+  const resourceAttribute = issue.signalType === "resource" ? uniqueContextValue(issue.findings, "attribute_name") : null;
+  const resourceStability = issue.signalType === "resource" ? uniqueContextValue(issue.findings, "stability") : null;
+  const rowTitle = issuePrimaryLabel(issue);
+  const hasMetadata = Boolean(
+    (resourceAttribute && resourceAttribute !== rowTitle)
+    || resourceStability
+    || showScope,
+  );
+  const hasIntroSection = issue.signalType === "resource" || hasMetadata || logSamples.length > 0;
+
+  return (
+    <DetailPanel
+      headerMode="close-only"
+      onClose={onClose}
+    >
+      <div className="findings-tab__detail-body">
+        <h3 className="findings-tab__detail-heading">{rowTitle}</h3>
+
+        {issue.signalType === "resource" ? (
+          <p className="findings-tab__detail-note">
+            Resource attributes apply across traces, metrics, and logs emitted by the same service.
+          </p>
+        ) : null}
+
+        {hasMetadata ? (
+          <dl className="findings-tab__detail-grid">
+            {resourceAttribute && resourceAttribute !== rowTitle ? <DetailRow label="Attribute">{resourceAttribute}</DetailRow> : null}
+            {resourceStability ? <DetailRow label="Stability">{resourceStability}</DetailRow> : null}
+            {showScope ? <DetailRow label="Scope">{issue.scopeName}</DetailRow> : null}
+          </dl>
+        ) : null}
+
+        {logSamples.length > 0 ? (
+          <div className="findings-tab__context">
+            <p className="findings-tab__eyebrow">Affected Logs</p>
+            <div className="findings-tab__sample-list">
+              {logSamples.map((sample) => (
+                <div key={sample} className="findings-tab__sample-item">{sample}</div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {issueVariants.length > 0 ? (
+          <div className={hasIntroSection ? "findings-tab__context" : "findings-tab__context findings-tab__context--first"}>
+            <p className="findings-tab__eyebrow">Findings</p>
+            <div className="findings-tab__variant-list">
+              {issueVariants.map((variant) => (
+                <article key={variant.key} className={`validation-item validation-item--${variant.severity}`}>
+                  <div className="validation-item__header">
+                    <span className={`validation-item__severity validation-item__severity--${variant.severity}`}>{variant.severity}</span>
+                    <span className="validation-item__rule">{variant.ruleId}</span>
+                  </div>
+                  <p className="validation-item__message">{variant.message}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </DetailPanel>
+  );
+}

--- a/observer/client/src/components/ValidationBadge.tsx
+++ b/observer/client/src/components/ValidationBadge.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import type { ValidationSeverity } from "../api/types";
+
+interface ValidationBadgeProps {
+  count: number;
+  severity: ValidationSeverity | null;
+  title?: string;
+}
+
+/** Compact badge for showing how many validation findings match an entity. */
+export function ValidationBadge({ count, severity, title }: ValidationBadgeProps): React.ReactElement | null {
+  if (count <= 0) return null;
+  return (
+    <span className={`validation-badge validation-badge--${severity ?? "information"}`} title={title ?? `${count} validation findings`}>
+      {count}
+    </span>
+  );
+}

--- a/observer/client/src/telemetry/useTelemetry.test.tsx
+++ b/observer/client/src/telemetry/useTelemetry.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useTelemetry } from "./useTelemetry";
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.onopen?.();
+    });
+  }
+
+  send(): void {}
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+}
+
+function Harness(): React.ReactElement {
+  const { state, pause, paused, hasNewUpdates } = useTelemetry();
+  return (
+    <>
+      <button type="button" onClick={pause}>pause</button>
+      <output data-testid="snapshot">
+        {JSON.stringify({
+          traces: state.traces.length,
+          metrics: state.metrics.length,
+          logs: state.logs.length,
+          traceCount: state.stats?.traceCount ?? -1,
+          validationFindings: state.validation?.findings.length ?? -1,
+          validationIssueServiceName: state.validation?.issues[0]?.serviceName ?? "none",
+          validationStatus: state.validation?.summary.status ?? "none",
+          paused,
+          hasNewUpdates,
+        })}
+      </output>
+    </>
+  );
+}
+
+describe("useTelemetry", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith("/api/query/traces")) {
+        return new Response(JSON.stringify([{ traceId: "trace-1", rootSpanName: "GET /orders", spanCount: 2, status: "ok" }]), { status: 200 });
+      }
+      if (url.endsWith("/api/query/metrics")) {
+        return new Response(JSON.stringify([{ name: "http.server.duration", type: "histogram", dataPointCount: 1 }]), { status: 200 });
+      }
+      if (url.endsWith("/api/query/logs")) {
+        return new Response(JSON.stringify([{ id: "log-1", timeUnixNano: "1", body: "hello", attributes: {}, resource: { attributes: {} }, scope: { name: "demo" } }]), { status: 200 });
+      }
+      if (url.endsWith("/api/query/stats")) {
+        return new Response(JSON.stringify({ spanCount: 2, dataPointCount: 1, metricNameCount: 1, logCount: 1, traceCount: 1, serviceNames: ["checkout"] }), { status: 200 });
+      }
+      if (url.endsWith("/api/query/validation/summary")) {
+        return new Response(JSON.stringify({
+          enabled: true,
+          ready: true,
+          status: "ready",
+          hasResult: true,
+          stale: false,
+          needsRun: false,
+          totalEntities: 1,
+          totalAdvisories: 1,
+          noAdviceCount: 0,
+          severityCounts: { violation: 1, improvement: 0, information: 0 },
+          highestSeverityCounts: { violation: 1, improvement: 0, information: 0 },
+          signalCounts: { span: 1 },
+          updatedAt: "2026-04-10T00:00:00Z",
+        }), { status: 200 });
+      }
+      if (url.endsWith("/api/query/validation/latest")) {
+        return new Response(JSON.stringify({
+          summary: {
+            enabled: true,
+            ready: true,
+            status: "ready",
+            hasResult: true,
+            stale: false,
+            needsRun: false,
+            totalEntities: 1,
+            totalAdvisories: 1,
+            noAdviceCount: 0,
+            severityCounts: { violation: 1, improvement: 0, information: 0 },
+            highestSeverityCounts: { violation: 1, improvement: 0, information: 0 },
+            signalCounts: { span: 1 },
+            updatedAt: "2026-04-10T00:00:00Z",
+          },
+          findings: [{
+            entityKey: "span:trace-1:span-1",
+            source: "weaver",
+            ruleId: "missing_http_method",
+            severity: "violation",
+            message: "missing http.method",
+            signal: { type: "span", serviceName: "checkout", traceId: "trace-1", spanId: "span-1", spanName: "GET /orders" },
+            updatedAt: "2026-04-10T00:00:00Z",
+          }],
+          issues: [{
+            key: "span:checkout:missing_http_method:GET /orders",
+            severity: "violation",
+            message: "missing http.method",
+            signalType: "span",
+            targetLabel: "GET /orders",
+            count: 1,
+            affectedEntityCount: 1,
+            firstSeen: "2026-04-10T00:00:00Z",
+            lastSeen: "2026-04-10T00:00:00Z",
+            findings: [{
+              entityKey: "span:trace-1:span-1",
+              source: "weaver",
+              ruleId: "missing_http_method",
+              severity: "violation",
+              message: "missing http.method",
+              signal: { type: "span", serviceName: "checkout", traceId: "trace-1", spanId: "span-1", spanName: "GET /orders" },
+              updatedAt: "2026-04-10T00:00:00Z",
+            }],
+          }],
+        }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("hydrates the initial telemetry snapshot from REST before websocket updates arrive", async () => {
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("snapshot").textContent).toContain('"traces":1');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"metrics":1');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"logs":1');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"traceCount":1');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"validationFindings":1');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"validationIssueServiceName":""');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"validationStatus":"ready"');
+    });
+  });
+
+  it("keeps validation live while buffering telemetry updates during pause", async () => {
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("snapshot").textContent).toContain('"paused":false');
+    });
+
+    screen.getByRole("button", { name: "pause" }).click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("snapshot").textContent).toContain('"paused":true');
+    });
+
+    const ws = MockWebSocket.instances.at(-1);
+    expect(ws).toBeTruthy();
+
+    ws?.onmessage?.({
+      data: JSON.stringify({
+        type: "update",
+        signal: "validation",
+        data: {
+          summary: {
+            enabled: true,
+            ready: false,
+            status: "running",
+            hasResult: true,
+            stale: false,
+            needsRun: false,
+            totalEntities: 1,
+            totalAdvisories: 1,
+            noAdviceCount: 0,
+            severityCounts: { violation: 1, improvement: 0, information: 0 },
+            highestSeverityCounts: { violation: 1, improvement: 0, information: 0 },
+            signalCounts: { span: 1 },
+            updatedAt: "2026-04-10T00:00:01Z",
+          },
+          findings: [],
+          issues: [],
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("snapshot").textContent).toContain('"validationStatus":"running"');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"hasNewUpdates":false');
+    });
+
+    ws?.onmessage?.({
+      data: JSON.stringify({
+        type: "update",
+        signal: "metrics",
+        data: [
+          { name: "http.server.duration", type: "histogram", dataPointCount: 1 },
+          { name: "http.server.request.count", type: "counter", dataPointCount: 2 },
+        ],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("snapshot").textContent).toContain('"metrics":1');
+      expect(screen.getByTestId("snapshot").textContent).toContain('"hasNewUpdates":true');
+    });
+  });
+});

--- a/observer/client/src/telemetry/useTelemetry.ts
+++ b/observer/client/src/telemetry/useTelemetry.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { TraceSummary, MetricGroup, LogRecord, Stats } from "../api/types";
+import type { TraceSummary, MetricGroup, LogRecord, Stats, ValidationSnapshot } from "../api/types";
 
 /** Snapshot of all telemetry signals received from the server. */
 export interface TelemetryState {
@@ -8,17 +8,18 @@ export interface TelemetryState {
   metrics: MetricGroup[];
   logs: LogRecord[];
   stats: Stats | null;
+  validation: ValidationSnapshot | null;
 }
 
 /** Controls returned by {@link useTelemetry} for reading and managing live telemetry. */
 export interface TelemetryHandle {
   /** Current telemetry snapshot. */
   state: TelemetryState;
-  /** Whether the WebSocket stream is paused. */
+  /** Whether live telemetry updates are paused. Validation stays live. */
   paused: boolean;
   /** True when updates arrived while paused. */
   hasNewUpdates: boolean;
-  /** Pause the live stream; updates are buffered until resumed. */
+  /** Pause live telemetry updates; traces, metrics, logs, and stats are buffered until resumed. */
   pause: () => void;
   /** Resume the live stream and apply any buffered updates. */
   resume: () => void;
@@ -40,9 +41,123 @@ const emptyState: TelemetryState = {
   metrics: [],
   logs: [],
   stats: null,
+  validation: null,
 };
 
 const RECONNECT_MS = 1000;
+
+async function fetchJSON<T>(path: string): Promise<T> {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function fetchValidationSnapshot(): Promise<ValidationSnapshot | null> {
+  try {
+    const summary = await fetchJSON<ValidationSnapshot["summary"]>("/api/query/validation/summary");
+    if (!summary.hasResult) {
+      return { summary, findings: [], issues: [] };
+    }
+    try {
+      return await fetchJSON<ValidationSnapshot>("/api/query/validation/latest");
+    } catch {
+      return { summary, findings: [], issues: [] };
+    }
+  } catch {
+    return null;
+  }
+}
+
+function normalizeValidationSnapshot(validation: ValidationSnapshot | null): ValidationSnapshot | null {
+  if (!validation) {
+    return null;
+  }
+
+  return {
+    summary: {
+      ...validation.summary,
+      severityCounts: validation.summary?.severityCounts ?? {},
+      highestSeverityCounts: validation.summary?.highestSeverityCounts ?? {},
+      signalCounts: validation.summary?.signalCounts ?? {},
+    },
+    findings: validation.findings ?? [],
+    issues: (validation.issues ?? []).map((issue) => ({
+      ...issue,
+      targetLabel: issue.targetLabel ?? "",
+      serviceName: issue.serviceName ?? "",
+      scopeName: issue.scopeName ?? "",
+      count: issue.count ?? 0,
+      violationCount: issue.violationCount ?? countIssueSeverity(issue.findings ?? [], "violation"),
+      improvementCount: issue.improvementCount ?? countIssueSeverity(issue.findings ?? [], "improvement"),
+      informationCount: issue.informationCount ?? countIssueSeverity(issue.findings ?? [], "information"),
+      affectedEntityCount: issue.affectedEntityCount ?? 0,
+      firstSeen: issue.firstSeen ?? "",
+      lastSeen: issue.lastSeen ?? "",
+      findings: issue.findings ?? [],
+    })),
+  };
+}
+
+function countIssueSeverity(findings: ValidationSnapshot["findings"], severity: "violation" | "improvement" | "information"): number {
+  let count = 0;
+  for (const finding of findings) {
+    if (finding.severity === severity) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function mergeValidationSnapshot(
+  current: ValidationSnapshot | null,
+  incoming: ValidationSnapshot | null,
+): ValidationSnapshot | null {
+  const normalized = normalizeValidationSnapshot(incoming);
+  if (!normalized) {
+    return null;
+  }
+  if (!current) {
+    return normalized;
+  }
+
+  const currentRunID = current.summary.resultRunId ?? "";
+  const nextRunID = normalized.summary.resultRunId ?? "";
+  const preservePinnedResult = current.summary.hasResult
+    && normalized.summary.hasResult
+    && currentRunID !== ""
+    && currentRunID === nextRunID;
+
+  if (!preservePinnedResult) {
+    return normalized;
+  }
+
+  return {
+    ...normalized,
+    findings: current.findings,
+    issues: current.issues,
+  };
+}
+
+async function fetchInitialTelemetryState(): Promise<TelemetryState> {
+  const [tracesResult, metricsResult, logsResult, statsResult, validation] = await Promise.all([
+    fetchJSON<TraceSummary[]>("/api/query/traces").catch(() => []),
+    fetchJSON<MetricGroup[]>("/api/query/metrics").catch(() => []),
+    fetchJSON<LogRecord[]>("/api/query/logs").catch(() => []),
+    fetchJSON<Stats | null>("/api/query/stats").catch(() => null),
+    fetchValidationSnapshot(),
+  ]);
+
+  return {
+    error: null,
+    traces: tracesResult ?? [],
+    metrics: metricsResult ?? [],
+    logs: logsResult ?? [],
+    stats: statsResult ? { ...statsResult, serviceNames: statsResult.serviceNames ?? [] } : null,
+    validation: normalizeValidationSnapshot(validation),
+  };
+}
 
 /**
  * Manages a WebSocket connection to the observer backend and exposes
@@ -77,10 +192,6 @@ export function useTelemetry(): TelemetryHandle {
 
       ws.onopen = () => {
         if (!active) return;
-        // Clear stale state on reconnect so the UI refreshes immediately.
-        setTelemetry(emptyState);
-        bufferRef.current = null;
-        setHasNewUpdates(false);
         // Restore the previous stream mode after reconnect.
         ws.send(JSON.stringify({ type: "subscribe" }));
         if (pausedRef.current) {
@@ -112,10 +223,22 @@ export function useTelemetry(): TelemetryHandle {
       ws.onclose = () => {
         wsRef.current = null;
         if (!active) return;
-        setTelemetry({ ...emptyState, error: "Disconnected. Reconnecting..." });
+        setTelemetry((current) => ({ ...current, error: "Disconnected. Reconnecting..." }));
         bufferRef.current = null;
-        reconnectTimer = setTimeout(connect, RECONNECT_MS);
+        reconnectTimer = setTimeout(() => {
+          void start();
+        }, RECONNECT_MS);
       };
+    }
+
+    async function start() {
+      const snapshot = await fetchInitialTelemetryState();
+      if (!active) return;
+      setTelemetry(snapshot);
+      telemetryRef.current = snapshot;
+      bufferRef.current = null;
+      setHasNewUpdates(false);
+      connect();
     }
 
     function applyUpdate(signal: string, data: unknown) {
@@ -131,21 +254,43 @@ export function useTelemetry(): TelemetryHandle {
             const s = data as Stats;
             return { ...current, stats: s ? { ...s, serviceNames: s.serviceNames ?? [] } : null };
           }
+          case "validation": {
+            const validation = mergeValidationSnapshot(current.validation, data as ValidationSnapshot);
+            return {
+              ...current,
+              validation,
+            };
+          }
           default:
             return current;
         }
       };
 
       if (pausedRef.current) {
+        if (signal === "validation") {
+          setTelemetry((current) => {
+            const next = apply(current);
+            telemetryRef.current = next;
+            return next;
+          });
+          if (bufferRef.current) {
+            bufferRef.current = apply(bufferRef.current);
+          }
+          return;
+        }
         const base = bufferRef.current ?? telemetryRef.current;
         bufferRef.current = apply(base);
         setHasNewUpdates(true);
       } else {
-        setTelemetry(apply);
+        setTelemetry((current) => {
+          const next = apply(current);
+          telemetryRef.current = next;
+          return next;
+        });
       }
     }
 
-    connect();
+    void start();
 
     return () => {
       active = false;

--- a/observer/client/src/traces/SpanDetailsPanel.tsx
+++ b/observer/client/src/traces/SpanDetailsPanel.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import type { Span } from "../api/types";
+import type { Span, ValidationFinding } from "../api/types";
 
 interface SpanDetailsPanelProps {
   span: Span;
+  validationFindings: ValidationFinding[];
 }
 
 type TabId = "info" | "attributes" | "events" | "links";
@@ -17,7 +18,7 @@ function relativeTime(eventNano: string, spanStartNano: string): string {
 }
 
 /** Tabbed detail view for a single span showing info, attributes, events, and links. */
-export function SpanDetailsPanel({ span }: SpanDetailsPanelProps): React.ReactElement {
+export function SpanDetailsPanel({ span, validationFindings }: SpanDetailsPanelProps): React.ReactElement {
   const [activeTab, setActiveTab] = useState<TabId>("info");
 
   const attrCount = Object.keys(span.attributes ?? {}).length;
@@ -67,6 +68,15 @@ export function SpanDetailsPanel({ span }: SpanDetailsPanelProps): React.ReactEl
         {activeTab === "info" ? (
           <div className="span-details__section">
             <div className="span-details__section-body">
+              {validationFindings.length > 0 ? (
+                <div className="span-details__validation">
+                  {validationFindings.map((finding) => (
+                    <div key={`${finding.entityKey}:${finding.ruleId}:${finding.updatedAt}`} className={`validation-inline validation-inline--${finding.severity}`}>
+                      <span>{finding.message}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
               <div className="span-details__detail-row">
                 <span className="span-details__detail-label">Kind</span>
                 <span className="span-details__detail-value">{span.kind}</span>

--- a/observer/client/src/traces/TraceWaterfall.tsx
+++ b/observer/client/src/traces/TraceWaterfall.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useMemo } from "react";
 import type { Span } from "../api/types";
 import { buildWaterfallTree, flattenTree, type WaterfallSpan } from "./waterfall-layout";
+import { ValidationBadge } from "../components/ValidationBadge";
+import type { ValidationIndex } from "../validation/utils";
+import { lookupSpanValidation } from "../validation/utils";
 import { TELEMETRY_SERIES_COLORS } from "../palette";
 
 interface TraceWaterfallProps {
@@ -8,6 +11,7 @@ interface TraceWaterfallProps {
   selectedSpanId: string | null;
   onSelectSpan: (spanId: string) => void;
   traceDurationMs: number;
+  validationIndex: ValidationIndex;
 }
 
 // Consistent service colors — same service always gets same color
@@ -25,7 +29,7 @@ function getServiceColorMap(spans: Span[]): Map<string, string> {
 }
 
 /** Renders a collapsible span waterfall with timing bars and service colors. */
-export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurationMs }: TraceWaterfallProps): React.ReactElement {
+export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurationMs, validationIndex }: TraceWaterfallProps): React.ReactElement {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
   const serviceColors = useMemo(() => getServiceColorMap(spans), [spans]);
@@ -87,6 +91,8 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
           const hasChildren = s.children.length > 0;
           const svcColor = serviceColors.get(s.resource?.serviceName ?? "unknown") ?? TELEMETRY_SERIES_COLORS[0];
           const childCount = countDescendants(s);
+          const validation = lookupSpanValidation(validationIndex, s.traceId, s.spanId);
+
           return (
             <div
               key={s.spanId}
@@ -107,6 +113,7 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
                 <span className="waterfall__service-dot" style={{ background: svcColor }} />
                 <span className="waterfall__service-name">{s.resource?.serviceName ?? ""}</span>
                 <span className="waterfall__span-name">{s.name}</span>
+                <ValidationBadge count={validation?.count ?? 0} severity={validation?.highestSeverity ?? null} />
               </div>
               <div className="waterfall__row-timeline">
                 <div

--- a/observer/client/src/traces/TracesTab.style.test.tsx
+++ b/observer/client/src/traces/TracesTab.style.test.tsx
@@ -58,6 +58,8 @@ describe("TracesTab row layout", () => {
         ]}
         telemetryError={null}
         onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,
     );
 
@@ -77,6 +79,7 @@ describe("TracesTab row layout", () => {
     expect(container.querySelector(".trace-row__trace-id")?.textContent).toBe("trace-1234567890ab");
     expect(container.querySelector(".trace-row__service")?.classList.contains("explorer-row__secondary")).toBe(true);
     expect(container.querySelector(".data-table__td--service")?.textContent).toBe("checkout");
+    expect(container.querySelector(".validation-badge")).toBeNull();
     expect(container.querySelector(".data-table__td--status")?.textContent).toContain("error");
     expect(container.querySelector(".data-table__td--duration .explorer-row__numeric")).toBeTruthy();
   });
@@ -90,6 +93,8 @@ describe("TracesTab row layout", () => {
         ]}
         telemetryError={null}
         onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,
     );
 
@@ -115,7 +120,7 @@ describe("TracesTab row layout", () => {
     expect(traceStatusLabel("weird")).toBe("unknown");
   });
 
-  it("renders span detail info without validation overlays", () => {
+  it("does not render validation rule ids in the span detail panel", () => {
     render(
       <SpanDetailsPanel
         span={{
@@ -134,11 +139,28 @@ describe("TracesTab row layout", () => {
           resource: { serviceName: "checkout", attributes: {} },
           scope: { name: "otel", version: "" },
         }}
+        validationFindings={[
+          {
+            entityKey: "span:trace-1:span-1",
+            source: "weaver",
+            ruleId: "invalid_format",
+            severity: "violation",
+            message: "Attribute 'traceId' does not match name formatting rules.",
+            signal: {
+              type: "span",
+              serviceName: "checkout",
+              traceId: "trace-1",
+              spanId: "span-1",
+              spanName: "GET /orders",
+            },
+            updatedAt: "2026-04-11T12:00:00Z",
+          },
+        ]}
       />,
     );
 
-    expect(screen.getByText("Kind")).toBeTruthy();
-    expect(screen.queryByText("Validation")).toBeNull();
+    expect(screen.getByText("Attribute 'traceId' does not match name formatting rules.")).toBeTruthy();
+    expect(screen.queryByText("invalid_format")).toBeNull();
   });
 
   it("uses bounded per-tab column caps with trailing spacer tracks", () => {
@@ -187,7 +209,7 @@ describe("TracesTab row layout", () => {
     expect(css).toContain(".findings-tab__head .data-table__th {\n  padding: 0 6px;\n  min-width: 0;\n  overflow: hidden;\n  text-overflow: ellipsis;\n}");
   });
 
-  it("uses the same vertical centering model for metric master cells", () => {
+  it("uses the same vertical centering model for metric and validation master cells", () => {
     const { readFileSync } = require("fs");
     const { resolve } = require("path");
     const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
@@ -195,5 +217,8 @@ describe("TracesTab row layout", () => {
     expect(css).toContain(".data-table__cell-content {\n  display: flex;\n  align-items: center;\n  justify-content: flex-start;\n  width: 100%;\n  min-width: 0;\n}");
     expect(css).toContain(".data-table__cell-content--meta {\n  gap: 8px;\n}");
     expect(css).toContain(".data-table__td--metric-meta {\n  display: flex;\n  align-items: center;\n  justify-content: flex-start;\n  min-width: 0;\n}");
+    expect(css).toContain(".findings-tab__item-title {\n  display: flex;\n  align-items: center;");
+    expect(css).toContain(".findings-tab__item-rule {\n  display: flex;\n  align-items: center;");
+    expect(css).toContain(".findings-tab__item-count {\n  display: flex;\n  align-items: center;\n  justify-content: flex-end;");
   });
 });

--- a/observer/client/src/traces/TracesTab.test.tsx
+++ b/observer/client/src/traces/TracesTab.test.tsx
@@ -30,6 +30,8 @@ describe("TracesTab", () => {
         ]}
         telemetryError={null}
         onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,
     );
 
@@ -51,6 +53,8 @@ describe("TracesTab", () => {
         ]}
         telemetryError={null}
         onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,
     );
 

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -1,20 +1,24 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import type { TraceSummary, TraceDetail } from "../api/types";
+import type { TraceSummary, TraceDetail, ValidationFinding } from "../api/types";
 import { fetchTraceDetail } from "../api/client";
 import { DetailPanel } from "../layout";
 import { TraceWaterfall } from "./TraceWaterfall";
 import { SpanDetailsPanel } from "./SpanDetailsPanel";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import type { ValidationIndex } from "../validation/utils";
+import { lookupSpanValidation } from "../validation/utils";
 
 interface TracesTabProps {
   traces: TraceSummary[];
   telemetryError: string | null;
   onInteract?: () => void;
+  validationFindings: ValidationFinding[];
+  validationIndex: ValidationIndex;
 }
 
 /** Traces tab with virtualized table and waterfall detail panel. */
-export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps): React.ReactElement {
+export function TracesTab({ traces, telemetryError, onInteract, validationFindings, validationIndex }: TracesTabProps): React.ReactElement {
   const [query, setQuery] = useState("");
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
   const [traceDetail, setTraceDetail] = useState<TraceDetail | null>(null);
@@ -126,6 +130,10 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
   });
 
   const selectedSpan = traceDetail?.spans.find((s) => s.spanId === selectedSpanId) ?? null;
+  const selectedSpanValidation = useMemo(
+    () => (selectedSpan ? lookupSpanValidation(validationIndex, selectedSpan.traceId, selectedSpan.spanId)?.findings ?? [] : []),
+    [selectedSpan, validationIndex],
+  );
   const errorSpanCount = traceDetail?.spans.filter((s) => s.status.code === "ERROR").length ?? 0;
 
   const hasDetail = Boolean(selectedTraceId && (traceDetail || detailLoading || detailError));
@@ -233,8 +241,9 @@ export function TracesTab({ traces, telemetryError, onInteract }: TracesTabProps
                 selectedSpanId={selectedSpanId}
                 onSelectSpan={setSelectedSpanId}
                 traceDurationMs={traceDetail.durationMs ?? 0}
+                validationIndex={validationIndex}
               />
-              {selectedSpan ? <SpanDetailsPanel span={selectedSpan} /> : null}
+              {selectedSpan ? <SpanDetailsPanel span={selectedSpan} validationFindings={selectedSpanValidation} /> : null}
             </DetailPanel>
           </div>
         ) : selectedTraceId && detailLoading ? (

--- a/observer/client/src/validation/utils.test.ts
+++ b/observer/client/src/validation/utils.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, it } from "vitest";
+import type { LogRecord, ValidationFinding, ValidationIssue } from "../api/types";
+import { buildValidationIndex, buildValidationIssues, filterValidationFindings, filterValidationIssues, formatSignalLabel, groupValidationIssues, issueVariantKey, lookupLogValidation, lookupMetricValidation, lookupSpanValidation, lookupTraceValidation, validationSeverityRank } from "./utils";
+
+function finding(overrides: Partial<ValidationFinding>): ValidationFinding {
+  return {
+    entityKey: "entity",
+    source: "weaver",
+    ruleId: "missing_attribute",
+    severity: "violation",
+    message: "missing attribute",
+    signal: { type: "span", serviceName: "checkout", traceId: "trace-1", spanId: "span-1", spanName: "GET /orders" },
+    updatedAt: "2026-04-09T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function logRecord(): LogRecord {
+  return {
+    id: "log-1",
+    body: "bad request",
+    timeUnixNano: "2026-04-09T00:00:00Z",
+    attributes: {},
+    resource: { serviceName: "checkout", attributes: {} },
+    scope: { name: "test" },
+    traceId: "trace-1",
+    spanId: "span-1",
+  };
+}
+
+describe("buildValidationIndex", () => {
+  it("indexes spans, traces, metrics, and logs", () => {
+    const index = buildValidationIndex([
+      finding({}),
+      finding({ signal: { type: "metric", serviceName: "checkout", metricName: "http.server.duration" } }),
+      finding({ signal: { type: "log", serviceName: "checkout", traceId: "trace-1", spanId: "span-1", logBody: "bad request" } }),
+    ]);
+
+    expect(lookupTraceValidation(index, "trace-1")?.count).toBe(2);
+    expect(lookupSpanValidation(index, "trace-1", "span-1")?.count).toBe(2);
+    expect(lookupMetricValidation(index, "http.server.duration", "checkout")?.count).toBe(1);
+    expect(lookupLogValidation(index, logRecord())?.count).toBe(1);
+  });
+});
+
+describe("filterValidationFindings", () => {
+  it("filters by severity and query text", () => {
+    const findings = [
+      finding({ severity: "violation", message: "missing http.method" }),
+      finding({ severity: "improvement", message: "deprecated attribute" }),
+    ];
+
+    expect(filterValidationFindings(findings, {
+      signalType: "",
+      severity: "violation",
+      query: "method",
+    })).toHaveLength(1);
+  });
+
+  it("treats span_event as span and searches service text", () => {
+    const findings = [
+      finding({
+        ruleId: "log_scope_missing",
+        signal: {
+          type: "span_event",
+          serviceName: "checkout-api",
+          traceId: "trace-1",
+          spanId: "span-1",
+          spanName: "GET /orders",
+        },
+      }),
+    ];
+
+    expect(filterValidationFindings(findings, {
+      signalType: "span",
+      severity: "",
+      query: "checkout-api",
+    })).toHaveLength(1);
+  });
+});
+
+describe("formatSignalLabel", () => {
+  it("returns a human-friendly signal label", () => {
+    expect(formatSignalLabel(finding({}))).toBe("GET /orders");
+    expect(formatSignalLabel(finding({ signal: { type: "metric", metricName: "http.server.duration" } }))).toBe("http.server.duration");
+  });
+});
+
+describe("buildValidationIssues", () => {
+  it("collapses repeated span findings into a stable issue", () => {
+    const issues = buildValidationIssues([
+      finding({
+        entityKey: "span:trace-1:span-1",
+        updatedAt: "2026-04-09T00:00:00Z",
+        signal: { type: "span", serviceName: "checkout", traceId: "trace-1", spanId: "span-1", spanName: "GET /orders" },
+      }),
+      finding({
+        entityKey: "span:trace-2:span-2",
+        updatedAt: "2026-04-09T00:01:00Z",
+        signal: { type: "span", serviceName: "checkout", traceId: "trace-2", spanId: "span-2", spanName: "GET /orders" },
+      }),
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.targetLabel).toBe("GET /orders");
+    expect(issues[0]?.count).toBe(1);
+    expect(issues[0]?.affectedEntityCount).toBe(2);
+    expect(issues[0]?.firstSeen).toBe("2026-04-09T00:00:00Z");
+    expect(issues[0]?.lastSeen).toBe("2026-04-09T00:01:00Z");
+  });
+
+  it("keeps span issues grouped even when validator context differs", () => {
+    const issues = buildValidationIssues([
+      finding({
+        ruleId: "deprecated",
+        message: "Attribute 'db.connection_string' is deprecated",
+        context: { attribute_name: "db.connection_string" },
+        signal: { type: "span", serviceName: "checkout", traceId: "trace-1", spanId: "span-1", spanName: "SELECT users" },
+      }),
+      finding({
+        ruleId: "deprecated",
+        message: "Attribute 'db.user' is deprecated",
+        context: { attribute_name: "db.user" },
+        signal: { type: "span", serviceName: "checkout", traceId: "trace-2", spanId: "span-2", spanName: "SELECT users" },
+      }),
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.count).toBe(2);
+  });
+
+  it("keeps non body-specific log rules grouped without trace ids", () => {
+    const issues = buildValidationIssues([
+      finding({
+        entityKey: "log:trace-1",
+        ruleId: "log_scope_missing",
+        signal: { type: "log", serviceName: "checkout", scopeName: "demo.logger", traceId: "trace-1", spanId: "span-1", logBody: "bad request" },
+      }),
+      finding({
+        entityKey: "log:trace-2",
+        ruleId: "log_scope_missing",
+        signal: { type: "log", serviceName: "checkout", scopeName: "demo.logger", traceId: "trace-2", spanId: "span-2", logBody: "failed request" },
+      }),
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.targetLabel).toBe("checkout logs");
+    expect(issues[0]?.count).toBe(1);
+  });
+
+  it("groups metric findings by target even when they have different rules", () => {
+    const issues = buildValidationIssues([
+      finding({
+        ruleId: "unexpected_instrument",
+        message: "Instrument should be 'updowncounter', but found 'gauge'.",
+        signal: { type: "metric", serviceName: "checkout", scopeName: "otel", metricName: "jvm.thread.count" },
+      }),
+      finding({
+        ruleId: "unit_mismatch",
+        message: "Unit should be '{thread}', but found ''.",
+        signal: { type: "metric", serviceName: "checkout", scopeName: "otel", metricName: "jvm.thread.count" },
+        updatedAt: "2026-04-09T00:01:00Z",
+      }),
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.targetLabel).toBe("jvm.thread.count");
+    expect(issues[0]?.findings).toHaveLength(2);
+    expect(issues[0]?.violationCount).toBe(2);
+    expect(issues[0]?.improvementCount).toBe(0);
+    expect(issues[0]?.informationCount).toBe(0);
+  });
+
+  it("counts distinct corrective variants instead of raw repeated findings", () => {
+    const issues = buildValidationIssues([
+      finding({
+        entityKey: "metric:orders:http.server.request.count",
+        ruleId: "missing_metric",
+        message: "Metric does not exist in the registry.",
+        signal: { type: "metric", metricName: "http.server.request.count" },
+      }),
+      finding({
+        entityKey: "metric:payments:http.server.request.count",
+        ruleId: "missing_metric",
+        message: "Metric does not exist in the registry.",
+        signal: { type: "metric", metricName: "http.server.request.count" },
+        updatedAt: "2026-04-09T00:01:00Z",
+      }),
+      finding({
+        entityKey: "metric:payments:http.server.request.count",
+        ruleId: "missing_description",
+        severity: "improvement",
+        message: "Metric needs a description.",
+        signal: { type: "metric", metricName: "http.server.request.count" },
+        updatedAt: "2026-04-09T00:02:00Z",
+      }),
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.count).toBe(2);
+    expect(issues[0]?.violationCount).toBe(1);
+    expect(issues[0]?.improvementCount).toBe(1);
+    expect(issues[0]?.affectedEntityCount).toBe(2);
+  });
+
+  it("uses a unique resource attribute name as the target label", () => {
+    const issues = buildValidationIssues([
+      finding({
+        entityKey: "resource:",
+        ruleId: "not_stable",
+        message: "Attribute 'deployment.environment.name' is not stable; stability = development.",
+        signal: { type: "resource" },
+        context: {
+          attribute_name: "deployment.environment.name",
+          stability: "development",
+        },
+      }),
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.targetLabel).toBe("deployment.environment.name");
+  });
+
+  it("preserves encounter order when rebuilding issues locally", () => {
+    const issues = buildValidationIssues([
+      finding({
+        entityKey: "metric:checkout:metric-a",
+        ruleId: "rule-a-1",
+        signal: { type: "metric", serviceName: "checkout", metricName: "metric-a" },
+      }),
+      finding({
+        entityKey: "metric:checkout:metric-a",
+        ruleId: "rule-a-2",
+        severity: "information",
+        signal: { type: "metric", serviceName: "checkout", metricName: "metric-a" },
+        updatedAt: "2026-04-09T00:01:00Z",
+      }),
+      finding({
+        entityKey: "metric:checkout:metric-b",
+        ruleId: "rule-b-1",
+        signal: { type: "metric", serviceName: "checkout", metricName: "metric-b" },
+      }),
+      finding({
+        entityKey: "metric:checkout:metric-b",
+        ruleId: "rule-b-2",
+        severity: "improvement",
+        signal: { type: "metric", serviceName: "checkout", metricName: "metric-b" },
+        updatedAt: "2026-04-09T00:01:00Z",
+      }),
+      finding({
+        entityKey: "metric:checkout:metric-c",
+        ruleId: "rule-c-1",
+        signal: { type: "metric", serviceName: "checkout", metricName: "metric-c" },
+      }),
+      finding({
+        entityKey: "metric:checkout:metric-c",
+        ruleId: "rule-c-2",
+        signal: { type: "metric", serviceName: "checkout", metricName: "metric-c" },
+        updatedAt: "2026-04-09T00:01:00Z",
+      }),
+    ]);
+
+    expect(issues.map((issue) => issue.targetLabel)).toEqual(["metric-a", "metric-b", "metric-c"]);
+  });
+});
+
+describe("issueVariantKey", () => {
+  it("normalizes context order when building a variant key", () => {
+    const left = issueVariantKey(finding({
+      context: {
+        b: "2",
+        a: "1",
+      },
+    }));
+    const right = issueVariantKey(finding({
+      context: {
+        a: "1",
+        b: "2",
+      },
+    }));
+
+    expect(left).toBe(right);
+  });
+});
+
+describe("groupValidationIssues", () => {
+  it("groups issues by service while preserving encounter order", () => {
+    const groups = groupValidationIssues(buildValidationIssues([
+      finding({ signal: { type: "metric", serviceName: "checkout", metricName: "http.server.duration" } }),
+      finding({ signal: { type: "metric", serviceName: "checkout", metricName: "db.client.duration" }, severity: "improvement" }),
+      finding({ signal: { type: "log", serviceName: "payments", scopeName: "demo.logger", logBody: "failed charge" } }),
+    ]), "service");
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]?.label).toBe("checkout");
+    expect(groups[0]?.issueCount).toBe(2);
+    expect(groups[1]?.label).toBe("payments");
+  });
+
+  it("groups issues by severity while preserving encounter order", () => {
+    const groups = groupValidationIssues(buildValidationIssues([
+      finding({ severity: "information", ruleId: "info_rule", signal: { type: "metric", serviceName: "checkout", metricName: "queue.depth" } }),
+      finding({ severity: "violation", ruleId: "violation_rule", signal: { type: "span", serviceName: "checkout", traceId: "trace-1", spanId: "span-1", spanName: "GET /orders" } }),
+      finding({ severity: "improvement", ruleId: "improvement_rule", signal: { type: "log", serviceName: "checkout", scopeName: "demo.logger", logBody: "warn" } }),
+    ]), "severity");
+
+    expect(groups.map((group) => group.label)).toEqual(["Information", "Violations", "Improvements"]);
+  });
+});
+
+describe("filterValidationIssues", () => {
+  it("does not crash when backend issues omit optional strings", () => {
+    const issues = [
+      {
+        key: "metric::otel:jvm.thread.count",
+        severity: "violation",
+        message: "Unit should be '{thread}', but found ''.",
+        signalType: "metric",
+        targetLabel: "jvm.thread.count",
+        count: 1,
+        affectedEntityCount: 1,
+        firstSeen: "2026-04-10T00:00:00Z",
+        lastSeen: "2026-04-10T00:00:00Z",
+        findings: [],
+      } as unknown as ValidationIssue,
+    ];
+
+    expect(() => filterValidationIssues(issues, { signalType: "", severity: "", query: "" })).not.toThrow();
+  });
+
+  it("preserves backend row order when filtering within existing grouped issues", () => {
+    const issues = [
+      {
+        key: "metric:first",
+        severity: "violation",
+        message: "first",
+        signalType: "metric",
+        targetLabel: "first",
+        serviceName: "checkout",
+        scopeName: "",
+        count: 2,
+        violationCount: 1,
+        improvementCount: 1,
+        informationCount: 0,
+        affectedEntityCount: 1,
+        firstSeen: "2026-04-10T00:00:00Z",
+        lastSeen: "2026-04-10T00:01:00Z",
+        findings: [
+          finding({
+            entityKey: "metric:first",
+            ruleId: "first-v",
+            signal: { type: "metric", serviceName: "checkout", metricName: "first" },
+          }),
+          finding({
+            entityKey: "metric:first",
+            ruleId: "first-i",
+            severity: "improvement",
+            signal: { type: "metric", serviceName: "checkout", metricName: "first" },
+            updatedAt: "2026-04-10T00:01:00Z",
+          }),
+        ],
+      },
+      {
+        key: "metric:second",
+        severity: "violation",
+        message: "second",
+        signalType: "metric",
+        targetLabel: "second",
+        serviceName: "checkout",
+        scopeName: "",
+        count: 2,
+        violationCount: 1,
+        improvementCount: 0,
+        informationCount: 1,
+        affectedEntityCount: 1,
+        firstSeen: "2026-04-10T00:00:00Z",
+        lastSeen: "2026-04-10T00:01:00Z",
+        findings: [
+          finding({
+            entityKey: "metric:second",
+            ruleId: "second-v",
+            signal: { type: "metric", serviceName: "checkout", metricName: "second" },
+          }),
+          finding({
+            entityKey: "metric:second",
+            ruleId: "second-info",
+            severity: "information",
+            signal: { type: "metric", serviceName: "checkout", metricName: "second" },
+            updatedAt: "2026-04-10T00:01:00Z",
+          }),
+        ],
+      },
+    ] satisfies ValidationIssue[];
+
+    const filtered = filterValidationIssues(issues, { signalType: "", severity: "violation", query: "" });
+    expect(filtered.map((issue) => issue.targetLabel)).toEqual(["first", "second"]);
+  });
+});
+
+describe("validationSeverityRank", () => {
+  it("ranks higher severities above lower severities", () => {
+    expect(validationSeverityRank("violation")).toBeGreaterThan(validationSeverityRank("improvement"));
+    expect(validationSeverityRank("improvement")).toBeGreaterThan(validationSeverityRank("information"));
+  });
+});

--- a/observer/client/src/validation/utils.ts
+++ b/observer/client/src/validation/utils.ts
@@ -1,0 +1,545 @@
+import type { LogRecord, ValidationFinding, ValidationIssue, ValidationSeverity } from "../api/types";
+
+export interface ValidationMatch {
+  count: number;
+  highestSeverity: ValidationSeverity | null;
+  findings: ValidationFinding[];
+}
+
+export interface ValidationIndex {
+  trace: Map<string, ValidationMatch>;
+  span: Map<string, ValidationMatch>;
+  metric: Map<string, ValidationMatch>;
+  log: Map<string, ValidationMatch>;
+}
+
+export interface ValidationFilters {
+  signalType: string;
+  severity: string;
+  query: string;
+}
+
+export type ValidationGroupBy = "severity" | "service" | "rule" | "signal";
+
+export interface ValidationIssueGroup {
+  key: string;
+  label: string;
+  issueCount: number;
+  occurrenceCount: number;
+  highestSeverity: ValidationSeverity | null;
+  issues: ValidationIssue[];
+}
+
+export function buildValidationIndex(findings: ValidationFinding[]): ValidationIndex {
+  const trace = new Map<string, ValidationMatch>();
+  const span = new Map<string, ValidationMatch>();
+  const metric = new Map<string, ValidationMatch>();
+  const log = new Map<string, ValidationMatch>();
+
+  for (const finding of findings) {
+    if (finding.signal.traceId) addMatch(trace, finding.signal.traceId, finding);
+    if (finding.signal.spanId) {
+      addMatch(span, `${finding.signal.traceId ?? ""}:${finding.signal.spanId}`, finding);
+      addMatch(span, finding.signal.spanId, finding);
+    }
+    if (finding.signal.metricName) {
+      addMatch(metric, `${finding.signal.serviceName ?? ""}:${finding.signal.metricName}`, finding);
+      addMatch(metric, `:${finding.signal.metricName}`, finding);
+    }
+    if (finding.signal.logBody) {
+      addMatch(log, logKey({
+        body: finding.signal.logBody,
+        resource: { serviceName: finding.signal.serviceName, attributes: {} },
+        traceId: finding.signal.traceId,
+        spanId: finding.signal.spanId,
+      }), finding);
+      addMatch(log, `${finding.signal.serviceName ?? ""}:::${finding.signal.logBody}`, finding);
+    }
+  }
+
+  return { trace, span, metric, log };
+}
+
+export function lookupTraceValidation(index: ValidationIndex, traceId: string): ValidationMatch | null {
+  return index.trace.get(traceId) ?? null;
+}
+
+export function lookupSpanValidation(index: ValidationIndex, traceId: string, spanId: string): ValidationMatch | null {
+  return index.span.get(`${traceId}:${spanId}`) ?? index.span.get(spanId) ?? null;
+}
+
+export function lookupMetricValidation(index: ValidationIndex, metricName: string, serviceName?: string): ValidationMatch | null {
+  return index.metric.get(`${serviceName ?? ""}:${metricName}`) ?? index.metric.get(`:${metricName}`) ?? null;
+}
+
+export function lookupLogValidation(index: ValidationIndex, logRecord: LogRecord): ValidationMatch | null {
+  return index.log.get(logKey(logRecord)) ?? index.log.get(`${logRecord.resource?.serviceName ?? ""}:::${logRecord.body}`) ?? null;
+}
+
+export function filterValidationFindings(findings: ValidationFinding[], filters: ValidationFilters): ValidationFinding[] {
+  const signalType = normalizeSignalType(filters.signalType);
+  const severity = filters.severity.toLowerCase();
+  const query = filters.query.toLowerCase();
+
+  return findings.filter((finding) => {
+    if (signalType && normalizeSignalType(finding.signal.type) !== signalType) return false;
+    if (severity && finding.severity.toLowerCase() !== severity) return false;
+    if (query) {
+      const haystack = [
+        finding.message,
+        finding.signal.type,
+        finding.signal.serviceName,
+        finding.signal.scopeName,
+        finding.signal.spanName,
+        finding.signal.metricName,
+        finding.signal.logBody,
+        finding.signal.traceId,
+        finding.signal.spanId,
+      ].join(" ").toLowerCase();
+      if (!haystack.includes(query)) return false;
+    }
+    return true;
+  });
+}
+
+export function formatSignalLabel(finding: ValidationFinding): string {
+  switch (normalizeSignalType(finding.signal.type)) {
+    case "span":
+      return finding.signal.spanName || finding.signal.spanId || "span";
+    case "metric":
+      return finding.signal.metricName || "metric";
+    case "log":
+      return finding.signal.logBody || "log";
+    case "resource":
+      return finding.signal.serviceName || "resource";
+    default:
+      return finding.signal.type || "signal";
+  }
+}
+
+export function buildValidationIssues(findings: ValidationFinding[]): ValidationIssue[] {
+  const issues = new Map<string, { issue: ValidationIssue; entityKeys: Set<string> }>();
+
+  for (const finding of findings) {
+    const key = issueKey(finding);
+    const existing = issues.get(key);
+    if (!existing) {
+      issues.set(key, {
+        issue: {
+          key,
+          severity: finding.severity,
+          message: finding.message,
+          signalType: normalizeSignalType(finding.signal.type),
+          targetLabel: issueTargetLabel(finding),
+          serviceName: finding.signal.serviceName ?? "",
+          scopeName: finding.signal.scopeName ?? "",
+          count: 0,
+          violationCount: 0,
+          improvementCount: 0,
+          informationCount: 0,
+          affectedEntityCount: 1,
+          firstSeen: finding.updatedAt,
+          lastSeen: finding.updatedAt,
+          findings: [finding],
+        },
+        entityKeys: new Set([finding.entityKey]),
+      });
+      continue;
+    }
+
+    existing.issue.findings.push(finding);
+    existing.issue.severity = highestSeverity(existing.issue.severity, finding.severity);
+
+    if (compareTimestamp(finding.updatedAt, existing.issue.firstSeen) < 0) {
+      existing.issue.firstSeen = finding.updatedAt;
+    }
+    if (compareTimestamp(finding.updatedAt, existing.issue.lastSeen) >= 0) {
+      existing.issue.lastSeen = finding.updatedAt;
+      existing.issue.message = finding.message;
+    }
+
+    existing.entityKeys.add(finding.entityKey);
+    existing.issue.affectedEntityCount = existing.entityKeys.size;
+  }
+
+  return Array.from(issues.values())
+    .map(({ issue }) => {
+      const findings = sortValidationFindings(issue.findings);
+      const totals = distinctIssueCounts(findings);
+      return {
+        ...issue,
+        targetLabel: issueDisplayTarget(issue),
+        count: totals.total,
+        violationCount: totals.violation,
+        improvementCount: totals.improvement,
+        informationCount: totals.information,
+        findings,
+      };
+    });
+}
+
+export function filterValidationIssues(issues: ValidationIssue[], filters: ValidationFilters): ValidationIssue[] {
+  const signalType = normalizeSignalType(filters.signalType);
+  const severity = filters.severity.toLowerCase();
+  const query = filters.query.toLowerCase();
+
+  return issues
+    .flatMap((issue) => {
+      if (signalType && normalizeSignalType(issue.signalType) !== signalType) {
+        return [];
+      }
+      if (!severity && !query) {
+        return [issue];
+      }
+      const filteredFindings = filterValidationFindings(issue.findings, filters);
+      if (filteredFindings.length === 0) {
+        return [];
+      }
+      return buildValidationIssues(filteredFindings);
+    });
+}
+
+export function groupValidationIssues(issues: ValidationIssue[], groupBy: ValidationGroupBy): ValidationIssueGroup[] {
+  const groups = new Map<string, ValidationIssueGroup>();
+
+  for (const issue of issues) {
+    const descriptor = issueGroupDescriptor(issue, groupBy);
+    const existing = groups.get(descriptor.key);
+    if (existing) {
+      existing.issueCount += 1;
+      existing.occurrenceCount += issue.count;
+      existing.highestSeverity = highestSeverity(existing.highestSeverity, issue.severity);
+      existing.issues.push(issue);
+      continue;
+    }
+
+    groups.set(descriptor.key, {
+      key: descriptor.key,
+      label: descriptor.label,
+      issueCount: 1,
+      occurrenceCount: issue.count,
+      highestSeverity: issue.severity,
+      issues: [issue],
+    });
+  }
+
+  return Array.from(groups.values())
+    .map((group) => ({
+      ...group,
+      issues: [...group.issues],
+    }));
+}
+
+export function validationSeverityRank(severity: ValidationSeverity): number {
+  switch (severity) {
+    case "violation":
+      return 3;
+    case "improvement":
+      return 2;
+    case "information":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function addMatch(map: Map<string, ValidationMatch>, key: string, finding: ValidationFinding): void {
+  if (!key) return;
+  const existing = map.get(key);
+  if (existing) {
+    existing.count += 1;
+    existing.findings.push(finding);
+    existing.highestSeverity = highestSeverity(existing.highestSeverity, finding.severity);
+    return;
+  }
+  map.set(key, {
+    count: 1,
+    highestSeverity: finding.severity,
+    findings: [finding],
+  });
+}
+
+function highestSeverity(current: ValidationSeverity | null, next: ValidationSeverity): ValidationSeverity {
+  if (!current) return next;
+  if (validationSeverityRank(next) > validationSeverityRank(current)) return next;
+  return current;
+}
+
+function sortValidationFindings(findings: ValidationFinding[]): ValidationFinding[] {
+  return [...findings].sort((left, right) => {
+    const severityDelta = validationSeverityRank(right.severity) - validationSeverityRank(left.severity);
+    if (severityDelta !== 0) return severityDelta;
+
+    const serviceDelta = (left.signal.serviceName ?? "").localeCompare(right.signal.serviceName ?? "");
+    if (serviceDelta !== 0) return serviceDelta;
+
+    const labelDelta = formatSignalLabel(left).localeCompare(formatSignalLabel(right));
+    if (labelDelta !== 0) return labelDelta;
+
+    return right.updatedAt.localeCompare(left.updatedAt);
+  });
+}
+
+function issueKey(finding: ValidationFinding): string {
+  const signalType = normalizeSignalType(finding.signal.type);
+  const serviceName = finding.signal.serviceName ?? "";
+  const scopeName = finding.signal.scopeName ?? "";
+
+  switch (signalType) {
+    case "span":
+      return `span:${serviceName}:${finding.ruleId}:${finding.signal.spanName ?? ""}`;
+    case "metric":
+      return `metric:${serviceName}:${scopeName}:${finding.signal.metricName ?? ""}`;
+    case "log":
+      return isBodySpecificLogRule(finding)
+        ? `log:${serviceName}:${scopeName}:${finding.ruleId}:${finding.signal.logBody ?? ""}`
+        : `log:${serviceName}:${scopeName}:${finding.ruleId}`;
+    case "resource":
+      return `resource:${serviceName}:${finding.ruleId}`;
+    default:
+      return `${signalType}:${serviceName}:${scopeName}:${finding.ruleId}:${issueTargetLabel(finding)}`;
+  }
+}
+
+function issueTargetLabel(finding: ValidationFinding): string {
+  switch (normalizeSignalType(finding.signal.type)) {
+    case "span":
+      return finding.signal.spanName || "Unnamed span";
+    case "metric":
+      return finding.signal.metricName || "Unnamed metric";
+    case "log":
+      if (isBodySpecificLogRule(finding) && finding.signal.logBody) {
+        return finding.signal.logBody;
+      }
+      if (finding.signal.serviceName) {
+        return `${finding.signal.serviceName} logs`;
+      }
+      return finding.signal.scopeName ? `${finding.signal.scopeName} logs` : "Log records";
+    case "resource":
+      return finding.signal.serviceName || "Resource";
+    default:
+      return formatSignalLabel(finding);
+  }
+}
+
+function issueDisplayTarget(issue: ValidationIssue): string {
+  switch (normalizeSignalType(issue.signalType)) {
+    case "resource": {
+      const attributeName = uniqueFindingContextValue(issue.findings, "attribute_name");
+      return attributeName ?? issue.targetLabel;
+    }
+    case "log":
+      if (issue.targetLabel === "Log records") {
+        return uniqueLogBody(issue.findings) ?? issue.targetLabel;
+      }
+      return issue.targetLabel;
+    default:
+      return issue.targetLabel;
+  }
+}
+
+function isBodySpecificLogRule(finding: ValidationFinding): boolean {
+  if (normalizeSignalType(finding.signal.type) !== "log") return false;
+  const haystack = [
+    finding.ruleId,
+    finding.message,
+    ...Object.keys(finding.context ?? {}),
+    ...Object.values(finding.context ?? {}).map((value) => String(value)),
+  ].join(" ").toLowerCase();
+  return haystack.includes("log body") || haystack.includes("log.body") || haystack.includes("body") || haystack.includes("message");
+}
+
+function issueGroupDescriptor(issue: ValidationIssue, groupBy: ValidationGroupBy): { key: string; label: string } {
+  switch (groupBy) {
+    case "severity":
+      return {
+        key: `severity:${issue.severity}`,
+        label: severityLabel(issue.severity),
+      };
+    case "service":
+      return {
+        key: `service:${issue.serviceName}`,
+        label: issue.serviceName || "Unassigned service",
+      };
+    case "rule":
+      return issueRuleDescriptor(issue);
+    case "signal":
+      return {
+        key: `signal:${signalBucket(issue.signalType)}`,
+        label: signalBucketLabel(issue.signalType),
+      };
+    default:
+      return {
+        key: "signal:other",
+        label: "Other",
+      };
+  }
+}
+
+function issueRuleDescriptor(issue: ValidationIssue): { key: string; label: string } {
+  const ruleIds = Array.from(new Set(issue.findings.map((finding) => finding.ruleId))).sort();
+  if (ruleIds.length === 0) {
+    return { key: "rule:unknown", label: "unknown" };
+  }
+  if (ruleIds.length === 1) {
+    return { key: `rule:${ruleIds[0]}`, label: ruleIds[0] };
+  }
+  return {
+    key: `rule-group:${ruleIds.join(",")}`,
+    label: `${ruleIds.length} rules`,
+  };
+}
+
+function safeLocaleCompare(left: string | null | undefined, right: string | null | undefined): number {
+  return (left ?? "").localeCompare(right ?? "");
+}
+
+function severityLabel(severity: ValidationSeverity): string {
+  switch (severity) {
+    case "violation":
+      return "Violations";
+    case "improvement":
+      return "Improvements";
+    case "information":
+      return "Information";
+    default:
+      return "Validation";
+  }
+}
+
+function normalizeSignalType(type: string): string {
+  switch (type.toLowerCase()) {
+    case "span_event":
+      return "span";
+    default:
+      return type.toLowerCase();
+  }
+}
+
+function signalBucket(type: string): string {
+  switch (normalizeSignalType(type)) {
+    case "span":
+      return "traces";
+    case "metric":
+      return "metrics";
+    case "log":
+      return "logs";
+    case "resource":
+      return "resources";
+    default:
+      return "other";
+  }
+}
+
+function signalBucketLabel(type: string): string {
+  switch (signalBucket(type)) {
+    case "traces":
+      return "Traces";
+    case "metrics":
+      return "Metrics";
+    case "logs":
+      return "Logs";
+    case "resources":
+      return "Resources";
+    default:
+      return "Other";
+  }
+}
+
+function compareTimestamp(left: string, right: string): number {
+  const leftTime = Date.parse(left);
+  const rightTime = Date.parse(right);
+
+  if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
+    return left.localeCompare(right);
+  }
+
+  return leftTime - rightTime;
+}
+
+function distinctIssueCounts(findings: ValidationFinding[]): {
+  total: number;
+  violation: number;
+  improvement: number;
+  information: number;
+} {
+  const seen = new Set<string>();
+  const totals = {
+    total: 0,
+    violation: 0,
+    improvement: 0,
+    information: 0,
+  };
+
+  for (const finding of findings) {
+    const key = issueVariantKey(finding);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    totals.total += 1;
+    totals[finding.severity] += 1;
+  }
+
+  return totals;
+}
+
+export function issueVariantKey(finding: ValidationFinding): string {
+  return JSON.stringify([
+    finding.ruleId,
+    finding.severity,
+    finding.message,
+    stableContextEntries(finding.context),
+  ]);
+}
+
+export function stableContextEntries(context: ValidationFinding["context"]): Array<[string, string]> {
+  if (!context) return [];
+  return Object.entries(context)
+    .map(([key, value]) => [key, String(value)] as [string, string])
+    .sort(([left], [right]) => left.localeCompare(right));
+}
+
+function uniqueFindingContextValue(findings: ValidationFinding[], key: string): string | null {
+  let value: string | null = null;
+  for (const finding of findings) {
+    const raw = finding.context?.[key];
+    if (raw === undefined || raw === null) {
+      continue;
+    }
+    const next = String(raw);
+    if (!next) {
+      continue;
+    }
+    if (value === null) {
+      value = next;
+      continue;
+    }
+    if (value !== next) {
+      return null;
+    }
+  }
+  return value;
+}
+
+function uniqueLogBody(findings: ValidationFinding[]): string | null {
+  let value: string | null = null;
+  for (const finding of findings) {
+    const next = finding.signal.logBody?.trim();
+    if (!next) {
+      continue;
+    }
+    if (value === null) {
+      value = next;
+      continue;
+    }
+    if (value !== next) {
+      return null;
+    }
+  }
+  return value;
+}
+
+function logKey(logRecord: Pick<LogRecord, "body" | "traceId" | "spanId" | "resource">): string {
+  return `${logRecord.resource?.serviceName ?? ""}:${logRecord.traceId ?? ""}:${logRecord.spanId ?? ""}:${logRecord.body}`;
+}

--- a/observer/cmd/fetch-weaver/main.go
+++ b/observer/cmd/fetch-weaver/main.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ulikunitz/xz"
+)
+
+const (
+	weaverVersion = "v0.22.1"
+	downloadBase  = "https://github.com/open-telemetry/weaver/releases/download/" + weaverVersion
+)
+
+type target struct {
+	goos              string
+	goarch            string
+	asset             string
+	archiveBinaryName string
+	bundledBinaryName string
+}
+
+var supportedTargets = []target{
+	{goos: "darwin", goarch: "arm64", asset: "weaver-aarch64-apple-darwin.tar.xz", archiveBinaryName: "weaver", bundledBinaryName: "weaver"},
+	{goos: "darwin", goarch: "amd64", asset: "weaver-x86_64-apple-darwin.tar.xz", archiveBinaryName: "weaver", bundledBinaryName: "weaver"},
+	{goos: "linux", goarch: "amd64", asset: "weaver-x86_64-unknown-linux-gnu.tar.xz", archiveBinaryName: "weaver", bundledBinaryName: "weaver"},
+	{goos: "windows", goarch: "amd64", asset: "weaver-x86_64-pc-windows-msvc.zip", archiveBinaryName: "weaver.exe", bundledBinaryName: "weaver"},
+}
+
+func main() {
+	var (
+		allTargets bool
+		goos       string
+		goarch     string
+		outputDir  string
+	)
+
+	flag.BoolVar(&allTargets, "all", false, "fetch Weaver for all supported release targets")
+	flag.StringVar(&goos, "goos", runtime.GOOS, "target operating system")
+	flag.StringVar(&goarch, "goarch", runtime.GOARCH, "target architecture")
+	flag.StringVar(&outputDir, "output", "", "destination directory")
+	flag.Parse()
+
+	if outputDir == "" {
+		log.Fatal("missing required -output flag")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	var err error
+	if allTargets {
+		err = fetchAll(ctx, outputDir)
+	} else {
+		err = fetchTarget(ctx, outputDir, goos, goarch)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func fetchAll(ctx context.Context, root string) error {
+	for _, target := range supportedTargets {
+		destDir := filepath.Join(root, target.goos+"-"+target.goarch)
+		if err := fetchTarget(ctx, destDir, target.goos, target.goarch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fetchTarget(ctx context.Context, outputDir, goos, goarch string) error {
+	target, err := findTarget(goos, goarch)
+	if err != nil {
+		return err
+	}
+
+	cachedBinary, err := ensureCachedBinary(ctx, target)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	outputBinary := filepath.Join(outputDir, target.bundledBinaryName)
+	if err := copyFile(cachedBinary, outputBinary); err != nil {
+		return fmt.Errorf("copy weaver binary: %w", err)
+	}
+	if err := makeExecutable(outputBinary); err != nil {
+		return fmt.Errorf("chmod weaver binary: %w", err)
+	}
+	return nil
+}
+
+func findTarget(goos, goarch string) (target, error) {
+	for _, target := range supportedTargets {
+		if target.goos == goos && target.goarch == goarch {
+			return target, nil
+		}
+	}
+	return target{}, fmt.Errorf("unsupported Weaver target %s/%s (supported: %s)", goos, goarch, strings.Join(supportedTargetNames(), ", "))
+}
+
+func supportedTargetNames() []string {
+	names := make([]string, 0, len(supportedTargets))
+	for _, target := range supportedTargets {
+		names = append(names, target.goos+"/"+target.goarch)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func ensureCachedBinary(ctx context.Context, target target) (string, error) {
+	cacheRoot, err := weaverCacheDir()
+	if err != nil {
+		return "", err
+	}
+	cacheDir := filepath.Join(cacheRoot, target.goos+"-"+target.goarch)
+	cachedBinary := filepath.Join(cacheDir, target.bundledBinaryName)
+	if _, err := os.Stat(cachedBinary); err == nil {
+		return cachedBinary, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "obstudio-weaver-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, target.asset)
+	if err := downloadFile(ctx, downloadBase+"/"+target.asset, archivePath); err != nil {
+		return "", err
+	}
+	extractedBinary, err := extractBinary(archivePath, tmpDir, target.archiveBinaryName)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("create cache dir: %w", err)
+	}
+	cacheTmp := cachedBinary + ".tmp"
+	if err := copyFile(extractedBinary, cacheTmp); err != nil {
+		return "", fmt.Errorf("write cache binary: %w", err)
+	}
+	if err := makeExecutable(cacheTmp); err != nil {
+		return "", fmt.Errorf("chmod cache binary: %w", err)
+	}
+	if err := os.Rename(cacheTmp, cachedBinary); err != nil {
+		return "", fmt.Errorf("finalize cache binary: %w", err)
+	}
+	return cachedBinary, nil
+}
+
+func weaverCacheDir() (string, error) {
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user cache dir: %w", err)
+	}
+	return filepath.Join(cacheRoot, "obstudio", "weaver", weaverVersion), nil
+}
+
+func downloadFile(ctx context.Context, url, destination string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create download request: %w", err)
+	}
+	req.Header.Set("User-Agent", "obstudio-fetch-weaver/"+weaverVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
+	}
+
+	out, err := os.Create(destination)
+	if err != nil {
+		return fmt.Errorf("create archive file: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("write archive file: %w", err)
+	}
+	return nil
+}
+
+func extractBinary(archivePath, workDir, binaryName string) (string, error) {
+	if strings.HasSuffix(archivePath, ".zip") {
+		return extractZipBinary(archivePath, workDir, binaryName)
+	}
+	if strings.HasSuffix(archivePath, ".tar.xz") {
+		return extractTarXZBinary(archivePath, workDir, binaryName)
+	}
+	return "", fmt.Errorf("unsupported archive format: %s", archivePath)
+}
+
+func extractZipBinary(archivePath, workDir, binaryName string) (string, error) {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("open zip archive: %w", err)
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		if filepath.Base(file.Name) != binaryName {
+			continue
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return "", fmt.Errorf("open zip entry: %w", err)
+		}
+		defer rc.Close()
+
+		destPath := filepath.Join(workDir, binaryName)
+		if err := writeReader(destPath, rc); err != nil {
+			return "", err
+		}
+		return destPath, nil
+	}
+	return "", fmt.Errorf("binary %s not found in %s", binaryName, archivePath)
+}
+
+func extractTarXZBinary(archivePath, workDir, binaryName string) (string, error) {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("open tar.xz archive: %w", err)
+	}
+	defer file.Close()
+
+	xzReader, err := xz.NewReader(file)
+	if err != nil {
+		return "", fmt.Errorf("open xz stream: %w", err)
+	}
+	tarReader := tar.NewReader(xzReader)
+
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("read tar entry: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg || filepath.Base(header.Name) != binaryName {
+			continue
+		}
+
+		destPath := filepath.Join(workDir, binaryName)
+		if err := writeReader(destPath, tarReader); err != nil {
+			return "", err
+		}
+		return destPath, nil
+	}
+	return "", fmt.Errorf("binary %s not found in %s", binaryName, archivePath)
+}
+
+func writeReader(destination string, src io.Reader) error {
+	out, err := os.Create(destination)
+	if err != nil {
+		return fmt.Errorf("create extracted binary: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, src); err != nil {
+		return fmt.Errorf("extract binary: %w", err)
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %q: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create %q: %w", dst, err)
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return fmt.Errorf("copy %q to %q: %w", src, dst, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %q: %w", dst, err)
+	}
+	return nil
+}
+
+func makeExecutable(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	return os.Chmod(path, 0o755)
+}

--- a/observer/cmd/fetch-weaver/main_test.go
+++ b/observer/cmd/fetch-weaver/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFindTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := findTarget("darwin", "arm64")
+	if err != nil {
+		t.Fatalf("findTarget returned error: %v", err)
+	}
+	if target.asset != "weaver-aarch64-apple-darwin.tar.xz" {
+		t.Fatalf("unexpected asset: %s", target.asset)
+	}
+	if target.bundledBinaryName != "weaver" {
+		t.Fatalf("unexpected bundled binary name: %s", target.bundledBinaryName)
+	}
+}
+
+func TestFindTargetUnsupported(t *testing.T) {
+	t.Parallel()
+
+	_, err := findTarget("linux", "arm64")
+	if err == nil {
+		t.Fatal("expected unsupported target error")
+	}
+}
+
+func TestFetchAllWritesPerTargetDirectories(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	want := filepath.Join(dir, "darwin-arm64")
+	if got := filepath.Join(dir, supportedTargets[0].goos+"-"+supportedTargets[0].goarch); got != want {
+		t.Fatalf("unexpected release output layout: %s", got)
+	}
+}
+
+func TestCopyFileWrapsSourcePathErrors(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "missing")
+	dst := filepath.Join(t.TempDir(), "out")
+
+	err := copyFile(src, dst)
+	if err == nil {
+		t.Fatal("expected copyFile to fail for missing source")
+	}
+	if !strings.Contains(err.Error(), "open") || !strings.Contains(err.Error(), src) {
+		t.Fatalf("expected wrapped source error, got %v", err)
+	}
+}
+
+func TestCopyFileCopiesContents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.bin")
+	dst := filepath.Join(dir, "dest.bin")
+	if err := os.WriteFile(src, []byte("weaver"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(data) != "weaver" {
+		t.Fatalf("unexpected destination contents: %q", string(data))
+	}
+}

--- a/observer/cmd/obstudio/main.go
+++ b/observer/cmd/obstudio/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/signalfx/obstudio/observer/internal/mcp"
 	"github.com/signalfx/obstudio/observer/internal/otlp"
 	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 	"github.com/signalfx/obstudio/observer/internal/web"
 )
 
@@ -44,6 +45,11 @@ func main() {
 
 func run() {
 	s := store.New()
+	v := validator.NewStore()
+	validatorManager := validator.NewManager(v, s)
+	s.SetInvalidateCallback(validatorManager.Reset)
+	s.SetChangeCallback(validatorManager.MarkTelemetryChanged)
+	startedAt := time.Now().UTC()
 
 	host := envOr("HOST", "127.0.0.1")
 	port := envOr("PORT", "3000")
@@ -61,15 +67,26 @@ func run() {
 	})
 
 	ctx := context.Background()
+	if err := validatorManager.Start(ctx); err != nil {
+		log.Printf("validator startup failed: %v", err)
+	}
+
 	rcv, err := otlp.StartReceiver(ctx, s, otlpGRPCAddr, otlpHTTPAddr)
 	if err != nil {
 		log.Fatalf("failed to start OTLP receiver: %v", err)
 	}
 
 	mux := http.NewServeMux()
-	api.Register(mux, s)
-	mcp.Register(mux, s)
-	webCleanup := web.Register(mux, s)
+	api.Register(mux, s, v, validatorManager, api.ServerInfo{
+		Kind:       "obstudio",
+		APIVersion: "v1",
+		Version:    version,
+		Owner:      envOr("OBSTUDIO_OWNER", "cli"),
+		Mode:       envOr("OBSTUDIO_MODE", "standalone"),
+		StartedAt:  startedAt,
+	})
+	mcp.Register(mux, s, v, validatorManager)
+	webCleanup := web.Register(mux, s, v)
 
 	srv := &http.Server{Addr: mainAddr, Handler: mux}
 	go func() {
@@ -84,7 +101,7 @@ func run() {
 	fmt.Fprintf(os.Stderr, "  OTLP/gRPC receiver:  %s\n", otlpGRPCAddr)
 	fmt.Fprintf(os.Stderr, "  MCP endpoint:        http://%s/mcp\n\n", mainAddr)
 
-	go mcp.RunStdio(s, os.Stdin, os.Stdout)
+	go mcp.RunStdio(s, os.Stdin, os.Stdout, v, validatorManager)
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
@@ -95,6 +112,7 @@ func run() {
 	defer cancel()
 	srv.Shutdown(shutCtx)
 	webCleanup()
+	validatorManager.Shutdown(shutCtx)
 	rcv.Shutdown(ctx)
 }
 

--- a/observer/go.mod
+++ b/observer/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/evanw/esbuild v0.28.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/ulikunitz/xz v0.5.15
 	go.opentelemetry.io/collector/config/configgrpc v0.149.0
 	go.opentelemetry.io/collector/config/confignet v1.55.0
 	go.opentelemetry.io/collector/config/configoptional v1.55.0

--- a/observer/go.sum
+++ b/observer/go.sum
@@ -83,6 +83,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/collector v0.149.0 h1:q+BSroKuC7GRMY2sWLqQXPABH8BRNRmMTnAeYZU0qp0=

--- a/observer/internal/api/handler.go
+++ b/observer/internal/api/handler.go
@@ -3,15 +3,17 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 )
 
-type serverInfo struct {
+type ServerInfo struct {
 	APIVersion string    `json:"apiVersion"`
 	Kind       string    `json:"kind"`
 	Mode       string    `json:"mode"`
@@ -21,22 +23,53 @@ type serverInfo struct {
 }
 
 type healthResponse struct {
-	serverInfo
+	ServerInfo
 	Endpoints map[string]string `json:"endpoints"`
 }
 
 // Register adds the REST API routes to the given mux.
 // It registers handlers for querying traces, metrics, logs, and stats.
-func Register(mux *http.ServeMux, s *store.Store) {
-	startedAt := time.Now().UTC()
+func Register(mux *http.ServeMux, s *store.Store, params ...any) {
+	validationStore := validator.NewStore()
+	var runner validator.Runner
+	info := ServerInfo{
+		Kind:       "obstudio",
+		APIVersion: "v1",
+		Version:    "dev",
+		Owner:      "unknown",
+		Mode:       "standalone",
+		StartedAt:  time.Now().UTC(),
+	}
+	for _, param := range params {
+		switch value := param.(type) {
+		case *validator.Store:
+			if value != nil {
+				validationStore = value
+			}
+		case validator.Runner:
+			if value != nil {
+				runner = value
+			}
+		case ServerInfo:
+			info = value
+		}
+	}
+	validationService := validator.NewService(validationStore, runner)
 	mux.HandleFunc("OPTIONS /api/", corsPreflightHandler())
-	mux.HandleFunc("GET /api/health", queryHealth(s, startedAt))
+	mux.HandleFunc("GET /api/health", queryHealth(s, info))
 	mux.HandleFunc("GET /api/query/traces", queryTraces(s))
 	mux.HandleFunc("GET /api/query/traces/{traceId}", queryTraceDetail(s))
 	mux.HandleFunc("GET /api/query/metrics", queryMetrics(s))
 	mux.HandleFunc("GET /api/query/logs", queryLogs(s))
 	mux.HandleFunc("GET /api/query/stats", queryStats(s))
-	mux.HandleFunc("DELETE /api/data", clearData(s))
+	mux.HandleFunc("GET /api/query/validation/summary", queryValidationStatus(validationService))
+	mux.HandleFunc("GET /api/query/validation/status", queryValidationStatus(validationService))
+	mux.HandleFunc("GET /api/query/validation/latest", queryValidationLatest(validationService))
+	mux.HandleFunc("POST /api/validation/run", runValidation(validationService))
+	mux.HandleFunc("POST /api/validation/refresh", refreshValidation(validationService))
+	mux.HandleFunc("POST /api/validation/analyze", analyzeValidation(validationService))
+	mux.HandleFunc("GET /api/query/validation/findings", queryValidationFindings(validationService))
+	mux.HandleFunc("DELETE /api/data", clearData(s, validationStore))
 }
 
 func queryTraces(s *store.Store) http.HandlerFunc {
@@ -75,7 +108,13 @@ func queryStats(s *store.Store) http.HandlerFunc {
 	}
 }
 
-func queryHealth(s *store.Store, startedAt time.Time) http.HandlerFunc {
+func queryValidationStatus(service *validator.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, service.Summary())
+	}
+}
+
+func queryHealth(s *store.Store, info ServerInfo) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var endpoints store.Endpoints
 		if s != nil {
@@ -88,14 +127,7 @@ func queryHealth(s *store.Store, startedAt time.Time) http.HandlerFunc {
 		}
 
 		writeJSON(w, healthResponse{
-			serverInfo: serverInfo{
-				APIVersion: "v1",
-				Kind:       "obstudio",
-				Mode:       "standalone",
-				Owner:      "unknown",
-				StartedAt:  startedAt,
-				Version:    "dev",
-			},
+			ServerInfo: info,
 			Endpoints: map[string]string{
 				"mcp":      mcpEndpoint,
 				"otlpGrpc": endpoints.OTLPgRPC,
@@ -106,9 +138,88 @@ func queryHealth(s *store.Store, startedAt time.Time) http.HandlerFunc {
 	}
 }
 
-func clearData(s *store.Store) http.HandlerFunc {
+func queryValidationFindings(service *validator.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		findings, err := service.Findings(validationQueryFromRequest(r), r.URL.Query().Get("runId"))
+		if err != nil {
+			statusCode, payload := validationHTTPErrorPayload(err, http.MethodPost, "/api/validation/analyze")
+			w.WriteHeader(statusCode)
+			writeJSON(w, payload)
+			return
+		}
+		writeJSON(w, findings)
+	}
+}
+
+func queryValidationLatest(service *validator.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		snapshot, err := service.Latest(validationQueryFromRequest(r))
+		if err != nil {
+			statusCode, payload := validationHTTPErrorPayload(err, http.MethodPost, "/api/validation/analyze")
+			w.WriteHeader(statusCode)
+			writeJSON(w, payload)
+			return
+		}
+		writeJSON(w, snapshot)
+	}
+}
+
+func analyzeValidation(service *validator.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		args := decodeJSONBodyMap(r)
+		query := validationQueryFromMap(args)
+		timeout := durationArgSeconds(args, "timeoutSeconds", 90*time.Second, 5*time.Second, 5*time.Minute)
+		freshness := freshnessArg(args, "freshness", validator.FreshnessAuto)
+
+		analysis, err := service.Analyze(r.Context(), query, freshness, timeout)
+		if err != nil {
+			nextMethod := http.MethodPost
+			nextPath := "/api/validation/analyze"
+			if freshness == validator.FreshnessLatestOK {
+				nextPath = "/api/validation/refresh"
+			}
+			statusCode, payload := validationHTTPErrorPayload(err, nextMethod, nextPath)
+			w.WriteHeader(statusCode)
+			writeJSON(w, payload)
+			return
+		}
+		writeJSON(w, analysis)
+	}
+}
+
+func refreshValidation(service *validator.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		args := decodeJSONBodyMap(r)
+		query := validationQueryFromMap(args)
+		timeout := durationArgSeconds(args, "timeoutSeconds", 90*time.Second, 5*time.Second, 5*time.Minute)
+		analysis, err := service.Refresh(r.Context(), query, timeout)
+		if err != nil {
+			statusCode, payload := validationHTTPErrorPayload(err, http.MethodGet, "/api/query/validation/status")
+			w.WriteHeader(statusCode)
+			writeJSON(w, payload)
+			return
+		}
+		writeJSON(w, analysis)
+	}
+}
+
+func runValidation(service *validator.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		summary, err := service.Run(r.Context())
+		if err != nil {
+			statusCode, payload := validationHTTPErrorPayload(err, http.MethodGet, "/api/query/validation/status")
+			w.WriteHeader(statusCode)
+			writeJSON(w, payload)
+			return
+		}
+		writeJSON(w, summary)
+	}
+}
+
+func clearData(s *store.Store, v *validator.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		s.Clear()
+		v.Clear()
 		writeJSON(w, map[string]string{"status": "cleared"})
 	}
 }
@@ -116,9 +227,137 @@ func clearData(s *store.Store) http.HandlerFunc {
 func corsPreflightHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func validationQueryFromRequest(r *http.Request) validator.Query {
+	return validator.Query{
+		ServiceName: r.URL.Query().Get("serviceName"),
+		SignalType:  r.URL.Query().Get("signalType"),
+		Severity:    r.URL.Query().Get("severity"),
+		RuleID:      r.URL.Query().Get("ruleId"),
+		TraceID:     r.URL.Query().Get("traceId"),
+		SpanID:      r.URL.Query().Get("spanId"),
+		MetricName:  r.URL.Query().Get("metricName"),
+		LogBody:     r.URL.Query().Get("logBody"),
+		Limit:       queryInt(r, "limit", 0),
+	}
+}
+
+func validationQueryFromMap(args map[string]any) validator.Query {
+	return validator.Query{
+		ServiceName: stringArg(args, "serviceName"),
+		SignalType:  stringArg(args, "signalType"),
+		Severity:    stringArg(args, "severity"),
+		RuleID:      stringArg(args, "ruleId"),
+		TraceID:     stringArg(args, "traceId"),
+		SpanID:      stringArg(args, "spanId"),
+		MetricName:  stringArg(args, "metricName"),
+		LogBody:     stringArg(args, "logBody"),
+		Limit:       intArg(args, "limit", 50),
+	}
+}
+
+func validationHTTPErrorPayload(err error, nextMethod, nextPath string) (int, map[string]any) {
+	var serviceErr *validator.ServiceError
+	if !errors.As(err, &serviceErr) {
+		return http.StatusConflict, map[string]any{
+			"error":      err.Error(),
+			"nextAction": map[string]string{"method": nextMethod, "path": nextPath},
+		}
+	}
+
+	payload := map[string]any{
+		"error":      serviceErr.Error(),
+		"summary":    serviceErr.Summary,
+		"nextAction": map[string]string{"method": nextMethod, "path": nextPath},
+	}
+	if serviceErr.RequestedRunID != "" {
+		payload["requestedRunId"] = serviceErr.RequestedRunID
+	}
+	if serviceErr.AvailableResultID != "" {
+		payload["availableResultId"] = serviceErr.AvailableResultID
+	}
+
+	switch serviceErr.Kind {
+	case validator.ErrRunnerUnavailable:
+		return http.StatusServiceUnavailable, payload
+	case validator.ErrRunStillRunning:
+		payload["nextAction"] = map[string]string{"method": http.MethodGet, "path": "/api/query/validation/status"}
+		return http.StatusConflict, payload
+	case validator.ErrRunTimeout, validator.ErrRunFailed, validator.ErrNoAnalysis, validator.ErrNoRetainedResult, validator.ErrRunNotRetained:
+		return http.StatusConflict, payload
+	default:
+		return http.StatusConflict, payload
+	}
+}
+
+func decodeJSONBodyMap(r *http.Request) map[string]any {
+	if r.Body == nil {
+		return map[string]any{}
+	}
+	defer r.Body.Close()
+	var payload map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		return map[string]any{}
+	}
+	return payload
+}
+
+func stringArg(m map[string]any, key string) string {
+	v, _ := m[key].(string)
+	return v
+}
+
+func intArg(m map[string]any, key string, def int) int {
+	switch v := m[key].(type) {
+	case float64:
+		n := int(v)
+		if n < 0 {
+			return def
+		}
+		if n > maxLimit {
+			return maxLimit
+		}
+		return n
+	case int:
+		if v < 0 {
+			return def
+		}
+		if v > maxLimit {
+			return maxLimit
+		}
+		return v
+	default:
+		return def
+	}
+}
+
+func durationArgSeconds(m map[string]any, key string, def, min, max time.Duration) time.Duration {
+	seconds := intArg(m, key, int(def/time.Second))
+	duration := time.Duration(seconds) * time.Second
+	if duration < min {
+		return min
+	}
+	if duration > max {
+		return max
+	}
+	return duration
+}
+
+func freshnessArg(m map[string]any, key string, def validator.FreshnessMode) validator.FreshnessMode {
+	switch value := stringArg(m, key); value {
+	case string(validator.FreshnessAuto):
+		return validator.FreshnessAuto
+	case string(validator.FreshnessFreshRequired):
+		return validator.FreshnessFreshRequired
+	case string(validator.FreshnessLatestOK):
+		return validator.FreshnessLatestOK
+	default:
+		return def
 	}
 }
 

--- a/observer/internal/api/handler_test.go
+++ b/observer/internal/api/handler_test.go
@@ -1,16 +1,33 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 )
+
+type fakeValidationRunner struct {
+	summary validator.Summary
+	calls   int
+	onRun   func(context.Context) validator.Summary
+}
+
+func (f *fakeValidationRunner) Run(context.Context) validator.Summary {
+	f.calls++
+	if f.onRun != nil {
+		return f.onRun(context.Background())
+	}
+	return f.summary
+}
 
 func mustGet(t *testing.T, url string) *http.Response {
 	t.Helper()
@@ -225,6 +242,568 @@ func TestQueryTraceDetailNotFound(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryValidationEndpoints(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	v.SetRuntimeStatus(validator.StatusReady, "ready")
+	v.UpsertEntity(validator.Entity{
+		Key:             "span:trace-1:span-1",
+		HighestSeverity: validator.SeverityViolation,
+		Signal:          validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+		UpdatedAt:       time.Now(),
+		Findings: []validator.Finding{
+			{
+				EntityKey: "span:trace-1:span-1",
+				Source:    "weaver",
+				RuleID:    "missing_attribute",
+				Severity:  validator.SeverityViolation,
+				Message:   "missing attribute",
+				Signal:    validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+				UpdatedAt: time.Now(),
+			},
+		},
+	})
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/validation/summary")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var summary validator.Summary
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if !summary.Ready || summary.TotalAdvisories != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+
+	resp = mustGet(t, server.URL+"/api/query/validation/findings?serviceName=checkout")
+	defer resp.Body.Close()
+	var findings []validator.Finding
+	if err := json.NewDecoder(resp.Body).Decode(&findings); err != nil {
+		t.Fatalf("decode findings: %v", err)
+	}
+	if len(findings) != 1 || findings[0].RuleID != "missing_attribute" {
+		t.Fatalf("unexpected findings: %+v", findings)
+	}
+}
+
+func TestQueryValidationStatusEndpoint(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/validation/status")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var summary validator.Summary
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.Status != validator.StatusIdle {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestAnalyzeValidationAutoRunsWhenNoResult(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	runner := &fakeValidationRunner{
+		onRun: func(context.Context) validator.Summary {
+			summary := v.StartRun("run-21", time.Unix(10, 0))
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				v.CompleteRun("run-21", map[string]validator.Entity{
+					"span:trace-1:span-1": {
+						Key:             "span:trace-1:span-1",
+						HighestSeverity: validator.SeverityViolation,
+						Signal:          validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+						UpdatedAt:       time.Unix(20, 0),
+						Findings: []validator.Finding{{
+							EntityKey: "span:trace-1:span-1",
+							Source:    "weaver",
+							RuleID:    "missing_attribute",
+							Severity:  validator.SeverityViolation,
+							Message:   "missing attribute",
+							Signal:    validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+							UpdatedAt: time.Unix(20, 0),
+						}},
+					},
+				}, validator.RunStats{}, time.Unix(20, 0))
+			}()
+			return summary
+		},
+	}
+
+	mux := http.NewServeMux()
+	Register(mux, s, v, runner)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req := mustNewRequest(t, http.MethodPost, server.URL+"/api/validation/analyze", strings.NewReader(`{"timeoutSeconds":5}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := mustDo(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("expected runner to be called once, got %d", runner.calls)
+	}
+
+	var analysis validator.Analysis
+	if err := json.NewDecoder(resp.Body).Decode(&analysis); err != nil {
+		t.Fatalf("decode analysis: %v", err)
+	}
+	if analysis.AnalysisBasis != validator.AnalysisBasisFreshRun {
+		t.Fatalf("unexpected analysis: %+v", analysis)
+	}
+	if len(analysis.Findings) != 1 {
+		t.Fatalf("expected findings from fresh run, got %+v", analysis)
+	}
+}
+
+func TestAnalyzeValidationReturnsStoredStaleResult(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	startedAt := time.Unix(10, 0)
+	completedAt := time.Unix(20, 0)
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	v.StartRun("run-22", startedAt)
+	v.CompleteRun("run-22", map[string]validator.Entity{
+		"metric:checkout::http.server.duration": {
+			Key:             "metric:checkout::http.server.duration",
+			HighestSeverity: validator.SeverityImprovement,
+			Signal:          validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+			UpdatedAt:       completedAt,
+			Findings: []validator.Finding{{
+				EntityKey: "metric:checkout::http.server.duration",
+				Source:    "weaver",
+				RuleID:    "deprecated",
+				Severity:  validator.SeverityImprovement,
+				Message:   "deprecated metric",
+				Signal:    validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+				UpdatedAt: completedAt,
+			}},
+		},
+	}, validator.RunStats{}, completedAt)
+	v.MarkTelemetryChanged(time.Unix(30, 0))
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req := mustNewRequest(t, http.MethodPost, server.URL+"/api/validation/analyze", strings.NewReader(`{"serviceName":"checkout"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := mustDo(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var analysis validator.Analysis
+	if err := json.NewDecoder(resp.Body).Decode(&analysis); err != nil {
+		t.Fatalf("decode analysis: %v", err)
+	}
+	if analysis.AnalysisBasis != validator.AnalysisBasisStaleResult {
+		t.Fatalf("expected stale basis, got %+v", analysis)
+	}
+	if !strings.Contains(analysis.AnalysisMessage, "based on run run-22 completed at") {
+		t.Fatalf("expected stale analysis message, got %+v", analysis)
+	}
+}
+
+func TestRefreshValidationEndpointReturnsFreshAnalysis(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	runner := &fakeValidationRunner{
+		onRun: func(context.Context) validator.Summary {
+			summary := v.StartRun("run-23", time.Unix(10, 0))
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				v.CompleteRun("run-23", map[string]validator.Entity{
+					"log:checkout": {
+						Key:             "log:checkout",
+						HighestSeverity: validator.SeverityInformation,
+						Signal:          validator.SignalRef{Type: "log", ServiceName: "checkout", LogBody: "slow query"},
+						UpdatedAt:       time.Unix(20, 0),
+						Findings: []validator.Finding{{
+							EntityKey: "log:checkout",
+							Source:    "weaver",
+							RuleID:    "unstable",
+							Severity:  validator.SeverityInformation,
+							Message:   "unstable semantic convention",
+							Signal:    validator.SignalRef{Type: "log", ServiceName: "checkout", LogBody: "slow query"},
+							UpdatedAt: time.Unix(20, 0),
+						}},
+					},
+				}, validator.RunStats{}, time.Unix(20, 0))
+			}()
+			return summary
+		},
+	}
+
+	mux := http.NewServeMux()
+	Register(mux, s, v, runner)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req := mustNewRequest(t, http.MethodPost, server.URL+"/api/validation/refresh", strings.NewReader(`{"timeoutSeconds":5}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := mustDo(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var analysis validator.Analysis
+	if err := json.NewDecoder(resp.Body).Decode(&analysis); err != nil {
+		t.Fatalf("decode analysis: %v", err)
+	}
+	if analysis.AnalysisBasis != validator.AnalysisBasisFreshRun {
+		t.Fatalf("expected fresh run analysis, got %+v", analysis)
+	}
+}
+
+func TestQueryHealthIncludesServerInfoAndEndpoints(t *testing.T) {
+	s := store.New()
+	s.SetEndpoints(store.Endpoints{
+		OTLPHTTP: "http://127.0.0.1:4318",
+		OTLPgRPC: "127.0.0.1:4317",
+		REST:     "http://127.0.0.1:3000",
+	})
+	startedAt := time.Date(2026, time.April, 10, 8, 0, 0, 0, time.UTC)
+
+	mux := http.NewServeMux()
+	Register(mux, s, ServerInfo{
+		Kind:       "obstudio",
+		APIVersion: "v1",
+		Version:    "0.0.1",
+		Owner:      "extension",
+		Mode:       "shared-fixed",
+		StartedAt:  startedAt,
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/health")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var health healthResponse
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &health); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if health.Kind != "obstudio" {
+		t.Fatalf("expected kind obstudio, got %q", health.Kind)
+	}
+	if health.APIVersion != "v1" {
+		t.Fatalf("expected apiVersion v1, got %q", health.APIVersion)
+	}
+	if health.Version != "0.0.1" {
+		t.Fatalf("expected version 0.0.1, got %q", health.Version)
+	}
+	if health.Owner != "extension" {
+		t.Fatalf("expected owner extension, got %q", health.Owner)
+	}
+	if health.Mode != "shared-fixed" {
+		t.Fatalf("expected mode shared-fixed, got %q", health.Mode)
+	}
+	if !health.StartedAt.Equal(startedAt) {
+		t.Fatalf("expected startedAt %s, got %s", startedAt, health.StartedAt)
+	}
+	if health.Endpoints["rest"] != "http://127.0.0.1:3000" {
+		t.Fatalf("expected rest endpoint http://127.0.0.1:3000, got %q", health.Endpoints["rest"])
+	}
+	if health.Endpoints["mcp"] != "http://127.0.0.1:3000/mcp" {
+		t.Fatalf("expected mcp endpoint http://127.0.0.1:3000/mcp, got %q", health.Endpoints["mcp"])
+	}
+	if health.Endpoints["otlpHttp"] != "http://127.0.0.1:4318" {
+		t.Fatalf("expected otlpHttp endpoint http://127.0.0.1:4318, got %q", health.Endpoints["otlpHttp"])
+	}
+	if health.Endpoints["otlpGrpc"] != "127.0.0.1:4317" {
+		t.Fatalf("expected otlpGrpc endpoint 127.0.0.1:4317, got %q", health.Endpoints["otlpGrpc"])
+	}
+}
+
+func TestValidationFindingsFailClosedWhenNoFreshResult(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/validation/findings")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", resp.StatusCode)
+	}
+
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if payload["nextAction"] == nil {
+		t.Fatalf("expected nextAction in fail-closed payload: %+v", payload)
+	}
+}
+
+func TestValidationLatestReturnsStoredStaleResult(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	startedAt := time.Unix(10, 0)
+	completedAt := time.Unix(20, 0)
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	v.StartRun("run-3", startedAt)
+	v.CompleteRun("run-3", map[string]validator.Entity{
+		"span:trace-1:span-1": {
+			Key:             "span:trace-1:span-1",
+			HighestSeverity: validator.SeverityViolation,
+			Signal:          validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+			UpdatedAt:       completedAt,
+			Findings: []validator.Finding{{
+				EntityKey: "span:trace-1:span-1",
+				Source:    "weaver",
+				RuleID:    "missing_attribute",
+				Severity:  validator.SeverityViolation,
+				Message:   "missing attribute",
+				Signal:    validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+				UpdatedAt: completedAt,
+			}},
+		},
+	}, validator.RunStats{}, completedAt)
+	v.MarkTelemetryChanged(time.Unix(30, 0))
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/validation/latest?serviceName=checkout")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var snapshot validator.Snapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if !snapshot.Summary.Stale {
+		t.Fatalf("expected stale snapshot summary, got %+v", snapshot.Summary)
+	}
+	if len(snapshot.Findings) != 1 {
+		t.Fatalf("expected one finding, got %+v", snapshot)
+	}
+}
+
+func TestValidationLatestReturnsAllFindingsByDefault(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	startedAt := time.Unix(10, 0)
+	completedAt := time.Unix(20, 0)
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	v.StartRun("run-all", startedAt)
+
+	findings := make([]validator.Finding, 0, 250)
+	for i := 0; i < 250; i++ {
+		findings = append(findings, validator.Finding{
+			EntityKey: "metric:checkout::jvm.thread.count",
+			Source:    "weaver",
+			RuleID:    fmt.Sprintf("rule-%03d", i),
+			Severity:  validator.SeverityViolation,
+			Message:   "validation finding",
+			Signal:    validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "jvm.thread.count"},
+			UpdatedAt: completedAt.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	v.CompleteRun("run-all", map[string]validator.Entity{
+		"metric:checkout::jvm.thread.count": {
+			Key:             "metric:checkout::jvm.thread.count",
+			HighestSeverity: validator.SeverityViolation,
+			Signal:          validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "jvm.thread.count"},
+			UpdatedAt:       completedAt,
+			Findings:        findings,
+		},
+	}, validator.RunStats{}, completedAt)
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/validation/latest")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var snapshot validator.Snapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if len(snapshot.Findings) != 250 {
+		t.Fatalf("expected all findings without an explicit limit, got %d", len(snapshot.Findings))
+	}
+	if len(snapshot.Issues) != 1 {
+		t.Fatalf("expected grouped issues in validation snapshot, got %d", len(snapshot.Issues))
+	}
+}
+
+func TestValidationFindingsAllowsExplicitRunIDAfterStale(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	startedAt := time.Unix(10, 0)
+	completedAt := time.Unix(20, 0)
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	v.StartRun("run-9", startedAt)
+	v.CompleteRun("run-9", map[string]validator.Entity{
+		"metric:checkout::http.server.duration": {
+			Key:             "metric:checkout::http.server.duration",
+			HighestSeverity: validator.SeverityImprovement,
+			Signal:          validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+			UpdatedAt:       completedAt,
+			Findings: []validator.Finding{{
+				EntityKey: "metric:checkout::http.server.duration",
+				Source:    "weaver",
+				RuleID:    "deprecated",
+				Severity:  validator.SeverityImprovement,
+				Message:   "deprecated metric",
+				Signal:    validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+				UpdatedAt: completedAt,
+			}},
+		},
+	}, validator.RunStats{}, completedAt)
+	v.MarkTelemetryChanged(time.Unix(30, 0))
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/validation/findings?runId=run-9")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var findings []validator.Finding
+	if err := json.NewDecoder(resp.Body).Decode(&findings); err != nil {
+		t.Fatalf("decode findings: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one run-scoped finding, got %+v", findings)
+	}
+}
+
+func TestValidationFindingsReturnsStoredResultWhenStaleResultExists(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	startedAt := time.Unix(10, 0)
+	completedAt := time.Unix(20, 0)
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	v.StartRun("run-12", startedAt)
+	v.CompleteRun("run-12", map[string]validator.Entity{
+		"metric:checkout::db.client.connections.usage": {
+			Key:             "metric:checkout::db.client.connections.usage",
+			HighestSeverity: validator.SeverityViolation,
+			Signal:          validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "db.client.connections.usage"},
+			UpdatedAt:       completedAt,
+			Findings: []validator.Finding{{
+				EntityKey: "metric:checkout::db.client.connections.usage",
+				Source:    "weaver",
+				RuleID:    "deprecated",
+				Severity:  validator.SeverityViolation,
+				Message:   "deprecated attribute",
+				Signal:    validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "db.client.connections.usage"},
+				UpdatedAt: completedAt,
+			}},
+		},
+	}, validator.RunStats{}, completedAt)
+	v.MarkTelemetryChanged(time.Unix(30, 0))
+
+	mux := http.NewServeMux()
+	Register(mux, s, v)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/validation/findings")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var findings []validator.Finding
+	if err := json.NewDecoder(resp.Body).Decode(&findings); err != nil {
+		t.Fatalf("decode findings: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one retained finding, got %+v", findings)
+	}
+}
+
+func TestRunValidationEndpoint(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	runner := &fakeValidationRunner{
+		summary: validator.Summary{
+			Enabled:          true,
+			Status:           validator.StatusRunning,
+			Message:          "Validation running",
+			ActiveRunID:      "run-7",
+			LastRunStartedAt: time.Now(),
+		},
+	}
+
+	mux := http.NewServeMux()
+	Register(mux, s, v, runner)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req := mustNewRequest(t, http.MethodPost, server.URL+"/api/validation/run", nil)
+	resp := mustDo(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("expected runner to be called once, got %d", runner.calls)
+	}
+
+	var summary validator.Summary
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.ActiveRunID != "run-7" {
+		t.Fatalf("unexpected run summary: %+v", summary)
 	}
 }
 

--- a/observer/internal/integration/integration_test.go
+++ b/observer/internal/integration/integration_test.go
@@ -581,7 +581,9 @@ func TestE2E_PauseResume(t *testing.T) {
 
 	// Subscribe.
 	subscribeMsg := map[string]any{"type": "subscribe"}
-	ws.WriteJSON(subscribeMsg)
+	if err := ws.WriteJSON(subscribeMsg); err != nil {
+		t.Fatalf("failed to send subscribe: %v", err)
+	}
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -628,17 +630,16 @@ func TestE2E_PauseResume(t *testing.T) {
 	resp, _ = http.Post(otlpHTTPURL+"/v1/traces", "application/json", bytes.NewReader(data))
 	resp.Body.Close()
 
-	// Should receive "paused-update" message.
+	// Should receive "paused-update" message after draining the initial snapshot backlog.
 	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
 	receivedPausedUpdate := false
-	for i := 0; i < 5; i++ {
+	for {
 		var pausedMsg map[string]any
 		if err := ws.ReadJSON(&pausedMsg); err != nil {
 			break
 		}
 
-		pausedType, _ := pausedMsg["type"].(string)
-		if pausedType == "paused-update" {
+		if pausedType, _ := pausedMsg["type"].(string); pausedType == "paused-update" {
 			receivedPausedUpdate = true
 			break
 		}

--- a/observer/internal/mcp/handler.go
+++ b/observer/internal/mcp/handler.go
@@ -2,10 +2,15 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 )
 
 var supportedVersions = []string{"2025-06-18", "2025-03-26", "2024-11-05"}
@@ -69,13 +74,35 @@ type toolContent struct {
 
 // Dispatcher handles MCP JSON-RPC method dispatch independent of transport.
 type Dispatcher struct {
-	store *store.Store
-	tools []toolDef
+	store             *store.Store
+	validationService *validator.Service
+	tools             []toolDef
 }
 
 // NewDispatcher creates a new transport-agnostic MCP dispatcher.
-func NewDispatcher(s *store.Store) *Dispatcher {
-	return &Dispatcher{store: s, tools: buildToolDefs()}
+func NewDispatcher(s *store.Store, params ...any) *Dispatcher {
+	var validationStore *validator.Store
+	var runner validator.Runner
+	for _, param := range params {
+		switch value := param.(type) {
+		case *validator.Store:
+			if value != nil {
+				validationStore = value
+			}
+		case validator.Runner:
+			if value != nil {
+				runner = value
+			}
+		}
+	}
+	if validationStore == nil {
+		validationStore = validator.NewStore()
+	}
+	return &Dispatcher{
+		store:             s,
+		validationService: validator.NewService(validationStore, runner),
+		tools:             buildToolDefs(),
+	}
 }
 
 // Dispatch processes a single JSON-RPC request and returns a response.
@@ -139,6 +166,12 @@ func (d *Dispatcher) handleToolsCall(req jsonRPCRequest) jsonRPCResponse {
 		result = d.clearStore()
 	case "observer_status":
 		result = d.status()
+	case "observer_validation_status":
+		result = d.validationStatus()
+	case "observer_validation_analyze":
+		result = d.validationAnalyze(args)
+	case "observer_validation_refresh":
+		result = d.validationRefresh(args)
 	default:
 		return rpcError(req.ID, -32602, fmt.Sprintf("Unknown tool: %s", toolName))
 	}
@@ -221,9 +254,38 @@ func (d *Dispatcher) status() toolResult {
 	ep := d.store.Endpoints()
 	stats := d.store.Stats()
 	return jsonToolResult(map[string]any{
-		"endpoints": ep,
-		"stats":     stats,
+		"endpoints":  ep,
+		"stats":      stats,
+		"validation": d.validationService.Summary(),
 	})
+}
+
+func (d *Dispatcher) validationStatus() toolResult {
+	return jsonToolResult(d.validationService.Summary())
+}
+
+func (d *Dispatcher) validationAnalyze(args map[string]any) toolResult {
+	query := validationQueryFromArgs(args)
+	timeout := durationArgSeconds(args, "timeoutSeconds", 90*time.Second, 5*time.Second, 5*time.Minute)
+	freshness := freshnessArg(args, "freshness", validator.FreshnessAuto)
+	analysis, err := d.validationService.Analyze(context.Background(), query, freshness, timeout)
+	if err != nil {
+		suggestedTool := "observer_validation_analyze"
+		if freshness == validator.FreshnessLatestOK {
+			suggestedTool = "observer_validation_refresh"
+		}
+		return jsonValidationErrorResult(err, suggestedTool, "observer_validation_status")
+	}
+	return jsonToolResult(analysis)
+}
+
+func (d *Dispatcher) validationRefresh(args map[string]any) toolResult {
+	timeout := durationArgSeconds(args, "timeoutSeconds", 90*time.Second, 5*time.Second, 5*time.Minute)
+	analysis, err := d.validationService.Refresh(context.Background(), validationQueryFromArgs(args), timeout)
+	if err != nil {
+		return jsonValidationErrorResult(err, "observer_validation_status")
+	}
+	return jsonToolResult(analysis)
 }
 
 func buildToolDefs() []toolDef {
@@ -231,7 +293,7 @@ func buildToolDefs() []toolDef {
 	return []toolDef{
 		{
 			Name:        "observer_metrics_overview",
-			Description: "List metrics currently present in the OTLP in-memory store, with compact summaries and bounded datapoint previews.",
+			Description: "List metrics currently present in the OTLP in-memory store, with compact summaries and bounded datapoint previews. Use this when the user asks what metrics are flowing right now or wants a quick metrics inventory.",
 			InputSchema: jsonSchema{
 				Type: "object", AdditionalProperties: &f,
 				Properties: map[string]jsonSchema{
@@ -240,7 +302,7 @@ func buildToolDefs() []toolDef {
 					"resourceAttribute": {Type: "string", Description: "Optional substring that must appear in the serialized resource attributes."},
 					"scopeName":         {Type: "string", Description: "Optional case-insensitive instrumentation scope name filter."},
 					"serviceName":       {Type: "string", Description: "Optional case-insensitive service.name filter."},
-					"type":              {Type: "string", Enum: []string{"counter", "gauge", "histogram", "summary", "exponential_histogram"}, Description: "Optional metric kind filter."},
+					"type":              {Type: "string", Enum: []string{"sum", "gauge", "histogram", "summary", "exponential_histogram"}, Description: "Optional metric type filter."},
 					"limit":             {Type: "integer", Minimum: intPtr(1), Maximum: intPtr(100), Default: 20, Description: "Maximum number of metric groups to return."},
 				},
 			},
@@ -248,7 +310,7 @@ func buildToolDefs() []toolDef {
 		},
 		{
 			Name:        "observer_metric_detail",
-			Description: "Fetch a single metric by exact name with resource and scope context plus a larger datapoint window.",
+			Description: "Fetch a single metric by exact name with resource and scope context plus a larger datapoint window. Use this when the user asks about one specific metric or wants to inspect a metric mentioned by validation.",
 			InputSchema: jsonSchema{
 				Type: "object", AdditionalProperties: &f, Required: []string{"metricName"},
 				Properties: map[string]jsonSchema{
@@ -262,7 +324,7 @@ func buildToolDefs() []toolDef {
 		},
 		{
 			Name:        "observer_traces_overview",
-			Description: "List recent traces from the OTLP in-memory store with compact span previews and status summaries.",
+			Description: "List recent traces from the OTLP in-memory store with compact span previews and status summaries. Use this when the user asks what traces are flowing, whether tracing is working, or which recent traces look interesting.",
 			InputSchema: jsonSchema{
 				Type: "object", AdditionalProperties: &f,
 				Properties: map[string]jsonSchema{
@@ -278,7 +340,7 @@ func buildToolDefs() []toolDef {
 		},
 		{
 			Name:        "observer_trace_detail",
-			Description: "Fetch one trace by traceId with ordered spans, attributes, links, and bounded event details.",
+			Description: "Fetch one trace by traceId with ordered spans, attributes, links, and bounded event details. Use this after observer_traces_overview or when validation points at a specific trace/span.",
 			InputSchema: jsonSchema{
 				Type: "object", AdditionalProperties: &f, Required: []string{"traceId"},
 				Properties: map[string]jsonSchema{
@@ -290,7 +352,7 @@ func buildToolDefs() []toolDef {
 		},
 		{
 			Name:        "observer_logs_overview",
-			Description: "List recent log records from the OTLP in-memory store, with filtering by service, severity, body text, and trace correlation.",
+			Description: "List recent log records from the OTLP in-memory store, with filtering by service, severity, body text, and trace correlation. Use this when the user asks what logs are flowing or wants logs related to a trace or validation issue.",
 			InputSchema: jsonSchema{
 				Type: "object", AdditionalProperties: &f,
 				Properties: map[string]jsonSchema{
@@ -304,8 +366,57 @@ func buildToolDefs() []toolDef {
 			Annotations: toolAnnot{Title: "Observer Logs Overview", ReadOnlyHint: true, IdempotentHint: true},
 		},
 		{
+			Name:        "observer_validation_status",
+			Description: "Return validator runtime state, freshness metadata, run identifiers, and summary counts for the latest retained validation result. Use this when the user explicitly asks whether validation has run, whether a result exists, whether it is stale, or whether a run is currently in progress.",
+			InputSchema: jsonSchema{
+				Type: "object", AdditionalProperties: &f,
+			},
+			Annotations: toolAnnot{Title: "Observer Validation Status", ReadOnlyHint: true, IdempotentHint: true},
+		},
+		{
+			Name:        "observer_validation_analyze",
+			Description: "Primary validation tool. Use this for almost all user requests about validation, missing telemetry, semantic convention issues, or what needs fixing. If validation has never run, this automatically runs validation and returns the result. If the latest retained result is stale, it still returns analysis and explicitly says the analysis is based on the prior run time.",
+			InputSchema: jsonSchema{
+				Type: "object", AdditionalProperties: &f,
+				Properties: map[string]jsonSchema{
+					"freshness":      {Type: "string", Enum: []string{"auto", "fresh_required", "latest_ok"}, Default: "auto", Description: "Choose how strictly to require a fresh validation. auto runs validation only when no retained result exists. fresh_required always runs validation now. latest_ok never auto-runs and only uses the latest retained result."},
+					"timeoutSeconds": {Type: "integer", Minimum: intPtr(5), Maximum: intPtr(300), Default: 90, Description: "Maximum time to wait for a fresh validation run to finish."},
+					"limit":          {Type: "integer", Minimum: intPtr(1), Maximum: intPtr(500), Default: 50, Description: "Maximum findings to include in the returned report."},
+					"logBody":        {Type: "string", Description: "Optional substring filter for log body findings."},
+					"metricName":     {Type: "string", Description: "Optional exact metric name filter."},
+					"ruleId":         {Type: "string", Description: "Optional case-insensitive rule identifier filter."},
+					"serviceName":    {Type: "string", Description: "Optional case-insensitive service.name filter."},
+					"severity":       {Type: "string", Enum: []string{"information", "improvement", "violation"}, Description: "Optional severity filter."},
+					"signalType":     {Type: "string", Enum: []string{"resource", "span", "span_event", "metric", "log"}, Description: "Optional signal type filter."},
+					"spanId":         {Type: "string", Description: "Optional exact span id filter."},
+					"traceId":        {Type: "string", Description: "Optional exact trace id filter."},
+				},
+			},
+			Annotations: toolAnnot{Title: "Observer Validation Analyze"},
+		},
+		{
+			Name:        "observer_validation_refresh",
+			Description: "Explicitly run validation against the current in-memory telemetry snapshot and wait for that run to complete. Use this only when the user explicitly asks to run, re-run, refresh, or validate the current telemetry now.",
+			InputSchema: jsonSchema{
+				Type: "object", AdditionalProperties: &f,
+				Properties: map[string]jsonSchema{
+					"timeoutSeconds": {Type: "integer", Minimum: intPtr(5), Maximum: intPtr(300), Default: 90, Description: "Maximum time to wait for the new validation run to finish."},
+					"limit":          {Type: "integer", Minimum: intPtr(1), Maximum: intPtr(500), Default: 50, Description: "Maximum findings to return."},
+					"logBody":        {Type: "string", Description: "Optional substring filter for log body findings."},
+					"metricName":     {Type: "string", Description: "Optional exact metric name filter."},
+					"ruleId":         {Type: "string", Description: "Optional case-insensitive rule identifier filter."},
+					"serviceName":    {Type: "string", Description: "Optional case-insensitive service.name filter."},
+					"severity":       {Type: "string", Enum: []string{"information", "improvement", "violation"}, Description: "Optional severity filter."},
+					"signalType":     {Type: "string", Enum: []string{"resource", "span", "span_event", "metric", "log"}, Description: "Optional signal type filter."},
+					"spanId":         {Type: "string", Description: "Optional exact span id filter."},
+					"traceId":        {Type: "string", Description: "Optional exact trace id filter."},
+				},
+			},
+			Annotations: toolAnnot{Title: "Observer Validation Refresh"},
+		},
+		{
 			Name:        "observer_clear",
-			Description: "Clear all telemetry data (traces, metrics, logs) from the in-memory store. Useful when restarting the instrumented application and wanting a clean slate.",
+			Description: "Clear all telemetry data (traces, metrics, logs) from the in-memory store. Use this only when the user explicitly asks to clear or reset the observer state.",
 			InputSchema: jsonSchema{
 				Type: "object", AdditionalProperties: &f,
 			},
@@ -313,7 +424,7 @@ func buildToolDefs() []toolDef {
 		},
 		{
 			Name:        "observer_status",
-			Description: "Return the collector's listening endpoints (OTLP HTTP, OTLP gRPC, REST/Web UI) and current telemetry stats. Use this to discover which addresses to point instrumented applications at and where to query results.",
+			Description: "Return the collector's listening endpoints (OTLP HTTP, OTLP gRPC, REST/Web UI) and current telemetry stats. Use this when the user asks whether telemetry is arriving, what ports to send OTLP to, or whether the observer backend is up.",
 			InputSchema: jsonSchema{
 				Type: "object", AdditionalProperties: &f,
 			},
@@ -340,6 +451,14 @@ func jsonToolResult(v any) toolResult {
 
 func errorResult(msg string) toolResult {
 	return toolResult{Content: []toolContent{{Type: "text", Text: msg}}, IsError: true}
+}
+
+func jsonErrorResult(v any) toolResult {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errorResult(err.Error())
+	}
+	return toolResult{Content: []toolContent{{Type: "text", Text: string(data)}}, IsError: true}
 }
 
 func negotiateVersion(client string) string {
@@ -385,3 +504,82 @@ func intArg(m map[string]any, key string, def int) int {
 }
 
 func intPtr(v int) *int { return &v }
+
+func boolArg(m map[string]any, key string, def bool) bool {
+	v, ok := m[key].(bool)
+	if !ok {
+		return def
+	}
+	return v
+}
+
+func durationArgSeconds(m map[string]any, key string, def, min, max time.Duration) time.Duration {
+	seconds := intArg(m, key, int(def/time.Second))
+	duration := time.Duration(seconds) * time.Second
+	if duration < min {
+		return min
+	}
+	if duration > max {
+		return max
+	}
+	return duration
+}
+
+func freshnessArg(m map[string]any, key string, def validator.FreshnessMode) validator.FreshnessMode {
+	switch strings.ToLower(strArg(m, key)) {
+	case string(validator.FreshnessAuto):
+		return validator.FreshnessAuto
+	case string(validator.FreshnessFreshRequired):
+		return validator.FreshnessFreshRequired
+	case string(validator.FreshnessLatestOK):
+		return validator.FreshnessLatestOK
+	default:
+		return def
+	}
+}
+
+func validationQueryFromArgs(args map[string]any) validator.Query {
+	return validator.Query{
+		ServiceName: strArg(args, "serviceName"),
+		SignalType:  strArg(args, "signalType"),
+		Severity:    strArg(args, "severity"),
+		RuleID:      strArg(args, "ruleId"),
+		TraceID:     strArg(args, "traceId"),
+		SpanID:      strArg(args, "spanId"),
+		MetricName:  strArg(args, "metricName"),
+		LogBody:     strArg(args, "logBody"),
+		Limit:       intArg(args, "limit", 50),
+	}
+}
+
+func jsonValidationErrorResult(err error, suggestedTools ...string) toolResult {
+	var serviceErr *validator.ServiceError
+	if !errors.As(err, &serviceErr) {
+		payload := map[string]any{"error": err.Error()}
+		if len(suggestedTools) > 0 {
+			payload["suggestedTool"] = suggestedTools[0]
+			payload["suggestedTools"] = suggestedTools
+		}
+		return jsonErrorResult(payload)
+	}
+
+	payload := map[string]any{
+		"error":   serviceErr.Error(),
+		"summary": serviceErr.Summary,
+	}
+	if serviceErr.RequestedRunID != "" {
+		payload["requestedRunId"] = serviceErr.RequestedRunID
+	}
+	if serviceErr.AvailableResultID != "" {
+		payload["availableResultId"] = serviceErr.AvailableResultID
+	}
+	if len(suggestedTools) > 0 {
+		payload["suggestedTool"] = suggestedTools[0]
+		payload["suggestedTools"] = suggestedTools
+	}
+	if serviceErr.Kind == validator.ErrRunStillRunning {
+		payload["suggestedTool"] = "observer_validation_status"
+		payload["suggestedTools"] = []string{"observer_validation_status"}
+	}
+	return jsonErrorResult(payload)
+}

--- a/observer/internal/mcp/handler_test.go
+++ b/observer/internal/mcp/handler_test.go
@@ -1,11 +1,14 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 )
 
 // Test helper to unmarshal JSON tool results
@@ -34,6 +37,29 @@ func toSliceAny(v any) []any {
 		return s
 	}
 	return []any{}
+}
+
+func containsAll(text string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(text, part) {
+			return false
+		}
+	}
+	return true
+}
+
+type fakeValidationRunner struct {
+	summary validator.Summary
+	calls   int
+	onRun   func(context.Context) validator.Summary
+}
+
+func (f *fakeValidationRunner) Run(ctx context.Context) validator.Summary {
+	f.calls++
+	if f.onRun != nil {
+		return f.onRun(ctx)
+	}
+	return f.summary
 }
 
 // Test 1: Dispatch Initialize - returns server info, negotiated protocol version, capabilities
@@ -86,9 +112,9 @@ func TestInitializeVersionNegotiation(t *testing.T) {
 	d := NewDispatcher(s)
 
 	tests := []struct {
-		name     string
+		name      string
 		clientVer string
-		expected string
+		expected  string
 	}{
 		{"known version", "2025-06-18", "2025-06-18"},
 		{"known version 2", "2025-03-26", "2025-03-26"},
@@ -118,7 +144,7 @@ func TestInitializeVersionNegotiation(t *testing.T) {
 	}
 }
 
-// Test 3: Dispatch tools/list - returns all 7 tools with names
+// Test 3: Dispatch tools/list - returns all observer tools with names
 func TestDispatchToolsList(t *testing.T) {
 	s := store.New()
 	d := NewDispatcher(s)
@@ -154,18 +180,21 @@ func TestDispatchToolsList(t *testing.T) {
 		t.Fatalf("tools is not []toolDef: %T", toolsRaw)
 	}
 
-	if len(toolsList) != 7 {
-		t.Fatalf("expected 7 tools, got %d", len(toolsList))
+	if len(toolsList) != 10 {
+		t.Fatalf("expected 10 tools, got %d", len(toolsList))
 	}
 
 	expectedToolNames := map[string]bool{
-		"observer_metrics_overview": false,
-		"observer_metric_detail":    false,
-		"observer_traces_overview":  false,
-		"observer_trace_detail":     false,
-		"observer_logs_overview":    false,
-		"observer_clear":            false,
-		"observer_status":           false,
+		"observer_metrics_overview":   false,
+		"observer_metric_detail":      false,
+		"observer_traces_overview":    false,
+		"observer_trace_detail":       false,
+		"observer_logs_overview":      false,
+		"observer_validation_status":  false,
+		"observer_validation_analyze": false,
+		"observer_validation_refresh": false,
+		"observer_clear":              false,
+		"observer_status":             false,
 	}
 
 	for _, tool := range toolsList {
@@ -181,6 +210,246 @@ func TestDispatchToolsList(t *testing.T) {
 		if !found {
 			t.Fatalf("tool not found: %s", name)
 		}
+	}
+}
+
+func TestValidationToolDescriptionsGuideNaturalUsage(t *testing.T) {
+	tools := buildToolDefs()
+	index := make(map[string]toolDef, len(tools))
+	for _, tool := range tools {
+		index[tool.Name] = tool
+	}
+
+	if got := index["observer_validation_status"].Description; !containsAll(got, "whether validation has run", "run is currently in progress") {
+		t.Fatalf("status description lost guidance: %q", got)
+	}
+	if got := index["observer_validation_analyze"].Description; !containsAll(got, "Primary validation tool", "automatically runs validation", "based on the prior run time") {
+		t.Fatalf("analyze description lost guidance: %q", got)
+	}
+	if got := index["observer_validation_refresh"].Description; !containsAll(got, "Explicitly run validation", "explicitly asks to run, re-run, refresh") {
+		t.Fatalf("refresh description lost guidance: %q", got)
+	}
+}
+
+func TestToolsCallValidationRefresh(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	runner := &fakeValidationRunner{
+		onRun: func(context.Context) validator.Summary {
+			summary := v.StartRun("run-1", time.Unix(10, 0))
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				v.CompleteRun("run-1", map[string]validator.Entity{
+					"metric:checkout::http.server.duration": {
+						Key:             "metric:checkout::http.server.duration",
+						HighestSeverity: validator.SeverityImprovement,
+						Signal:          validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+						UpdatedAt:       time.Unix(20, 0),
+						Findings: []validator.Finding{{
+							EntityKey: "metric:checkout::http.server.duration",
+							Source:    "weaver",
+							RuleID:    "deprecated",
+							Severity:  validator.SeverityImprovement,
+							Message:   "deprecated metric",
+							Signal:    validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+							UpdatedAt: time.Unix(20, 0),
+						}},
+					},
+				}, validator.RunStats{}, time.Unix(20, 0))
+			}()
+			return summary
+		},
+	}
+	d := NewDispatcher(s, v, runner)
+
+	resp, handled := d.Dispatch(jsonRPCRequest{
+		ID:      1,
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "observer_validation_refresh",
+			"arguments": map[string]any{
+				"timeoutSeconds": 5,
+			},
+		},
+	})
+	if !handled || resp.Error != nil {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("expected runner to be called once, got %d", runner.calls)
+	}
+	data := parseToolResult(t, resp.Result.(toolResult))
+	analysis := toMapAny(data)
+	if analysis["analysisBasis"] != "fresh_run" {
+		t.Fatalf("unexpected refresh analysis: %+v", analysis)
+	}
+}
+
+func TestToolsCallValidationAnalyzeAutoRunsWhenNoResult(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	runner := &fakeValidationRunner{
+		onRun: func(context.Context) validator.Summary {
+			summary := v.StartRun("run-2", time.Unix(10, 0))
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				v.CompleteRun("run-2", map[string]validator.Entity{
+					"span:trace-1:span-1": {
+						Key:             "span:trace-1:span-1",
+						HighestSeverity: validator.SeverityViolation,
+						Signal:          validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+						UpdatedAt:       time.Unix(20, 0),
+						Findings: []validator.Finding{{
+							EntityKey: "span:trace-1:span-1",
+							Source:    "weaver",
+							RuleID:    "missing_attribute",
+							Severity:  validator.SeverityViolation,
+							Message:   "missing attribute",
+							Signal:    validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+							UpdatedAt: time.Unix(20, 0),
+						}},
+					},
+				}, validator.RunStats{}, time.Unix(20, 0))
+			}()
+			return summary
+		},
+	}
+
+	d := NewDispatcher(s, v, runner)
+	resp, handled := d.Dispatch(jsonRPCRequest{
+		ID:      1,
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "observer_validation_analyze",
+			"arguments": map[string]any{
+				"timeoutSeconds": 5,
+			},
+		},
+	})
+	if !handled || resp.Error != nil {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("expected analyze to run validation once, got %d", runner.calls)
+	}
+
+	analysis := toMapAny(parseToolResult(t, resp.Result.(toolResult)))
+	if analysis["analysisBasis"] != "fresh_run" {
+		t.Fatalf("expected fresh run analysis, got %+v", analysis)
+	}
+}
+
+func TestToolsCallValidationAnalyzeReturnsStoredStaleResult(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	startedAt := time.Unix(10, 0)
+	completedAt := time.Unix(20, 0)
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	v.StartRun("run-1", startedAt)
+	v.CompleteRun("run-1", map[string]validator.Entity{
+		"span:trace-1:span-1": {
+			Key:             "span:trace-1:span-1",
+			HighestSeverity: validator.SeverityViolation,
+			Signal:          validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+			UpdatedAt:       completedAt,
+			Findings: []validator.Finding{{
+				EntityKey: "span:trace-1:span-1",
+				Source:    "weaver",
+				RuleID:    "missing_attribute",
+				Severity:  validator.SeverityViolation,
+				Message:   "missing attribute",
+				Signal:    validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+				UpdatedAt: completedAt,
+			}},
+		},
+	}, validator.RunStats{}, completedAt)
+	v.MarkTelemetryChanged(time.Unix(30, 0))
+
+	d := NewDispatcher(s, v)
+	resp, handled := d.Dispatch(jsonRPCRequest{
+		ID:      1,
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "observer_validation_analyze",
+			"arguments": map[string]any{
+				"serviceName": "checkout",
+			},
+		},
+	})
+	if !handled || resp.Error != nil {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	data := parseToolResult(t, resp.Result.(toolResult))
+	snapshot := toMapAny(data)
+	summary := toMapAny(snapshot["summary"])
+	if stale, _ := summary["stale"].(bool); !stale {
+		t.Fatalf("expected stale summary, got %+v", summary)
+	}
+	if snapshot["analysisBasis"] != "stale_result" {
+		t.Fatalf("expected stale analysis basis, got %+v", snapshot)
+	}
+	message, _ := snapshot["analysisMessage"].(string)
+	if !strings.Contains(message, "based on run run-1 completed at") {
+		t.Fatalf("expected stale analysis message, got %+v", snapshot)
+	}
+	findings := toSliceAny(snapshot["findings"])
+	if len(findings) != 1 {
+		t.Fatalf("expected one stale finding, got %+v", snapshot)
+	}
+}
+
+func TestToolsCallValidationAnalyzeReturnsCachedResultWithoutRerun(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	startedAt := time.Unix(10, 0)
+	completedAt := time.Unix(20, 0)
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+	v.StartRun("run-4", startedAt)
+	v.CompleteRun("run-4", map[string]validator.Entity{
+		"span:trace-1:span-1": {
+			Key:             "span:trace-1:span-1",
+			HighestSeverity: validator.SeverityViolation,
+			Signal:          validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+			UpdatedAt:       completedAt,
+			Findings: []validator.Finding{{
+				EntityKey: "span:trace-1:span-1",
+				Source:    "weaver",
+				RuleID:    "missing_attribute",
+				Severity:  validator.SeverityViolation,
+				Message:   "missing attribute",
+				Signal:    validator.SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+				UpdatedAt: completedAt,
+			}},
+		},
+	}, validator.RunStats{}, completedAt)
+	v.MarkTelemetryChanged(time.Unix(30, 0))
+	runner := &fakeValidationRunner{}
+
+	d := NewDispatcher(s, v, runner)
+	resp, handled := d.Dispatch(jsonRPCRequest{
+		ID:      1,
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "observer_validation_analyze",
+		},
+	})
+	if !handled || resp.Error != nil {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("expected cached analysis path to avoid rerun, got %d calls", runner.calls)
+	}
+
+	snapshot := toMapAny(parseToolResult(t, resp.Result.(toolResult)))
+	summary := toMapAny(snapshot["summary"])
+	if stale, _ := summary["stale"].(bool); !stale {
+		t.Fatalf("expected cached stale analysis, got %+v", summary)
 	}
 }
 
@@ -230,6 +499,51 @@ func TestToolsCallObserverStatus(t *testing.T) {
 	stats := toMapAny(statusMap["stats"])
 	if stats["spanCount"] == nil {
 		t.Fatalf("missing spanCount in stats")
+	}
+}
+
+func TestToolsCallValidationStatus(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+	v.SetRuntimeStatus(validator.StatusReady, "ready")
+	v.UpsertEntity(validator.Entity{
+		Key:             "metric:checkout::http.server.duration",
+		HighestSeverity: validator.SeverityImprovement,
+		Signal:          validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+		UpdatedAt:       time.Now(),
+		Findings: []validator.Finding{
+			{
+				EntityKey: "metric:checkout::http.server.duration",
+				Source:    "weaver",
+				RuleID:    "deprecated",
+				Severity:  validator.SeverityImprovement,
+				Message:   "deprecated metric",
+				Signal:    validator.SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+				UpdatedAt: time.Now(),
+			},
+		},
+	})
+
+	d := NewDispatcher(s, v)
+	resp, handled := d.Dispatch(jsonRPCRequest{
+		ID:      1,
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name": "observer_validation_status",
+		},
+	})
+	if !handled || resp.Error != nil {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	data := parseToolResult(t, resp.Result.(toolResult))
+	summary := toMapAny(data)
+	if summary["status"] != "ready" {
+		t.Fatalf("unexpected status: %v", summary["status"])
+	}
+	if summary["totalAdvisories"] != float64(1) {
+		t.Fatalf("unexpected advisory count: %v", summary["totalAdvisories"])
 	}
 }
 
@@ -493,8 +807,8 @@ func TestToolsCallTraceDetailMissingTraceId(t *testing.T) {
 		JSONRPC: "2.0",
 		Method:  "tools/call",
 		Params: map[string]any{
-			"name":        "observer_trace_detail",
-			"arguments":   map[string]any{},
+			"name":      "observer_trace_detail",
+			"arguments": map[string]any{},
 		},
 	}
 
@@ -576,8 +890,8 @@ func TestToolsCallMetricsOverview(t *testing.T) {
 		JSONRPC: "2.0",
 		Method:  "tools/call",
 		Params: map[string]any{
-			"name":        "observer_metrics_overview",
-			"arguments":   map[string]any{},
+			"name":      "observer_metrics_overview",
+			"arguments": map[string]any{},
 		},
 	}
 
@@ -754,8 +1068,8 @@ func TestToolsCallMetricDetailMissingName(t *testing.T) {
 		JSONRPC: "2.0",
 		Method:  "tools/call",
 		Params: map[string]any{
-			"name":        "observer_metric_detail",
-			"arguments":   map[string]any{},
+			"name":      "observer_metric_detail",
+			"arguments": map[string]any{},
 		},
 	}
 
@@ -828,8 +1142,8 @@ func TestToolsCallLogsOverview(t *testing.T) {
 		JSONRPC: "2.0",
 		Method:  "tools/call",
 		Params: map[string]any{
-			"name":        "observer_logs_overview",
-			"arguments":   map[string]any{},
+			"name":      "observer_logs_overview",
+			"arguments": map[string]any{},
 		},
 	}
 
@@ -926,7 +1240,7 @@ func TestToolsCallLogsOverviewWithFilters(t *testing.T) {
 		t.Fatalf("expected 1 log with 'started', got %d", len(logsList2))
 	}
 	log2 := toMapAny(logsList2[0])
-	if !contains(log2["body"].(string), "started") {
+	if !strings.Contains(log2["body"].(string), "started") {
 		t.Fatalf("expected 'started' in body")
 	}
 }
@@ -968,8 +1282,8 @@ func TestToolsCallClear(t *testing.T) {
 		JSONRPC: "2.0",
 		Method:  "tools/call",
 		Params: map[string]any{
-			"name":        "observer_clear",
-			"arguments":   map[string]any{},
+			"name":      "observer_clear",
+			"arguments": map[string]any{},
 		},
 	}
 
@@ -997,8 +1311,8 @@ func TestToolsCallUnknownTool(t *testing.T) {
 		JSONRPC: "2.0",
 		Method:  "tools/call",
 		Params: map[string]any{
-			"name":        "unknown_tool",
-			"arguments":   map[string]any{},
+			"name":      "unknown_tool",
+			"arguments": map[string]any{},
 		},
 	}
 
@@ -1148,14 +1462,4 @@ func TestToolResponseDataCorrectness(t *testing.T) {
 			t.Fatalf("missing required field: %s", field)
 		}
 	}
-}
-
-// Helper function
-func contains(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/observer/internal/mcp/http.go
+++ b/observer/internal/mcp/http.go
@@ -19,8 +19,8 @@ type httpHandler struct {
 }
 
 // Register adds the MCP HTTP endpoints to the given ServeMux.
-func Register(mux *http.ServeMux, s *store.Store) {
-	h := &httpHandler{dispatcher: NewDispatcher(s)}
+func Register(mux *http.ServeMux, s *store.Store, params ...any) {
+	h := &httpHandler{dispatcher: NewDispatcher(s, params...)}
 	mux.HandleFunc("POST /mcp", h.handle)
 	mux.HandleFunc("OPTIONS /mcp", h.handleOptions)
 }

--- a/observer/internal/mcp/stdio.go
+++ b/observer/internal/mcp/stdio.go
@@ -11,8 +11,8 @@ import (
 
 // RunStdio runs the MCP server over stdin/stdout using newline-delimited
 // JSON-RPC. It blocks until the input stream closes.
-func RunStdio(s *store.Store, in io.Reader, out io.Writer) {
-	d := NewDispatcher(s)
+func RunStdio(s *store.Store, in io.Reader, out io.Writer, params ...any) {
+	d := NewDispatcher(s, params...)
 	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 	enc := json.NewEncoder(out)

--- a/observer/internal/store/store.go
+++ b/observer/internal/store/store.go
@@ -196,6 +196,13 @@ type Endpoints struct {
 	REST     string `json:"rest,omitempty"`
 }
 
+// TelemetrySnapshot is a point-in-time copy of the in-memory telemetry buffers.
+type TelemetrySnapshot struct {
+	Spans   []Span            `json:"spans"`
+	Metrics []MetricDataPoint `json:"metrics"`
+	Logs    []LogRecord       `json:"logs"`
+}
+
 // Store is the in-memory telemetry store.
 type Store struct {
 	mu      sync.RWMutex
@@ -213,6 +220,12 @@ type Store struct {
 	subMu       sync.Mutex
 	subscribers map[int]chan Signal
 	nextSubID   int
+
+	invalidateMu sync.RWMutex
+	invalidate   func()
+
+	changeMu sync.RWMutex
+	change   func(time.Time)
 }
 
 // ringBuffer is a fixed-capacity circular buffer. When full, the oldest
@@ -295,6 +308,21 @@ func (s *Store) Endpoints() Endpoints {
 	return s.endpoints
 }
 
+// SetInvalidateCallback installs a callback invoked when the store is cleared,
+// reset, or evicted in a way that invalidates derived state such as validation.
+func (s *Store) SetInvalidateCallback(fn func()) {
+	s.invalidateMu.Lock()
+	s.invalidate = fn
+	s.invalidateMu.Unlock()
+}
+
+// SetChangeCallback installs a callback invoked when new telemetry is ingested.
+func (s *Store) SetChangeCallback(fn func(time.Time)) {
+	s.changeMu.Lock()
+	s.change = fn
+	s.changeMu.Unlock()
+}
+
 // New creates a new Store with default configuration.
 func New() *Store {
 	return &Store{
@@ -316,15 +344,20 @@ func (s *Store) AddSpansForConnection(connID string, spans []Span) {
 		}
 	}
 	s.spans.push(spans)
-	s.lastIngest = time.Now()
+	changedAt := time.Now()
+	s.lastIngest = changedAt
 	s.mu.Unlock()
+	if reset {
+		s.runInvalidateCallback()
+	}
+	s.runChangeCallback(changedAt)
 	if reset {
 		s.notify(SignalTraces)
 		s.notify(SignalMetrics)
 		s.notify(SignalLogs)
-	} else {
-		s.notify(SignalTraces)
+		return
 	}
+	s.notify(SignalTraces)
 }
 
 // AddMetricsForConnection adds metrics with an associated connection ID for later eviction.
@@ -337,15 +370,20 @@ func (s *Store) AddMetricsForConnection(connID string, metrics []MetricDataPoint
 		}
 	}
 	s.metrics.push(metrics)
-	s.lastIngest = time.Now()
+	changedAt := time.Now()
+	s.lastIngest = changedAt
 	s.mu.Unlock()
+	if reset {
+		s.runInvalidateCallback()
+	}
+	s.runChangeCallback(changedAt)
 	if reset {
 		s.notify(SignalTraces)
 		s.notify(SignalMetrics)
 		s.notify(SignalLogs)
-	} else {
-		s.notify(SignalMetrics)
+		return
 	}
+	s.notify(SignalMetrics)
 }
 
 // AddLogsForConnection adds logs with an associated connection ID for later eviction.
@@ -364,15 +402,20 @@ func (s *Store) AddLogsForConnection(connID string, logs []LogRecord) {
 		}
 	}
 	s.logs.push(logs)
-	s.lastIngest = time.Now()
+	changedAt := time.Now()
+	s.lastIngest = changedAt
 	s.mu.Unlock()
+	if reset {
+		s.runInvalidateCallback()
+	}
+	s.runChangeCallback(changedAt)
 	if reset {
 		s.notify(SignalTraces)
 		s.notify(SignalMetrics)
 		s.notify(SignalLogs)
-	} else {
-		s.notify(SignalLogs)
+		return
 	}
+	s.notify(SignalLogs)
 }
 
 // Clear removes all stored telemetry and resets the session clock.
@@ -383,6 +426,7 @@ func (s *Store) Clear() {
 	s.logs.clear()
 	s.lastIngest = time.Time{}
 	s.mu.Unlock()
+	s.runInvalidateCallback()
 	s.notify(SignalTraces)
 	s.notify(SignalMetrics)
 	s.notify(SignalLogs)
@@ -407,6 +451,10 @@ func (s *Store) EvictConnection(connID string) {
 		s.lastIngest = time.Time{}
 	}
 	s.mu.Unlock()
+
+	if hasSpans || hasMetrics || hasLogs {
+		s.runInvalidateCallback()
+	}
 
 	if hasSpans {
 		s.notify(SignalTraces)
@@ -732,6 +780,29 @@ func (s *Store) Stats() Stats {
 	}
 }
 
+// SnapshotTelemetry returns a point-in-time copy of all retained telemetry.
+func (s *Store) SnapshotTelemetry() TelemetrySnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	spans := s.spans.snapshot()
+	metrics := s.metrics.snapshot()
+	logs := s.logs.snapshot()
+
+	return TelemetrySnapshot{
+		Spans:   append([]Span(nil), spans...),
+		Metrics: append([]MetricDataPoint(nil), metrics...),
+		Logs:    append([]LogRecord(nil), logs...),
+	}
+}
+
+// LastIngest returns the timestamp of the most recent telemetry ingest.
+func (s *Store) LastIngest() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastIngest
+}
+
 // Subscribe registers for updates on store changes and returns a subscription ID and channel.
 func (s *Store) Subscribe() (int, <-chan Signal) {
 	ch := make(chan Signal, 8)
@@ -761,8 +832,26 @@ func (s *Store) notify(sig Signal) {
 	for _, ch := range s.subscribers {
 		select {
 		case ch <- sig:
-			default:
+		default:
 		}
+	}
+}
+
+func (s *Store) runInvalidateCallback() {
+	s.invalidateMu.RLock()
+	fn := s.invalidate
+	s.invalidateMu.RUnlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+func (s *Store) runChangeCallback(changedAt time.Time) {
+	s.changeMu.RLock()
+	fn := s.change
+	s.changeMu.RUnlock()
+	if fn != nil {
+		fn(changedAt)
 	}
 }
 

--- a/observer/internal/validator/export.go
+++ b/observer/internal/validator/export.go
@@ -1,0 +1,575 @@
+package validator
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	telemetrystore "github.com/signalfx/obstudio/observer/internal/store"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+type snapshotSignals struct {
+	traces  ptrace.Traces
+	metrics pmetric.Metrics
+	logs    plog.Logs
+}
+
+func buildSnapshotSignals(snapshot telemetrystore.TelemetrySnapshot) (snapshotSignals, error) {
+	traces, err := buildSnapshotTraces(snapshot.Spans)
+	if err != nil {
+		return snapshotSignals{}, err
+	}
+	metrics, err := buildSnapshotMetrics(snapshot.Metrics)
+	if err != nil {
+		return snapshotSignals{}, err
+	}
+	logs, err := buildSnapshotLogs(snapshot.Logs)
+	if err != nil {
+		return snapshotSignals{}, err
+	}
+	return snapshotSignals{traces: traces, metrics: metrics, logs: logs}, nil
+}
+
+func buildSnapshotTraces(spans []telemetrystore.Span) (ptrace.Traces, error) {
+	td := ptrace.NewTraces()
+	resourceMap := make(map[string]ptrace.ResourceSpans)
+
+	for _, span := range spans {
+		rs, err := getOrAppendResourceSpans(td.ResourceSpans(), resourceMap, span.Resource)
+		if err != nil {
+			return ptrace.NewTraces(), err
+		}
+		scopeSpans := getOrAppendScopeSpans(rs.ScopeSpans(), scopeKey(span.Scope))
+		pspan := scopeSpans.Spans().AppendEmpty()
+
+		traceID, err := decodeTraceID(span.TraceID)
+		if err != nil {
+			return ptrace.NewTraces(), fmt.Errorf("decode trace id: %w", err)
+		}
+		spanID, err := decodeSpanID(span.SpanID)
+		if err != nil {
+			return ptrace.NewTraces(), fmt.Errorf("decode span id: %w", err)
+		}
+		parentSpanID, err := decodeOptionalSpanID(span.ParentSpanID)
+		if err != nil {
+			return ptrace.NewTraces(), fmt.Errorf("decode parent span id: %w", err)
+		}
+
+		pspan.SetTraceID(traceID)
+		pspan.SetSpanID(spanID)
+		if parentSpanID != ([8]byte{}) {
+			pspan.SetParentSpanID(parentSpanID)
+		}
+		pspan.SetName(span.Name)
+		pspan.SetKind(spanKindFromString(span.Kind))
+		pspan.SetStartTimestamp(pcommon.NewTimestampFromTime(span.StartTime))
+		pspan.SetEndTimestamp(pcommon.NewTimestampFromTime(span.EndTime))
+		if err := setMapValues(pspan.Attributes(), span.Attributes); err != nil {
+			return ptrace.NewTraces(), err
+		}
+		status := pspan.Status()
+		status.SetCode(statusCodeFromString(span.Status.Code))
+		status.SetMessage(span.Status.Message)
+
+		events := pspan.Events()
+		for _, event := range span.Events {
+			pEvent := events.AppendEmpty()
+			pEvent.SetName(event.Name)
+			pEvent.SetTimestamp(pcommon.NewTimestampFromTime(event.Timestamp))
+			if err := setMapValues(pEvent.Attributes(), event.Attributes); err != nil {
+				return ptrace.NewTraces(), err
+			}
+		}
+
+		links := pspan.Links()
+		for _, link := range span.Links {
+			pLink := links.AppendEmpty()
+			linkTraceID, err := decodeTraceID(link.TraceID)
+			if err != nil {
+				return ptrace.NewTraces(), fmt.Errorf("decode link trace id: %w", err)
+			}
+			linkSpanID, err := decodeSpanID(link.SpanID)
+			if err != nil {
+				return ptrace.NewTraces(), fmt.Errorf("decode link span id: %w", err)
+			}
+			pLink.SetTraceID(linkTraceID)
+			pLink.SetSpanID(linkSpanID)
+			if err := setMapValues(pLink.Attributes(), link.Attributes); err != nil {
+				return ptrace.NewTraces(), err
+			}
+		}
+	}
+
+	return td, nil
+}
+
+func buildSnapshotMetrics(points []telemetrystore.MetricDataPoint) (pmetric.Metrics, error) {
+	md := pmetric.NewMetrics()
+	resourceMap := make(map[string]pmetric.ResourceMetrics)
+	metricMap := make(map[string]pmetric.Metric)
+
+	for _, point := range points {
+		rm, err := getOrAppendResourceMetrics(md.ResourceMetrics(), resourceMap, point.Resource)
+		if err != nil {
+			return pmetric.NewMetrics(), err
+		}
+		sm := getOrAppendScopeMetrics(rm.ScopeMetrics(), scopeKey(point.Scope))
+
+		key := metricKey(point)
+		metric, ok := metricMap[key]
+		if !ok {
+			metric = sm.Metrics().AppendEmpty()
+			metric.SetName(point.Name)
+			metric.SetDescription(point.Description)
+			metric.SetUnit(point.Unit)
+			initializeMetric(metric, point)
+			metricMap[key] = metric
+		}
+
+		switch point.Type {
+		case "gauge":
+			dp := metric.Gauge().DataPoints().AppendEmpty()
+			populateNumberDataPoint(dp, point)
+		case "sum", "counter":
+			dp := metric.Sum().DataPoints().AppendEmpty()
+			populateNumberDataPoint(dp, point)
+		case "histogram":
+			dp := metric.Histogram().DataPoints().AppendEmpty()
+			populateHistogramDataPoint(dp, point)
+		case "summary":
+			dp := metric.Summary().DataPoints().AppendEmpty()
+			populateSummaryDataPoint(dp, point)
+		case "exponential_histogram":
+			dp := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+			populateExpHistogramDataPoint(dp, point)
+		default:
+			dp := metric.Gauge().DataPoints().AppendEmpty()
+			populateNumberDataPoint(dp, point)
+		}
+	}
+
+	return md, nil
+}
+
+func buildSnapshotLogs(records []telemetrystore.LogRecord) (plog.Logs, error) {
+	ld := plog.NewLogs()
+	resourceMap := make(map[string]plog.ResourceLogs)
+
+	for _, record := range records {
+		rl, err := getOrAppendResourceLogs(ld.ResourceLogs(), resourceMap, record.Resource)
+		if err != nil {
+			return plog.NewLogs(), err
+		}
+		scopeLogs := getOrAppendScopeLogs(rl.ScopeLogs(), scopeKey(record.Scope))
+		logRecord := scopeLogs.LogRecords().AppendEmpty()
+
+		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(record.Timestamp))
+		logRecord.SetSeverityNumber(plog.SeverityNumber(record.SeverityNumber))
+		logRecord.SetSeverityText(record.SeverityText)
+		logRecord.Body().SetStr(record.Body)
+		if err := setMapValues(logRecord.Attributes(), record.Attributes); err != nil {
+			return plog.NewLogs(), err
+		}
+		traceID, err := decodeOptionalTraceID(record.TraceID)
+		if err != nil {
+			return plog.NewLogs(), fmt.Errorf("decode log trace id: %w", err)
+		}
+		if traceID != ([16]byte{}) {
+			logRecord.SetTraceID(traceID)
+		}
+		spanID, err := decodeOptionalSpanID(record.SpanID)
+		if err != nil {
+			return plog.NewLogs(), fmt.Errorf("decode log span id: %w", err)
+		}
+		if spanID != ([8]byte{}) {
+			logRecord.SetSpanID(spanID)
+		}
+	}
+
+	return ld, nil
+}
+
+func initializeMetric(metric pmetric.Metric, point telemetrystore.MetricDataPoint) {
+	switch point.Type {
+	case "sum", "counter":
+		sum := metric.SetEmptySum()
+		sum.SetAggregationTemporality(temporalityFromString(point.Temporality))
+		sum.SetIsMonotonic(point.IsMonotonic)
+	case "histogram":
+		hist := metric.SetEmptyHistogram()
+		hist.SetAggregationTemporality(temporalityFromString(point.Temporality))
+	case "summary":
+		metric.SetEmptySummary()
+	case "exponential_histogram":
+		exp := metric.SetEmptyExponentialHistogram()
+		exp.SetAggregationTemporality(temporalityFromString(point.Temporality))
+	default:
+		metric.SetEmptyGauge()
+	}
+}
+
+func populateNumberDataPoint(dp pmetric.NumberDataPoint, point telemetrystore.MetricDataPoint) {
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(point.Timestamp))
+	if !point.StartTime.IsZero() {
+		dp.SetStartTimestamp(pcommon.NewTimestampFromTime(point.StartTime))
+	}
+	dp.SetDoubleValue(point.Value)
+	dp.SetFlags(pmetric.DataPointFlags(point.Flags))
+	_ = setMapValues(dp.Attributes(), point.Attributes)
+}
+
+func populateHistogramDataPoint(dp pmetric.HistogramDataPoint, point telemetrystore.MetricDataPoint) {
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(point.Timestamp))
+	if !point.StartTime.IsZero() {
+		dp.SetStartTimestamp(pcommon.NewTimestampFromTime(point.StartTime))
+	}
+	dp.SetCount(point.Count)
+	dp.SetSum(point.Sum)
+	dp.SetMin(point.Min)
+	dp.SetMax(point.Max)
+	dp.SetFlags(pmetric.DataPointFlags(point.Flags))
+	dp.BucketCounts().FromRaw(point.BucketCounts)
+	dp.ExplicitBounds().FromRaw(point.ExplicitBounds)
+	_ = setMapValues(dp.Attributes(), point.Attributes)
+}
+
+func populateSummaryDataPoint(dp pmetric.SummaryDataPoint, point telemetrystore.MetricDataPoint) {
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(point.Timestamp))
+	if !point.StartTime.IsZero() {
+		dp.SetStartTimestamp(pcommon.NewTimestampFromTime(point.StartTime))
+	}
+	dp.SetCount(point.Count)
+	dp.SetSum(point.Sum)
+	dp.SetFlags(pmetric.DataPointFlags(point.Flags))
+	quantiles := dp.QuantileValues()
+	for _, quantile := range point.Quantiles {
+		qv := quantiles.AppendEmpty()
+		qv.SetQuantile(quantile.Quantile)
+		qv.SetValue(quantile.Value)
+	}
+	_ = setMapValues(dp.Attributes(), point.Attributes)
+}
+
+func populateExpHistogramDataPoint(dp pmetric.ExponentialHistogramDataPoint, point telemetrystore.MetricDataPoint) {
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(point.Timestamp))
+	if !point.StartTime.IsZero() {
+		dp.SetStartTimestamp(pcommon.NewTimestampFromTime(point.StartTime))
+	}
+	dp.SetCount(point.Count)
+	dp.SetSum(point.Sum)
+	dp.SetMin(point.Min)
+	dp.SetMax(point.Max)
+	dp.SetScale(0)
+	dp.SetZeroCount(0)
+	dp.Positive().SetOffset(0)
+	dp.Negative().SetOffset(0)
+	dp.SetFlags(pmetric.DataPointFlags(point.Flags))
+	_ = setMapValues(dp.Attributes(), point.Attributes)
+}
+
+func getOrAppendResourceSpans(items ptrace.ResourceSpansSlice, cache map[string]ptrace.ResourceSpans, resource telemetrystore.Resource) (ptrace.ResourceSpans, error) {
+	key := resourceKey(resource)
+	if existing, ok := cache[key]; ok {
+		return existing, nil
+	}
+	item := items.AppendEmpty()
+	if err := populateResource(item.Resource(), resource); err != nil {
+		return ptrace.ResourceSpans{}, err
+	}
+	item.SetSchemaUrl(resource.SchemaURL)
+	cache[key] = item
+	return item, nil
+}
+
+func getOrAppendScopeSpans(items ptrace.ScopeSpansSlice, scope telemetrystore.Scope) ptrace.ScopeSpans {
+	for i := 0; i < items.Len(); i++ {
+		item := items.At(i)
+		if item.Scope().Name() == scope.Name && item.Scope().Version() == scope.Version && item.SchemaUrl() == scope.SchemaURL {
+			return item
+		}
+	}
+	item := items.AppendEmpty()
+	populateScope(item.Scope(), scope)
+	item.SetSchemaUrl(scope.SchemaURL)
+	return item
+}
+
+func getOrAppendResourceMetrics(items pmetric.ResourceMetricsSlice, cache map[string]pmetric.ResourceMetrics, resource telemetrystore.Resource) (pmetric.ResourceMetrics, error) {
+	key := resourceKey(resource)
+	if existing, ok := cache[key]; ok {
+		return existing, nil
+	}
+	item := items.AppendEmpty()
+	if err := populateResource(item.Resource(), resource); err != nil {
+		return pmetric.ResourceMetrics{}, err
+	}
+	item.SetSchemaUrl(resource.SchemaURL)
+	cache[key] = item
+	return item, nil
+}
+
+func getOrAppendScopeMetrics(items pmetric.ScopeMetricsSlice, scope telemetrystore.Scope) pmetric.ScopeMetrics {
+	for i := 0; i < items.Len(); i++ {
+		item := items.At(i)
+		if item.Scope().Name() == scope.Name && item.Scope().Version() == scope.Version && item.SchemaUrl() == scope.SchemaURL {
+			return item
+		}
+	}
+	item := items.AppendEmpty()
+	populateScope(item.Scope(), scope)
+	item.SetSchemaUrl(scope.SchemaURL)
+	return item
+}
+
+func getOrAppendResourceLogs(items plog.ResourceLogsSlice, cache map[string]plog.ResourceLogs, resource telemetrystore.Resource) (plog.ResourceLogs, error) {
+	key := resourceKey(resource)
+	if existing, ok := cache[key]; ok {
+		return existing, nil
+	}
+	item := items.AppendEmpty()
+	if err := populateResource(item.Resource(), resource); err != nil {
+		return plog.ResourceLogs{}, err
+	}
+	item.SetSchemaUrl(resource.SchemaURL)
+	cache[key] = item
+	return item, nil
+}
+
+func getOrAppendScopeLogs(items plog.ScopeLogsSlice, scope telemetrystore.Scope) plog.ScopeLogs {
+	for i := 0; i < items.Len(); i++ {
+		item := items.At(i)
+		if item.Scope().Name() == scope.Name && item.Scope().Version() == scope.Version && item.SchemaUrl() == scope.SchemaURL {
+			return item
+		}
+	}
+	item := items.AppendEmpty()
+	populateScope(item.Scope(), scope)
+	item.SetSchemaUrl(scope.SchemaURL)
+	return item
+}
+
+func resourceKey(resource telemetrystore.Resource) string {
+	return marshalExportKey(struct {
+		SchemaURL string         `json:"schemaUrl"`
+		Service   string         `json:"serviceName"`
+		Attrs     map[string]any `json:"attributes"`
+	}{
+		SchemaURL: resource.SchemaURL,
+		Service:   resource.ServiceName,
+		Attrs:     resourceAttributes(resource),
+	})
+}
+
+func scopeKey(scope telemetrystore.Scope) telemetrystore.Scope {
+	return scope
+}
+
+func metricKey(point telemetrystore.MetricDataPoint) string {
+	return marshalExportKey(struct {
+		Resource string `json:"resource"`
+		Scope    string `json:"scope"`
+		Name     string `json:"name"`
+		Desc     string `json:"description"`
+		Unit     string `json:"unit"`
+		Type     string `json:"type"`
+		Temp     string `json:"temporality"`
+		Mono     bool   `json:"monotonic"`
+	}{
+		Resource: resourceKey(point.Resource),
+		Scope:    point.Scope.Name + "|" + point.Scope.Version + "|" + point.Scope.SchemaURL,
+		Name:     point.Name,
+		Desc:     point.Description,
+		Unit:     point.Unit,
+		Type:     point.Type,
+		Temp:     point.Temporality,
+		Mono:     point.IsMonotonic,
+	})
+}
+
+func marshalExportKey(value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Sprintf("marshal export key: %v", err))
+	}
+	return string(data)
+}
+
+func populateResource(resource pcommon.Resource, value telemetrystore.Resource) error {
+	return setMapValues(resource.Attributes(), resourceAttributes(value))
+}
+
+func populateScope(scope pcommon.InstrumentationScope, value telemetrystore.Scope) {
+	scope.SetName(value.Name)
+	scope.SetVersion(value.Version)
+}
+
+func resourceAttributes(resource telemetrystore.Resource) map[string]any {
+	if resource.ServiceName == "" {
+		return resource.Attributes
+	}
+	attrs := make(map[string]any, len(resource.Attributes)+1)
+	for key, value := range resource.Attributes {
+		attrs[key] = value
+	}
+	if _, ok := attrs["service.name"]; !ok {
+		attrs["service.name"] = resource.ServiceName
+	}
+	return attrs
+}
+
+func setMapValues(dest pcommon.Map, values map[string]any) error {
+	for key, value := range values {
+		if err := setValue(dest.PutEmpty(key), value); err != nil {
+			return fmt.Errorf("attribute %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func setValue(dest pcommon.Value, value any) error {
+	switch v := value.(type) {
+	case nil:
+		dest.SetEmptyBytes()
+	case string:
+		dest.SetStr(v)
+	case bool:
+		dest.SetBool(v)
+	case int:
+		dest.SetInt(int64(v))
+	case int8:
+		dest.SetInt(int64(v))
+	case int16:
+		dest.SetInt(int64(v))
+	case int32:
+		dest.SetInt(int64(v))
+	case int64:
+		dest.SetInt(v)
+	case uint:
+		dest.SetInt(int64(v))
+	case uint8:
+		dest.SetInt(int64(v))
+	case uint16:
+		dest.SetInt(int64(v))
+	case uint32:
+		dest.SetInt(int64(v))
+	case uint64:
+		dest.SetInt(int64(v))
+	case float32:
+		dest.SetDouble(float64(v))
+	case float64:
+		dest.SetDouble(v)
+	case []byte:
+		dest.SetEmptyBytes().FromRaw(v)
+	case []any:
+		arr := dest.SetEmptySlice()
+		for _, item := range v {
+			if err := setValue(arr.AppendEmpty(), item); err != nil {
+				return err
+			}
+		}
+	case []string:
+		arr := dest.SetEmptySlice()
+		for _, item := range v {
+			arr.AppendEmpty().SetStr(item)
+		}
+	case []int:
+		arr := dest.SetEmptySlice()
+		for _, item := range v {
+			arr.AppendEmpty().SetInt(int64(item))
+		}
+	case []float64:
+		arr := dest.SetEmptySlice()
+		for _, item := range v {
+			arr.AppendEmpty().SetDouble(item)
+		}
+	case map[string]any:
+		kv := dest.SetEmptyMap()
+		return setMapValues(kv, v)
+	default:
+		return fmt.Errorf("unsupported attribute type %T", value)
+	}
+	return nil
+}
+
+func decodeTraceID(value string) (pcommon.TraceID, error) {
+	var id pcommon.TraceID
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return id, err
+	}
+	if len(decoded) != len(id) {
+		return id, fmt.Errorf("expected 16 bytes, got %d", len(decoded))
+	}
+	copy(id[:], decoded)
+	return id, nil
+}
+
+func decodeOptionalTraceID(value string) (pcommon.TraceID, error) {
+	if value == "" {
+		return pcommon.TraceID{}, nil
+	}
+	return decodeTraceID(value)
+}
+
+func decodeSpanID(value string) (pcommon.SpanID, error) {
+	var id pcommon.SpanID
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return id, err
+	}
+	if len(decoded) != len(id) {
+		return id, fmt.Errorf("expected 8 bytes, got %d", len(decoded))
+	}
+	copy(id[:], decoded)
+	return id, nil
+}
+
+func decodeOptionalSpanID(value string) (pcommon.SpanID, error) {
+	if value == "" {
+		return pcommon.SpanID{}, nil
+	}
+	return decodeSpanID(value)
+}
+
+func spanKindFromString(value string) ptrace.SpanKind {
+	switch value {
+	case "INTERNAL":
+		return ptrace.SpanKindInternal
+	case "SERVER":
+		return ptrace.SpanKindServer
+	case "CLIENT":
+		return ptrace.SpanKindClient
+	case "PRODUCER":
+		return ptrace.SpanKindProducer
+	case "CONSUMER":
+		return ptrace.SpanKindConsumer
+	default:
+		return ptrace.SpanKindUnspecified
+	}
+}
+
+func statusCodeFromString(value string) ptrace.StatusCode {
+	switch value {
+	case "OK":
+		return ptrace.StatusCodeOk
+	case "ERROR":
+		return ptrace.StatusCodeError
+	default:
+		return ptrace.StatusCodeUnset
+	}
+}
+
+func temporalityFromString(value string) pmetric.AggregationTemporality {
+	switch value {
+	case "delta":
+		return pmetric.AggregationTemporalityDelta
+	case "cumulative":
+		return pmetric.AggregationTemporalityCumulative
+	default:
+		return pmetric.AggregationTemporalityUnspecified
+	}
+}

--- a/observer/internal/validator/manager.go
+++ b/observer/internal/validator/manager.go
@@ -1,0 +1,633 @@
+package validator
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	telemetrystore "github.com/signalfx/obstudio/observer/internal/store"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const defaultValidatorHealthTimeout = 90 * time.Second
+
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+type Manager struct {
+	store     *Store
+	telemetry *telemetrystore.Store
+
+	mu           sync.Mutex
+	activeRunID  string
+	activeCancel context.CancelFunc
+	runSeq       atomic.Uint64
+}
+
+func NewManager(store *Store, telemetry *telemetrystore.Store) *Manager {
+	return &Manager{store: store, telemetry: telemetry}
+}
+
+func (m *Manager) Start(context.Context) error {
+	if _, err := resolveWeaverPath(); err != nil {
+		m.store.SetRuntimeStatus(StatusDisabled, "Weaver runtime not found beside obstudio or on PATH")
+		return nil
+	}
+	m.store.SetRuntimeStatus(StatusIdle, "Validation has not been run yet")
+	return nil
+}
+
+func (m *Manager) Shutdown(context.Context) error {
+	m.cancelActiveRun()
+	return nil
+}
+
+func (m *Manager) Reset() {
+	m.cancelActiveRun()
+	m.store.Clear()
+}
+
+func (m *Manager) MarkTelemetryChanged(changedAt time.Time) {
+	m.store.MarkTelemetryChanged(changedAt)
+}
+
+func (m *Manager) Run(context.Context) Summary {
+	if _, err := resolveWeaverPath(); err != nil {
+		m.cancelActiveRun()
+		m.store.SetRuntimeStatus(StatusDisabled, "Weaver runtime not found beside obstudio or on PATH")
+		return m.store.Summary()
+	}
+
+	summary := m.store.Summary()
+	if summary.Status == StatusDisabled {
+		m.store.SetRuntimeStatus(StatusIdle, "Validation has not been run yet")
+	}
+
+	runID := fmt.Sprintf("run-%d", m.runSeq.Add(1))
+	startedAt := time.Now()
+	summary = m.store.StartRun(runID, startedAt)
+	if summary.ActiveRunID != runID || summary.Status != StatusRunning {
+		return summary
+	}
+
+	snapshot := m.telemetry.SnapshotTelemetry()
+	runCtx, cancel := context.WithCancel(context.Background())
+	m.setActiveRun(runID, cancel)
+
+	go m.executeRun(runCtx, runID, snapshot)
+
+	return m.store.Summary()
+}
+
+func (m *Manager) executeRun(ctx context.Context, runID string, snapshot telemetrystore.TelemetrySnapshot) {
+	defer m.clearActiveRun(runID)
+
+	if len(snapshot.Spans) == 0 && len(snapshot.Metrics) == 0 && len(snapshot.Logs) == 0 {
+		m.store.CompleteRun(runID, map[string]Entity{}, weaverStats{}, time.Now())
+		return
+	}
+
+	path, err := resolveWeaverPath()
+	if err != nil {
+		m.store.FailRun(runID, "Weaver runtime not found beside obstudio or on PATH", time.Now())
+		return
+	}
+
+	signals, err := buildSnapshotSignals(snapshot)
+	if err != nil {
+		m.store.FailRun(runID, fmt.Sprintf("build validation snapshot: %v", err), time.Now())
+		return
+	}
+
+	result, err := runWeaverSnapshot(ctx, path, signals)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		m.store.FailRun(runID, fmt.Sprintf("validation failed: %v", err), time.Now())
+		return
+	}
+
+	enrichValidationEntities(result.entities, snapshot)
+	m.store.CompleteRun(runID, result.entities, result.stats, time.Now())
+}
+
+func (m *Manager) setActiveRun(runID string, cancel context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.activeRunID = runID
+	m.activeCancel = cancel
+}
+
+func (m *Manager) clearActiveRun(runID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.activeRunID != runID {
+		return
+	}
+	m.activeRunID = ""
+	m.activeCancel = nil
+}
+
+func (m *Manager) cancelActiveRun() {
+	m.mu.Lock()
+	cancel := m.activeCancel
+	m.activeRunID = ""
+	m.activeCancel = nil
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+type runResult struct {
+	entities map[string]Entity
+	stats    weaverStats
+}
+
+type runCollector struct {
+	mu       sync.Mutex
+	entities map[string]Entity
+	stats    weaverStats
+}
+
+func newRunCollector() *runCollector {
+	return &runCollector{entities: make(map[string]Entity)}
+}
+
+func (c *runCollector) readStdout(stdout io.Reader) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		normalized, ok, err := normalizeLine(line, time.Now())
+		if err != nil {
+			log.Printf("[validator] parse error: %v", err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		c.mu.Lock()
+		if normalized.Entity != nil {
+			c.entities[normalized.Entity.Key] = *normalized.Entity
+		}
+		if normalized.Stats != nil {
+			c.stats = *normalized.Stats
+		}
+		c.mu.Unlock()
+	}
+}
+
+func (c *runCollector) snapshot() runResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entities := make(map[string]Entity, len(c.entities))
+	for key, entity := range c.entities {
+		entities[key] = entity
+	}
+	return runResult{entities: entities, stats: c.stats}
+}
+
+func runWeaverSnapshot(ctx context.Context, binaryPath string, signals snapshotSignals) (runResult, error) {
+	otlpPort, err := pickFreePort()
+	if err != nil {
+		return runResult{}, fmt.Errorf("pick validator OTLP port: %w", err)
+	}
+	adminPort, err := pickFreePort()
+	if err != nil {
+		return runResult{}, fmt.Errorf("pick validator admin port: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, binaryPath,
+		"registry", "live-check",
+		"--format", "jsonl",
+		"--otlp-grpc-port", otlpPort,
+		"--admin-port", adminPort,
+		"--inactivity-timeout", "0",
+	)
+	cmd.Dir = validatorWorkingDir(binaryPath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return runResult{}, fmt.Errorf("weaver stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return runResult{}, fmt.Errorf("weaver stderr pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return runResult{}, fmt.Errorf("start weaver: %w", err)
+	}
+
+	adminURL := "http://127.0.0.1:" + adminPort
+	collector := newRunCollector()
+	stderrCollector := newValidatorStderr()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		collector.readStdout(stdout)
+	}()
+	go func() {
+		defer wg.Done()
+		readStderr(stderr, stderrCollector)
+	}()
+
+	if err := waitForHealth(ctx, adminURL+"/health", validatorHealthTimeout()); err != nil {
+		gracefulStop, processErr := stopProcess(cmd, adminURL)
+		wg.Wait()
+		return runResult{}, validatorStartupError(err, processErr, gracefulStop, stderrCollector.summary())
+	}
+
+	conn, err := grpc.NewClient("127.0.0.1:"+otlpPort, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		stopProcess(cmd, adminURL)
+		wg.Wait()
+		return runResult{}, fmt.Errorf("connect to weaver: %w", err)
+	}
+	defer conn.Close()
+
+	if err := exportSnapshot(ctx, conn, signals); err != nil {
+		stopProcess(cmd, adminURL)
+		wg.Wait()
+		return runResult{}, err
+	}
+
+	gracefulStop, processErr := stopProcess(cmd, adminURL)
+	wg.Wait()
+	if processErr != nil && !isExpectedExit(processErr, gracefulStop) && !errors.Is(processErr, context.Canceled) {
+		return runResult{}, fmt.Errorf("weaver exit: %w", processErr)
+	}
+
+	return collector.snapshot(), nil
+}
+
+func exportSnapshot(ctx context.Context, conn *grpc.ClientConn, signals snapshotSignals) error {
+	traceClient := ptraceotlp.NewGRPCClient(conn)
+	metricClient := pmetricotlp.NewGRPCClient(conn)
+	logClient := plogotlp.NewGRPCClient(conn)
+
+	if signals.traces.ResourceSpans().Len() > 0 {
+		exportCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if _, err := traceClient.Export(exportCtx, ptraceotlp.NewExportRequestFromTraces(signals.traces)); err != nil {
+			return fmt.Errorf("export traces: %w", err)
+		}
+	}
+	if signals.metrics.ResourceMetrics().Len() > 0 {
+		exportCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if _, err := metricClient.Export(exportCtx, pmetricotlp.NewExportRequestFromMetrics(signals.metrics)); err != nil {
+			return fmt.Errorf("export metrics: %w", err)
+		}
+	}
+	if signals.logs.ResourceLogs().Len() > 0 {
+		exportCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if _, err := logClient.Export(exportCtx, plogotlp.NewExportRequestFromLogs(signals.logs)); err != nil {
+			return fmt.Errorf("export logs: %w", err)
+		}
+	}
+	return nil
+}
+
+func readStderr(stderr io.Reader, collector *validatorStderr) {
+	scanner := bufio.NewScanner(stderr)
+	scanner.Buffer(make([]byte, 0, 16*1024), 512*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		log.Printf("[validator] %s", line)
+		if collector != nil {
+			collector.add(line)
+		}
+	}
+}
+
+func enrichValidationEntities(entities map[string]Entity, snapshot telemetrystore.TelemetrySnapshot) {
+	spanByID := make(map[string]telemetrystore.Span, len(snapshot.Spans))
+	spanByName := make(map[string]signalMetadata)
+	metricByName := make(map[string]signalMetadata)
+	logByBody := make(map[string]signalMetadata)
+
+	for _, span := range snapshot.Spans {
+		if span.TraceID != "" && span.SpanID != "" {
+			spanByID[span.TraceID+":"+span.SpanID] = span
+		}
+		addSignalMetadata(spanByName, span.Name, span.Resource.ServiceName, span.Scope.Name)
+	}
+	for _, metric := range snapshot.Metrics {
+		addSignalMetadata(metricByName, metric.Name, metric.Resource.ServiceName, metric.Scope.Name)
+	}
+	for _, record := range snapshot.Logs {
+		addSignalMetadata(logByBody, record.Body, record.Resource.ServiceName, record.Scope.Name)
+	}
+
+	for key, entity := range entities {
+		entity.Signal = enrichSignalRef(entity.Signal, spanByID, spanByName, metricByName, logByBody)
+		for i := range entity.Findings {
+			entity.Findings[i].Signal = enrichSignalRef(entity.Findings[i].Signal, spanByID, spanByName, metricByName, logByBody)
+		}
+		entities[key] = entity
+	}
+}
+
+type signalMetadata struct {
+	serviceName string
+	scopeName   string
+	ambiguous   bool
+}
+
+func addSignalMetadata(index map[string]signalMetadata, key, serviceName, scopeName string) {
+	if key == "" {
+		return
+	}
+	if current, ok := index[key]; ok {
+		if current.serviceName != serviceName || current.scopeName != scopeName {
+			current.ambiguous = true
+			index[key] = current
+		}
+		return
+	}
+	index[key] = signalMetadata{
+		serviceName: serviceName,
+		scopeName:   scopeName,
+	}
+}
+
+func enrichSignalRef(
+	signal SignalRef,
+	spanByID map[string]telemetrystore.Span,
+	spanByName map[string]signalMetadata,
+	metricByName map[string]signalMetadata,
+	logByBody map[string]signalMetadata,
+) SignalRef {
+	switch normalizeSignalType(signal.Type) {
+	case "span":
+		signal.MetricName = ""
+		if signal.TraceID != "" && signal.SpanID != "" {
+			if span, ok := spanByID[signal.TraceID+":"+signal.SpanID]; ok {
+				if signal.ServiceName == "" {
+					signal.ServiceName = span.Resource.ServiceName
+				}
+				if signal.ScopeName == "" {
+					signal.ScopeName = span.Scope.Name
+				}
+				if signal.SpanName == "" {
+					signal.SpanName = span.Name
+				}
+				return signal
+			}
+		}
+		if meta, ok := spanByName[signal.SpanName]; ok && !meta.ambiguous {
+			if signal.ServiceName == "" {
+				signal.ServiceName = meta.serviceName
+			}
+			if signal.ScopeName == "" {
+				signal.ScopeName = meta.scopeName
+			}
+		}
+	case "metric":
+		if meta, ok := metricByName[signal.MetricName]; ok && !meta.ambiguous {
+			if signal.ServiceName == "" {
+				signal.ServiceName = meta.serviceName
+			}
+			if signal.ScopeName == "" {
+				signal.ScopeName = meta.scopeName
+			}
+		}
+	case "log":
+		if meta, ok := logByBody[signal.LogBody]; ok && !meta.ambiguous {
+			if signal.ServiceName == "" {
+				signal.ServiceName = meta.serviceName
+			}
+			if signal.ScopeName == "" {
+				signal.ScopeName = meta.scopeName
+			}
+		}
+	}
+
+	return signal
+}
+
+type validatorStderr struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func newValidatorStderr() *validatorStderr {
+	return &validatorStderr{lines: make([]string, 0, 8)}
+}
+
+func (c *validatorStderr) add(line string) {
+	cleaned := strings.TrimSpace(ansiEscapePattern.ReplaceAllString(line, ""))
+	if cleaned == "" {
+		return
+	}
+	if isValidatorNoise(cleaned) {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.lines) == cap(c.lines) {
+		copy(c.lines, c.lines[1:])
+		c.lines = c.lines[:len(c.lines)-1]
+	}
+	c.lines = append(c.lines, cleaned)
+}
+
+func (c *validatorStderr) summary() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.lines) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(c.lines))
+	for _, line := range c.lines {
+		trimmed := strings.TrimSpace(strings.TrimLeft(line, "×│• "))
+		if trimmed == "" {
+			continue
+		}
+		parts = append(parts, trimmed)
+	}
+	return strings.Join(parts, " ")
+}
+
+func isValidatorNoise(line string) bool {
+	switch {
+	case strings.HasPrefix(line, "Weaver Registry Live Check"):
+		return true
+	case strings.HasPrefix(line, "Resolving registry "):
+		return true
+	case strings.HasPrefix(line, "Diagnostic report"):
+		return true
+	case strings.HasPrefix(line, "Total execution time:"):
+		return true
+	case strings.HasPrefix(line, "ℹ To stop the OTLP receiver:"):
+		return true
+	case strings.HasPrefix(line, "The OTLP receiver will run indefinitely"):
+		return true
+	case strings.HasPrefix(line, "✔ "):
+		return true
+	default:
+		return false
+	}
+}
+
+func validatorStartupError(waitErr error, processErr error, gracefulStop bool, stderrSummary string) error {
+	if errors.Is(waitErr, context.Canceled) {
+		return waitErr
+	}
+	if stderrSummary != "" {
+		return fmt.Errorf("validator startup failed: %s", stderrSummary)
+	}
+	if processErr != nil && !isExpectedExit(processErr, gracefulStop) && !errors.Is(processErr, context.Canceled) {
+		return fmt.Errorf("validator startup failed: %w", processErr)
+	}
+	return waitErr
+}
+
+func resolveWeaverPath() (string, error) {
+	if custom := os.Getenv("WEAVER_PATH"); custom != "" {
+		return custom, nil
+	}
+
+	exe, err := os.Executable()
+	if err == nil {
+		candidates := []string{filepath.Join(filepath.Dir(exe), "weaver")}
+		if runtime.GOOS == "windows" {
+			candidates = append(candidates, filepath.Join(filepath.Dir(exe), "weaver.exe"))
+		}
+		for _, candidate := range candidates {
+			if _, statErr := os.Stat(candidate); statErr == nil {
+				return candidate, nil
+			}
+		}
+	}
+
+	return exec.LookPath("weaver")
+}
+
+func validatorWorkingDir(binaryPath string) string {
+	if dir := filepath.Dir(binaryPath); dir != "." && dir != "" {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if info, statErr := os.Stat(home); statErr == nil && info.IsDir() {
+			return home
+		}
+	}
+	return os.TempDir()
+}
+
+func pickFreePort() (string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	defer ln.Close()
+	return fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port), nil
+}
+
+func validatorHealthTimeout() time.Duration {
+	raw := os.Getenv("OBSTUDIO_VALIDATOR_HEALTH_TIMEOUT")
+	if raw == "" {
+		return defaultValidatorHealthTimeout
+	}
+
+	parsed, err := time.ParseDuration(raw)
+	if err != nil || parsed <= 0 {
+		return defaultValidatorHealthTimeout
+	}
+	return parsed
+}
+
+func waitForHealth(ctx context.Context, url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("validator health check timed out")
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func stopProcess(cmd *exec.Cmd, adminURL string) (bool, error) {
+	gracefulStop := false
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	req, err := http.NewRequestWithContext(stopCtx, http.MethodPost, adminURL+"/stop", nil)
+	if err == nil {
+		resp, reqErr := http.DefaultClient.Do(req)
+		if reqErr == nil {
+			gracefulStop = resp.StatusCode >= 200 && resp.StatusCode < 300
+			resp.Body.Close()
+		}
+	}
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return gracefulStop, err
+	case <-time.After(2 * time.Second):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return gracefulStop, <-done
+	}
+}
+
+func isExpectedExit(err error, gracefulStop bool) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+		if status.Signaled() {
+			return true
+		}
+		if gracefulStop && status.ExitStatus() == 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/observer/internal/validator/manager_test.go
+++ b/observer/internal/validator/manager_test.go
@@ -1,0 +1,303 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	telemetrystore "github.com/signalfx/obstudio/observer/internal/store"
+)
+
+func TestValidatorHealthTimeoutDefault(t *testing.T) {
+	t.Setenv("OBSTUDIO_VALIDATOR_HEALTH_TIMEOUT", "")
+
+	if got := validatorHealthTimeout(); got != defaultValidatorHealthTimeout {
+		t.Fatalf("expected default timeout %s, got %s", defaultValidatorHealthTimeout, got)
+	}
+}
+
+func TestValidatorHealthTimeoutParsesOverride(t *testing.T) {
+	t.Setenv("OBSTUDIO_VALIDATOR_HEALTH_TIMEOUT", "2m15s")
+
+	if got := validatorHealthTimeout(); got != 2*time.Minute+15*time.Second {
+		t.Fatalf("expected parsed timeout 2m15s, got %s", got)
+	}
+}
+
+func TestValidatorHealthTimeoutRejectsInvalidOverride(t *testing.T) {
+	t.Setenv("OBSTUDIO_VALIDATOR_HEALTH_TIMEOUT", "not-a-duration")
+
+	if got := validatorHealthTimeout(); got != defaultValidatorHealthTimeout {
+		t.Fatalf("expected invalid override to fall back to %s, got %s", defaultValidatorHealthTimeout, got)
+	}
+}
+
+func TestValidatorWorkingDirUsesBinaryDirectoryWhenAvailable(t *testing.T) {
+	dir := t.TempDir()
+	binary := dir + "/weaver"
+
+	if got := validatorWorkingDir(binary); got != dir {
+		t.Fatalf("expected working dir %q, got %q", dir, got)
+	}
+}
+
+func TestValidatorWorkingDirFallsBackWhenBinaryDirectoryMissing(t *testing.T) {
+	dir := t.TempDir()
+	missingDir := dir + "/gone"
+	binary := missingDir + "/weaver"
+
+	if got := validatorWorkingDir(binary); got == missingDir {
+		t.Fatalf("expected missing binary directory to be rejected, got %q", got)
+	}
+	if got := validatorWorkingDir(binary); got == "" {
+		t.Fatal("expected non-empty fallback working directory")
+	}
+}
+
+func TestWaitForHealthEventuallyReady(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) < 3 {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := waitForHealth(t.Context(), server.URL, time.Second); err != nil {
+		t.Fatalf("expected waitForHealth to succeed, got %v", err)
+	}
+}
+
+func TestWaitForHealthTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	if err := waitForHealth(t.Context(), server.URL, 150*time.Millisecond); err == nil {
+		t.Fatal("expected waitForHealth to time out")
+	}
+}
+
+func TestValidatorStderrSummaryDropsNoiseAndAnsi(t *testing.T) {
+	collector := newValidatorStderr()
+	collector.add("Weaver Registry Live Check")
+	collector.add("\u001b[31mDiagnostic report:\u001b[0m")
+	collector.add("  × Git error occurred while cloning `https://github.com/open-telemetry/")
+	collector.add("  │ semantic-conventions.git`: Could not obtain the current directory")
+
+	if got := collector.summary(); got != "Git error occurred while cloning `https://github.com/open-telemetry/ semantic-conventions.git`: Could not obtain the current directory" {
+		t.Fatalf("unexpected stderr summary: %q", got)
+	}
+}
+
+func TestStopProcessReturnsGracefulFlagBeforeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cmd := exec.Command("sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper command: %v", err)
+	}
+
+	graceful, err := stopProcess(cmd, server.URL)
+	if err != nil {
+		t.Fatalf("stopProcess returned error: %v", err)
+	}
+	if !graceful {
+		t.Fatal("expected stopProcess to report graceful stop after successful admin request")
+	}
+}
+
+func TestExportKeysRemainNonEmpty(t *testing.T) {
+	resource := telemetrystore.Resource{
+		ServiceName: "checkout",
+		Attributes: map[string]any{
+			"deployment.environment": "test",
+		},
+		SchemaURL: "https://opentelemetry.io/schemas/1.0.0",
+	}
+	if got := resourceKey(resource); got == "" {
+		t.Fatal("expected resourceKey to return a non-empty key")
+	}
+
+	point := telemetrystore.MetricDataPoint{
+		Name:        "http.server.duration",
+		Description: "Request duration",
+		Unit:        "ms",
+		Type:        "histogram",
+		Temporality: "delta",
+		IsMonotonic: false,
+		Resource:    resource,
+		Scope: telemetrystore.Scope{
+			Name:      "otel",
+			Version:   "1.0.0",
+			SchemaURL: "https://opentelemetry.io/schemas/1.0.0",
+		},
+	}
+	if got := metricKey(point); got == "" {
+		t.Fatal("expected metricKey to return a non-empty key")
+	}
+}
+
+func TestValidatorStartupErrorPrefersStderrSummary(t *testing.T) {
+	err := validatorStartupError(
+		errors.New("validator health check timed out"),
+		runExitCodeHelper(t, "1"),
+		false,
+		"Git error occurred while cloning semantic-conventions.git: Could not obtain the current directory",
+	)
+	if err == nil {
+		t.Fatal("expected startup error")
+	}
+	if got := err.Error(); got != "validator startup failed: Git error occurred while cloning semantic-conventions.git: Could not obtain the current directory" {
+		t.Fatalf("unexpected startup error: %q", got)
+	}
+}
+
+func TestValidatorStartupErrorPreservesCancellation(t *testing.T) {
+	err := validatorStartupError(context.Canceled, nil, false, "some diagnostic")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func TestIsExpectedExitAllowsExitStatusOneAfterGracefulStop(t *testing.T) {
+	err := runExitCodeHelper(t, "1")
+	if err == nil {
+		t.Fatal("expected helper to exit non-zero")
+	}
+	if !isExpectedExit(err, true) {
+		t.Fatal("expected graceful stop to treat exit status 1 as expected")
+	}
+	if isExpectedExit(err, false) {
+		t.Fatal("expected exit status 1 without graceful stop to remain unexpected")
+	}
+}
+
+func TestExitCodeHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_VALIDATOR_EXIT_HELPER") != "1" {
+		return
+	}
+	code, err := strconv.Atoi(os.Getenv("VALIDATOR_HELPER_EXIT_CODE"))
+	if err != nil {
+		code = 1
+	}
+	os.Exit(code)
+}
+
+func runExitCodeHelper(t *testing.T, code string) error {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestExitCodeHelper")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_VALIDATOR_EXIT_HELPER=1",
+		"VALIDATOR_HELPER_EXIT_CODE="+code,
+	)
+	return cmd.Run()
+}
+
+func TestEnrichValidationEntitiesInfersSpanServiceAndScopeFromSnapshotName(t *testing.T) {
+	entities := map[string]Entity{
+		"span::not_stable:send payment.processed": {
+			Key:    "span::not_stable:send payment.processed",
+			Signal: SignalRef{Type: "span", SpanName: "send payment.processed", MetricName: "send payment.processed"},
+			Findings: []Finding{{
+				EntityKey: "span::not_stable:send payment.processed",
+				RuleID:    "not_stable",
+				Severity:  SeverityViolation,
+				Message:   "span is unstable",
+				Signal:    SignalRef{Type: "span", SpanName: "send payment.processed", MetricName: "send payment.processed"},
+			}},
+		},
+	}
+
+	snapshot := telemetrystore.TelemetrySnapshot{
+		Spans: []telemetrystore.Span{{
+			TraceID:   "trace-1",
+			SpanID:    "span-1",
+			Name:      "send payment.processed",
+			Resource:  telemetrystore.Resource{ServiceName: "notification-service"},
+			Scope:     telemetrystore.Scope{Name: "orders.consumer"},
+			StartTime: time.Unix(10, 0),
+			EndTime:   time.Unix(10, int64(750*time.Microsecond)),
+		}},
+	}
+
+	enrichValidationEntities(entities, snapshot)
+
+	entity := entities["span::not_stable:send payment.processed"]
+	if entity.Signal.ServiceName != "notification-service" {
+		t.Fatalf("expected entity service name to be enriched, got %q", entity.Signal.ServiceName)
+	}
+	if entity.Signal.ScopeName != "orders.consumer" {
+		t.Fatalf("expected entity scope name to be enriched, got %q", entity.Signal.ScopeName)
+	}
+	if entity.Signal.MetricName != "" {
+		t.Fatalf("expected span metricName to be cleared, got %q", entity.Signal.MetricName)
+	}
+	if entity.Findings[0].Signal.ServiceName != "notification-service" {
+		t.Fatalf("expected finding service name to be enriched, got %q", entity.Findings[0].Signal.ServiceName)
+	}
+	if entity.Findings[0].Signal.ScopeName != "orders.consumer" {
+		t.Fatalf("expected finding scope name to be enriched, got %q", entity.Findings[0].Signal.ScopeName)
+	}
+	if entity.Findings[0].Signal.MetricName != "" {
+		t.Fatalf("expected span finding metricName to be cleared, got %q", entity.Findings[0].Signal.MetricName)
+	}
+}
+
+func TestEnrichValidationEntitiesLeavesAmbiguousSpanNamesUnset(t *testing.T) {
+	entities := map[string]Entity{
+		"span::not_stable:process": {
+			Key:    "span::not_stable:process",
+			Signal: SignalRef{Type: "span", SpanName: "process"},
+			Findings: []Finding{{
+				EntityKey: "span::not_stable:process",
+				RuleID:    "not_stable",
+				Severity:  SeverityViolation,
+				Message:   "span is unstable",
+				Signal:    SignalRef{Type: "span", SpanName: "process"},
+			}},
+		},
+	}
+
+	snapshot := telemetrystore.TelemetrySnapshot{
+		Spans: []telemetrystore.Span{
+			{
+				TraceID:  "trace-1",
+				SpanID:   "span-1",
+				Name:     "process",
+				Resource: telemetrystore.Resource{ServiceName: "orders"},
+				Scope:    telemetrystore.Scope{Name: "orders.scope"},
+			},
+			{
+				TraceID:  "trace-2",
+				SpanID:   "span-2",
+				Name:     "process",
+				Resource: telemetrystore.Resource{ServiceName: "payments"},
+				Scope:    telemetrystore.Scope{Name: "payments.scope"},
+			},
+		},
+	}
+
+	enrichValidationEntities(entities, snapshot)
+
+	entity := entities["span::not_stable:process"]
+	if entity.Signal.ServiceName != "" {
+		t.Fatalf("expected ambiguous span service to remain unset, got %q", entity.Signal.ServiceName)
+	}
+	if entity.Signal.ScopeName != "" {
+		t.Fatalf("expected ambiguous span scope to remain unset, got %q", entity.Signal.ScopeName)
+	}
+}

--- a/observer/internal/validator/normalize.go
+++ b/observer/internal/validator/normalize.go
@@ -1,0 +1,363 @@
+package validator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type normalizedLine struct {
+	Entity *Entity
+	Stats  *weaverStats
+}
+
+func normalizeLine(raw []byte, now time.Time) (normalizedLine, bool, error) {
+	line := bytes.TrimSpace(raw)
+	if len(line) == 0 || line[0] != '{' {
+		return normalizedLine{}, false, nil
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(line, &payload); err != nil {
+		return normalizedLine{}, false, err
+	}
+	if len(payload) == 0 {
+		return normalizedLine{}, false, nil
+	}
+
+	if stats, ok := decodeStats(payload); ok {
+		return normalizedLine{Stats: &stats}, true, nil
+	}
+
+	entityType, entityPayload, ok := topLevelEntity(payload)
+	if !ok {
+		return normalizedLine{}, false, nil
+	}
+
+	signal := signalRefFromEntity(entityType, entityPayload)
+	entity := Entity{
+		Key:       entityKey(signal),
+		Signal:    signal,
+		UpdatedAt: now,
+	}
+	collectAdvice(entityPayload, signal, now, &entity)
+	if len(entity.Findings) == 0 {
+		return normalizedLine{}, false, nil
+	}
+	for _, finding := range entity.Findings {
+		entity.HighestSeverity = maxSeverity(entity.HighestSeverity, finding.Severity)
+	}
+	return normalizedLine{Entity: &entity}, true, nil
+}
+
+func decodeStats(payload map[string]any) (weaverStats, bool) {
+	if _, ok := payload["total_entities"]; !ok {
+		if _, ok = payload["advice_level_counts"]; !ok {
+			return weaverStats{}, false
+		}
+	}
+
+	out := weaverStats{
+		AdviceLevelCounts:        map[string]int{},
+		HighestAdviceLevelCounts: map[string]int{},
+		TotalEntitiesByType:      map[string]int{},
+	}
+	out.TotalEntities = intValue(payload["total_entities"])
+	out.TotalAdvisories = intValue(payload["total_advisories"])
+	out.NoAdviceCount = intValue(payload["no_advice_count"])
+	copyIntMap(out.AdviceLevelCounts, payload["advice_level_counts"])
+	copyIntMap(out.HighestAdviceLevelCounts, payload["highest_advice_level_counts"])
+	copyIntMap(out.TotalEntitiesByType, payload["total_entities_by_type"])
+	return out, true
+}
+
+func topLevelEntity(payload map[string]any) (string, map[string]any, bool) {
+	for _, key := range []string{"span", "metric", "log", "resource"} {
+		value, ok := payload[key]
+		if !ok {
+			continue
+		}
+		entity, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		return key, entity, true
+	}
+	return "", nil, false
+}
+
+func signalRefFromEntity(entityType string, entity map[string]any) SignalRef {
+	ref := SignalRef{
+		Type:        entityType,
+		ServiceName: serviceNameFromEntity(entity),
+		TraceID:     stringValue(entity["trace_id"]),
+		SpanID:      stringValue(firstNonNil(entity["span_id"], entity["id"])),
+		SpanName:    stringValue(entity["name"]),
+		MetricName:  stringValue(entity["name"]),
+		ScopeName:   scopeNameFromEntity(entity),
+		LogBody:     bodyValue(entity["body"]),
+	}
+
+	if ref.TraceID == "" {
+		ref.TraceID = stringValue(entity["traceId"])
+	}
+	if ref.SpanID == "" {
+		ref.SpanID = stringValue(entity["spanId"])
+	}
+	if ref.ServiceName == "" {
+		ref.ServiceName = serviceNameFromAttrs(entity["resource_attributes"])
+	}
+	switch entityType {
+	case "metric":
+		ref.SpanName = ""
+		ref.LogBody = ""
+	case "log":
+		ref.MetricName = ""
+		ref.SpanName = ""
+	case "resource":
+		ref.TraceID = ""
+		ref.SpanID = ""
+		ref.SpanName = ""
+		ref.MetricName = ""
+		ref.LogBody = ""
+	}
+	return ref
+}
+
+func collectAdvice(value any, signal SignalRef, now time.Time, entity *Entity) {
+	switch v := value.(type) {
+	case map[string]any:
+		if result, ok := v["live_check_result"].(map[string]any); ok {
+			if allAdvice, ok := result["all_advice"].([]any); ok {
+				for _, rawAdvice := range allAdvice {
+					advice, ok := rawAdvice.(map[string]any)
+					if !ok {
+						continue
+					}
+					finding := Finding{
+						EntityKey: entity.Key,
+						Source:    "weaver",
+						RuleID:    stringValue(advice["id"]),
+						Severity:  Severity(strings.ToLower(stringValue(advice["level"]))),
+						Message:   stringValue(advice["message"]),
+						Context:   mapValue(advice["context"]),
+						Signal:    mergeSignal(signal, advice),
+						UpdatedAt: now,
+					}
+					if finding.RuleID == "" || finding.Severity == "" || finding.Message == "" {
+						continue
+					}
+					entity.Findings = append(entity.Findings, finding)
+				}
+			}
+		}
+		for key, child := range v {
+			if key == "live_check_result" {
+				continue
+			}
+			collectAdvice(child, signal, now, entity)
+		}
+	case []any:
+		for _, child := range v {
+			collectAdvice(child, signal, now, entity)
+		}
+	}
+}
+
+func mergeSignal(base SignalRef, advice map[string]any) SignalRef {
+	out := base
+	if signalType := stringValue(advice["signal_type"]); signalType != "" {
+		out.Type = signalType
+	}
+	if signalName := stringValue(advice["signal_name"]); signalName != "" {
+		switch out.Type {
+		case "metric":
+			out.MetricName = signalName
+		case "span", "span_event":
+			out.SpanName = signalName
+		case "log":
+			if out.LogBody == "" {
+				out.LogBody = signalName
+			}
+		}
+	}
+	return out
+}
+
+func entityKey(signal SignalRef) string {
+	switch signal.Type {
+	case "span", "span_event":
+		if signal.TraceID != "" || signal.SpanID != "" {
+			return fmt.Sprintf("span:%s:%s", signal.TraceID, signal.SpanID)
+		}
+		return fmt.Sprintf("span:%s:%s", signal.ServiceName, signal.SpanName)
+	case "metric":
+		return fmt.Sprintf("metric:%s:%s:%s", signal.ServiceName, signal.ScopeName, signal.MetricName)
+	case "log":
+		return fmt.Sprintf("log:%s:%s:%s:%s", signal.ServiceName, signal.TraceID, signal.SpanID, signal.LogBody)
+	case "resource":
+		return fmt.Sprintf("resource:%s", signal.ServiceName)
+	default:
+		return fmt.Sprintf("%s:%s:%s", signal.Type, signal.ServiceName, signal.SpanName)
+	}
+}
+
+func serviceNameFromEntity(entity map[string]any) string {
+	if resource, ok := entity["resource"].(map[string]any); ok {
+		if serviceName := stringValue(resource["service_name"]); serviceName != "" {
+			return serviceName
+		}
+		if serviceName := serviceNameFromAttrs(resource["attributes"]); serviceName != "" {
+			return serviceName
+		}
+	}
+	return serviceNameFromAttrs(entity["resource_attributes"])
+}
+
+func scopeNameFromEntity(entity map[string]any) string {
+	if scope, ok := entity["scope"].(map[string]any); ok {
+		if name := stringValue(scope["name"]); name != "" {
+			return name
+		}
+	}
+	return stringValue(entity["scope_name"])
+}
+
+func serviceNameFromAttrs(raw any) string {
+	attrs := flattenAttrs(raw)
+	if serviceName := stringValue(attrs["service.name"]); serviceName != "" {
+		return serviceName
+	}
+	return stringValue(attrs["service_name"])
+}
+
+func flattenAttrs(raw any) map[string]any {
+	switch attrs := raw.(type) {
+	case map[string]any:
+		if nested, ok := attrs["attributes"]; ok {
+			return flattenAttrs(nested)
+		}
+		out := make(map[string]any, len(attrs))
+		for key, value := range attrs {
+			out[key] = attributeValue(value)
+		}
+		return out
+	case []any:
+		out := make(map[string]any, len(attrs))
+		for _, item := range attrs {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			key := stringValue(firstNonNil(entry["name"], entry["key"]))
+			if key == "" {
+				continue
+			}
+			out[key] = attributeValue(entry["value"])
+		}
+		return out
+	default:
+		return map[string]any{}
+	}
+}
+
+func attributeValue(raw any) any {
+	switch value := raw.(type) {
+	case map[string]any:
+		for _, key := range []string{"stringValue", "string_value", "intValue", "int_value", "doubleValue", "double_value", "boolValue", "bool_value"} {
+			if candidate, ok := value[key]; ok {
+				return candidate
+			}
+		}
+		if len(value) == 1 {
+			for _, candidate := range value {
+				return candidate
+			}
+		}
+		return value
+	default:
+		return value
+	}
+}
+
+func bodyValue(raw any) string {
+	switch body := raw.(type) {
+	case string:
+		return body
+	case map[string]any:
+		return stringValue(attributeValue(body))
+	default:
+		return stringValue(body)
+	}
+}
+
+func copyIntMap(dst map[string]int, raw any) {
+	src, ok := raw.(map[string]any)
+	if !ok {
+		return
+	}
+	for key, value := range src {
+		dst[key] = intValue(value)
+	}
+}
+
+func mapValue(raw any) map[string]any {
+	value, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]any, len(value))
+	for key, item := range value {
+		out[key] = attributeValue(item)
+	}
+	return out
+}
+
+func stringValue(raw any) string {
+	switch value := raw.(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	case float64:
+		return fmt.Sprintf("%.0f", value)
+	case int:
+		return fmt.Sprintf("%d", value)
+	case int64:
+		return fmt.Sprintf("%d", value)
+	case bool:
+		if value {
+			return "true"
+		}
+		return "false"
+	default:
+		return ""
+	}
+}
+
+func intValue(raw any) int {
+	switch value := raw.(type) {
+	case float64:
+		return int(value)
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case json.Number:
+		n, _ := value.Int64()
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func firstNonNil(values ...any) any {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}

--- a/observer/internal/validator/normalize_test.go
+++ b/observer/internal/validator/normalize_test.go
@@ -1,0 +1,100 @@
+package validator
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeLineEntity(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	line := []byte(`{
+		"span": {
+			"name": "GET /orders",
+			"trace_id": "trace-1",
+			"span_id": "span-1",
+			"resource": {
+				"attributes": [
+					{"name": "service.name", "value": "checkout"}
+				]
+			},
+			"live_check_result": {
+				"all_advice": [
+					{
+						"id": "deprecated",
+						"level": "improvement",
+						"message": "Uses deprecated attribute",
+						"context": {"attribute_name": "http.method"},
+						"signal_type": "span",
+						"signal_name": "GET /orders"
+					}
+				]
+			}
+		}
+	}`)
+
+	normalized, ok, err := normalizeLine(line, now)
+	if err != nil {
+		t.Fatalf("normalizeLine returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected line to normalize")
+	}
+	if normalized.Entity == nil {
+		t.Fatalf("expected entity output")
+	}
+
+	entity := normalized.Entity
+	if entity.Key != "span:trace-1:span-1" {
+		t.Fatalf("unexpected entity key: %s", entity.Key)
+	}
+	if entity.Signal.ServiceName != "checkout" {
+		t.Fatalf("unexpected service name: %s", entity.Signal.ServiceName)
+	}
+	if entity.HighestSeverity != SeverityImprovement {
+		t.Fatalf("unexpected highest severity: %s", entity.HighestSeverity)
+	}
+	if len(entity.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(entity.Findings))
+	}
+	if entity.Findings[0].RuleID != "deprecated" {
+		t.Fatalf("unexpected rule id: %s", entity.Findings[0].RuleID)
+	}
+}
+
+func TestNormalizeLineStats(t *testing.T) {
+	line := []byte(`{
+		"advice_level_counts": {"violation": 2, "improvement": 1},
+		"highest_advice_level_counts": {"violation": 2},
+		"total_advisories": 3,
+		"total_entities": 4,
+		"no_advice_count": 1,
+		"total_entities_by_type": {"span": 2, "metric": 2}
+	}`)
+
+	normalized, ok, err := normalizeLine(line, time.Now())
+	if err != nil {
+		t.Fatalf("normalizeLine returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected line to normalize")
+	}
+	if normalized.Stats == nil {
+		t.Fatalf("expected stats output")
+	}
+	if normalized.Stats.TotalEntities != 4 {
+		t.Fatalf("unexpected total entities: %d", normalized.Stats.TotalEntities)
+	}
+	if normalized.Stats.AdviceLevelCounts["violation"] != 2 {
+		t.Fatalf("unexpected violation count: %d", normalized.Stats.AdviceLevelCounts["violation"])
+	}
+}
+
+func TestNormalizeLineIgnoresBanner(t *testing.T) {
+	normalized, ok, err := normalizeLine([]byte("Starting live-check"), time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok || normalized.Entity != nil || normalized.Stats != nil {
+		t.Fatalf("expected non-JSON line to be ignored")
+	}
+}

--- a/observer/internal/validator/service.go
+++ b/observer/internal/validator/service.go
@@ -1,0 +1,341 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type Runner interface {
+	Run(context.Context) Summary
+}
+
+type FreshnessMode string
+
+const (
+	FreshnessAuto          FreshnessMode = "auto"
+	FreshnessFreshRequired FreshnessMode = "fresh_required"
+	FreshnessLatestOK      FreshnessMode = "latest_ok"
+)
+
+type ServiceErrorKind string
+
+const (
+	ErrRunnerUnavailable ServiceErrorKind = "runner_unavailable"
+	ErrNoRetainedResult  ServiceErrorKind = "no_retained_result"
+	ErrRunStillRunning   ServiceErrorKind = "run_still_running"
+	ErrRunNotRetained    ServiceErrorKind = "run_not_retained"
+	ErrRunFailed         ServiceErrorKind = "run_failed"
+	ErrRunTimeout        ServiceErrorKind = "run_timeout"
+	ErrNoAnalysis        ServiceErrorKind = "no_analysis_available"
+)
+
+type ServiceError struct {
+	Kind              ServiceErrorKind
+	Summary           Summary
+	RequestedRunID    string
+	AvailableResultID string
+	Cause             error
+}
+
+func (e *ServiceError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	switch e.Kind {
+	case ErrRunnerUnavailable:
+		return "validation runner unavailable"
+	case ErrNoRetainedResult:
+		return "validation has not been run yet and no retained result is available"
+	case ErrRunStillRunning:
+		return fmt.Sprintf("validation run %q is still running", e.RequestedRunID)
+	case ErrRunNotRetained:
+		return fmt.Sprintf("validation results for run %q are not retained", e.RequestedRunID)
+	case ErrRunFailed:
+		return "validation run failed"
+	case ErrRunTimeout:
+		return "validation run did not complete before timeout"
+	case ErrNoAnalysis:
+		return "validation did not produce analysis"
+	default:
+		return "validation unavailable"
+	}
+}
+
+func (e *ServiceError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+type Service struct {
+	store  *Store
+	runner Runner
+}
+
+func NewService(store *Store, runner Runner) *Service {
+	if store == nil {
+		store = NewStore()
+	}
+	return &Service{store: store, runner: runner}
+}
+
+func (s *Service) Summary() Summary {
+	return s.store.Summary()
+}
+
+func (s *Service) Run(ctx context.Context) (Summary, error) {
+	if s.runner == nil {
+		return Summary{}, &ServiceError{
+			Kind:    ErrRunnerUnavailable,
+			Summary: s.store.Summary(),
+		}
+	}
+	return s.runner.Run(ctx), nil
+}
+
+func (s *Service) Latest(q Query) (Snapshot, error) {
+	summary := s.store.Summary()
+	if !LatestAvailable(summary) {
+		return Snapshot{}, &ServiceError{
+			Kind:    ErrNoRetainedResult,
+			Summary: summary,
+		}
+	}
+	return Snapshot{
+		Summary:  summary,
+		Findings: s.store.QueryFindings(q),
+		Issues:   s.store.QueryIssues(q),
+	}, nil
+}
+
+func (s *Service) Findings(q Query, runID string) ([]Finding, error) {
+	summary := s.store.Summary()
+	if runID != "" {
+		if err := validationRunAccessError(summary, runID); err != nil {
+			return nil, err
+		}
+		return s.store.QueryFindings(q), nil
+	}
+	if !LatestAvailable(summary) {
+		return nil, &ServiceError{
+			Kind:    ErrNoRetainedResult,
+			Summary: summary,
+		}
+	}
+	return s.store.QueryFindings(q), nil
+}
+
+func (s *Service) Analyze(ctx context.Context, q Query, freshness FreshnessMode, timeout time.Duration) (Analysis, error) {
+	summary := s.store.Summary()
+	switch freshness {
+	case FreshnessFreshRequired:
+		return s.runAnalysis(ctx, q, timeout)
+	case FreshnessLatestOK:
+		if !LatestAvailable(summary) {
+			return Analysis{}, &ServiceError{
+				Kind:    ErrNoRetainedResult,
+				Summary: summary,
+			}
+		}
+	default:
+		if !LatestAvailable(summary) {
+			return s.runAnalysis(ctx, q, timeout)
+		}
+	}
+	return AnalysisForSummary(s.store, summary, q, AnalysisBasisFromSummary(summary)), nil
+}
+
+func (s *Service) Refresh(ctx context.Context, q Query, timeout time.Duration) (Analysis, error) {
+	return s.runAnalysis(ctx, q, timeout)
+}
+
+func (s *Service) runAnalysis(ctx context.Context, q Query, timeout time.Duration) (Analysis, error) {
+	summary := s.store.Summary()
+	if s.runner == nil {
+		return Analysis{}, &ServiceError{
+			Kind:    ErrRunnerUnavailable,
+			Summary: summary,
+		}
+	}
+	if !summary.Enabled {
+		s.store.SetRuntimeStatus(StatusIdle, "Validation has not been run yet")
+	}
+
+	started := s.runner.Run(ctx)
+	runID := started.ActiveRunID
+	if runID == "" {
+		if LatestAvailable(started) {
+			return AnalysisForSummary(s.store, started, q, AnalysisBasisFreshRun), nil
+		}
+		return Analysis{}, &ServiceError{
+			Kind:    ErrNoAnalysis,
+			Summary: started,
+		}
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	snapshot, err := WaitForRun(waitCtx, s.store, runID, q)
+	if err != nil {
+		var serviceErr *ServiceError
+		if errors.As(err, &serviceErr) {
+			return Analysis{}, serviceErr
+		}
+		return Analysis{}, err
+	}
+
+	return Analysis{
+		AnalysisBasis: AnalysisBasisFreshRun,
+		Summary:       snapshot.Summary,
+		Findings:      snapshot.Findings,
+		Issues:        snapshot.Issues,
+	}, nil
+}
+
+func WaitForRun(ctx context.Context, store *Store, runID string, q Query) (Snapshot, error) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		summary := store.Summary()
+		if summary.ResultRunID == runID && summary.HasResult {
+			return Snapshot{
+				Summary:  summary,
+				Findings: store.QueryFindings(q),
+				Issues:   store.QueryIssues(q),
+			}, nil
+		}
+		if summary.ActiveRunID != "" && summary.ActiveRunID != runID {
+			return Snapshot{}, &ServiceError{
+				Kind:    ErrRunNotRetained,
+				Summary: summary,
+				Cause:   fmt.Errorf("validation run %q completed, but a newer run %q replaced it before results were fetched", runID, summary.ActiveRunID),
+			}
+		}
+		if summary.ActiveRunID == "" && summary.Status == StatusError {
+			return Snapshot{}, &ServiceError{
+				Kind:    ErrRunFailed,
+				Summary: summary,
+				Cause:   fmt.Errorf("validation run %q failed: %s", runID, summary.LastError),
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return Snapshot{}, &ServiceError{
+				Kind:    ErrRunTimeout,
+				Summary: store.Summary(),
+				Cause:   fmt.Errorf("validation run %q did not complete before timeout", runID),
+			}
+		case <-ticker.C:
+		}
+	}
+}
+
+func Fresh(summary Summary) bool {
+	return summary.Enabled && summary.Ready && summary.HasResult && !summary.Stale
+}
+
+func LatestAvailable(summary Summary) bool {
+	return summary.HasResult
+}
+
+func AnalysisBasisFromSummary(summary Summary) AnalysisBasis {
+	if summary.Stale {
+		return AnalysisBasisStaleResult
+	}
+	return AnalysisBasisLatestFresh
+}
+
+func AnalysisMessage(summary Summary, basis AnalysisBasis) string {
+	if basis != AnalysisBasisStaleResult {
+		return ""
+	}
+	runID := summary.ResultRunID
+	if runID == "" {
+		runID = "latest retained run"
+	}
+	if summary.LastRunCompletedAt.IsZero() {
+		return fmt.Sprintf("Validation analysis is based on %s. New telemetry has arrived since then.", runID)
+	}
+	return fmt.Sprintf(
+		"Validation analysis is based on run %s completed at %s. New telemetry has arrived since then.",
+		runID,
+		summary.LastRunCompletedAt.UTC().Format(time.RFC3339),
+	)
+}
+
+func AnalysisForSummary(store *Store, summary Summary, q Query, basis AnalysisBasis) Analysis {
+	return Analysis{
+		AnalysisBasis:   basis,
+		AnalysisMessage: AnalysisMessage(summary, basis),
+		Summary:         summary,
+		Findings:        store.QueryFindings(q),
+		Issues:          store.QueryIssues(q),
+	}
+}
+
+func ReadError(summary Summary) string {
+	switch {
+	case !summary.Enabled:
+		return "validator unavailable"
+	case summary.Status == StatusRunning:
+		return "validation is still running"
+	case summary.Status == StatusError:
+		return "latest validation attempt failed"
+	case !summary.HasResult:
+		return "validation has not been run yet"
+	case summary.Stale:
+		return "validation results are stale"
+	default:
+		return "validation results are unavailable"
+	}
+}
+
+func LatestReadError(summary Summary) string {
+	switch {
+	case !summary.Enabled:
+		return "validator unavailable"
+	case summary.Status == StatusRunning:
+		return "validation is still running and no previous result is retained yet"
+	case summary.Status == StatusError:
+		return "latest validation attempt failed and no previous result is retained"
+	default:
+		return "validation has not been run yet"
+	}
+}
+
+func validationRunAccessError(summary Summary, runID string) error {
+	switch {
+	case runID == "":
+		return nil
+	case summary.ResultRunID == runID && summary.HasResult:
+		return nil
+	case summary.ActiveRunID == runID:
+		return &ServiceError{
+			Kind:           ErrRunStillRunning,
+			Summary:        summary,
+			RequestedRunID: runID,
+		}
+	case summary.ResultRunID == "":
+		return &ServiceError{
+			Kind:           ErrNoRetainedResult,
+			Summary:        summary,
+			RequestedRunID: runID,
+		}
+	default:
+		return &ServiceError{
+			Kind:              ErrRunNotRetained,
+			Summary:           summary,
+			RequestedRunID:    runID,
+			AvailableResultID: summary.ResultRunID,
+		}
+	}
+}

--- a/observer/internal/validator/store.go
+++ b/observer/internal/validator/store.go
@@ -1,0 +1,711 @@
+package validator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Store struct {
+	mu       sync.RWMutex
+	status   RuntimeStatus
+	message  string
+	updated  time.Time
+	entities map[string]Entity
+	stats    weaverStats
+
+	lastError          string
+	hasResult          bool
+	stale              bool
+	activeRunID        string
+	resultRunID        string
+	lastRunStartedAt   time.Time
+	lastRunCompletedAt time.Time
+	lastTelemetryAt    time.Time
+
+	subMu       sync.Mutex
+	subscribers map[int]chan Signal
+	nextSubID   int
+}
+
+func NewStore() *Store {
+	return &Store{
+		status:      StatusDisabled,
+		message:     "Validator unavailable",
+		entities:    make(map[string]Entity),
+		subscribers: make(map[int]chan Signal),
+	}
+}
+
+func (s *Store) SetRuntimeStatus(status RuntimeStatus, message string) {
+	s.mu.Lock()
+	s.status = status
+	s.message = message
+	if status == StatusDisabled {
+		s.lastError = ""
+		s.hasResult = false
+		s.stale = false
+		s.activeRunID = ""
+		s.resultRunID = ""
+		s.lastRunStartedAt = time.Time{}
+		s.lastRunCompletedAt = time.Time{}
+		s.lastTelemetryAt = time.Time{}
+		s.entities = make(map[string]Entity)
+		s.stats = weaverStats{}
+	}
+	s.updated = time.Now()
+	s.mu.Unlock()
+	s.notify(SignalValidation)
+}
+
+func (s *Store) SetStats(stats weaverStats) {
+	s.mu.Lock()
+	s.stats = stats
+	s.hasResult = true
+	s.updated = time.Now()
+	s.mu.Unlock()
+	s.notify(SignalValidation)
+}
+
+func (s *Store) UpsertEntity(entity Entity) {
+	s.mu.Lock()
+	s.entities[entity.Key] = entity
+	s.hasResult = true
+	s.updated = time.Now()
+	s.mu.Unlock()
+	s.notify(SignalValidation)
+}
+
+func (s *Store) StartRun(runID string, startedAt time.Time) Summary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.status == StatusDisabled {
+		return s.summaryLocked()
+	}
+	if s.status == StatusRunning && s.activeRunID != "" {
+		return s.summaryLocked()
+	}
+
+	s.status = StatusRunning
+	s.message = "Validation running"
+	s.lastError = ""
+	s.activeRunID = runID
+	s.lastRunStartedAt = startedAt
+	s.updated = startedAt
+
+	summary := s.summaryLocked()
+	go s.notify(SignalValidation)
+	return summary
+}
+
+func (s *Store) CompleteRun(runID string, entities map[string]Entity, stats weaverStats, completedAt time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.activeRunID != runID {
+		return false
+	}
+
+	if entities == nil {
+		entities = make(map[string]Entity)
+	}
+
+	s.entities = entities
+	s.stats = stats
+	s.hasResult = true
+	s.stale = !s.lastTelemetryAt.IsZero() && s.lastTelemetryAt.After(s.lastRunStartedAt)
+	s.status = StatusReady
+	if s.stale {
+		s.message = "Validation complete, but new telemetry has arrived"
+	} else {
+		s.message = "Validation complete"
+	}
+	s.lastError = ""
+	s.resultRunID = runID
+	s.activeRunID = ""
+	s.lastRunCompletedAt = completedAt
+	s.updated = completedAt
+
+	go s.notify(SignalValidation)
+	return true
+}
+
+func (s *Store) FailRun(runID, message string, completedAt time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.activeRunID != runID {
+		return false
+	}
+
+	s.activeRunID = ""
+	s.status = StatusError
+	s.message = message
+	s.lastError = message
+	s.lastRunCompletedAt = completedAt
+	if s.hasResult {
+		s.stale = true
+	}
+	s.updated = completedAt
+
+	go s.notify(SignalValidation)
+	return true
+}
+
+func (s *Store) MarkTelemetryChanged(changedAt time.Time) {
+	s.mu.Lock()
+	s.lastTelemetryAt = changedAt
+	if s.hasResult {
+		s.stale = true
+		if s.status == StatusReady {
+			s.message = "New telemetry since last validation"
+		}
+	}
+	s.updated = changedAt
+	s.mu.Unlock()
+	s.notify(SignalValidation)
+}
+
+func (s *Store) Clear() {
+	s.mu.Lock()
+	s.entities = make(map[string]Entity)
+	s.stats = weaverStats{}
+	s.lastError = ""
+	s.hasResult = false
+	s.stale = false
+	s.activeRunID = ""
+	s.resultRunID = ""
+	s.lastRunStartedAt = time.Time{}
+	s.lastRunCompletedAt = time.Time{}
+	s.lastTelemetryAt = time.Time{}
+	if s.status == StatusDisabled {
+		s.message = "Validator unavailable"
+	} else {
+		s.status = StatusIdle
+		s.message = "Validation has not been run yet"
+	}
+	s.updated = time.Now()
+	s.mu.Unlock()
+	s.notify(SignalValidation)
+}
+
+func (s *Store) Summary() Summary {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.summaryLocked()
+}
+
+func (s *Store) Snapshot(limit int) Snapshot {
+	findings := s.QueryFindings(Query{Limit: limit})
+	return Snapshot{
+		Summary:  s.Summary(),
+		Findings: findings,
+		Issues:   buildIssues(findings),
+	}
+}
+
+func (s *Store) QueryFindings(q Query) []Finding {
+	s.mu.RLock()
+	findings := make([]Finding, 0, len(s.entities))
+	for _, entity := range s.entities {
+		findings = append(findings, entity.Findings...)
+	}
+	s.mu.RUnlock()
+
+	filtered := findings[:0]
+	for _, finding := range findings {
+		if q.ServiceName != "" && !strings.EqualFold(finding.Signal.ServiceName, q.ServiceName) {
+			continue
+		}
+		if q.SignalType != "" && !strings.EqualFold(finding.Signal.Type, q.SignalType) {
+			continue
+		}
+		if q.Severity != "" && !strings.EqualFold(string(finding.Severity), q.Severity) {
+			continue
+		}
+		if q.RuleID != "" && !strings.EqualFold(finding.RuleID, q.RuleID) {
+			continue
+		}
+		if q.TraceID != "" && finding.Signal.TraceID != q.TraceID {
+			continue
+		}
+		if q.SpanID != "" && finding.Signal.SpanID != q.SpanID {
+			continue
+		}
+		if q.MetricName != "" && !strings.EqualFold(finding.Signal.MetricName, q.MetricName) {
+			continue
+		}
+		if q.LogBody != "" && !strings.Contains(strings.ToLower(finding.Signal.LogBody), strings.ToLower(q.LogBody)) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].UpdatedAt.Equal(filtered[j].UpdatedAt) {
+			if filtered[i].EntityKey == filtered[j].EntityKey {
+				return filtered[i].RuleID < filtered[j].RuleID
+			}
+			return filtered[i].EntityKey < filtered[j].EntityKey
+		}
+		return filtered[i].UpdatedAt.After(filtered[j].UpdatedAt)
+	})
+
+	if q.Limit > 0 && len(filtered) > q.Limit {
+		filtered = filtered[:q.Limit]
+	}
+	if len(filtered) == 0 {
+		return []Finding{}
+	}
+	return append([]Finding(nil), filtered...)
+}
+
+func (s *Store) QueryIssues(q Query) []Issue {
+	return buildIssues(s.QueryFindings(q))
+}
+
+func buildIssues(findings []Finding) []Issue {
+	type groupedIssue struct {
+		issue      Issue
+		entityKeys map[string]struct{}
+	}
+
+	issues := make(map[string]*groupedIssue)
+
+	for _, finding := range findings {
+		key := issueKey(finding)
+		if key == "" {
+			continue
+		}
+
+		existing, ok := issues[key]
+		if !ok {
+			issues[key] = &groupedIssue{
+				issue: Issue{
+					Key:                 key,
+					Severity:            finding.Severity,
+					Message:             finding.Message,
+					SignalType:          normalizeSignalType(finding.Signal.Type),
+					TargetLabel:         issueTargetLabel(finding),
+					ServiceName:         finding.Signal.ServiceName,
+					ScopeName:           finding.Signal.ScopeName,
+					Count:               0,
+					ViolationCount:      0,
+					ImprovementCount:    0,
+					InformationCount:    0,
+					AffectedEntityCount: 1,
+					FirstSeen:           finding.UpdatedAt,
+					LastSeen:            finding.UpdatedAt,
+					Findings:            []Finding{finding},
+				},
+				entityKeys: map[string]struct{}{finding.EntityKey: {}},
+			}
+			continue
+		}
+
+		existing.issue.Findings = append(existing.issue.Findings, finding)
+		existing.issue.Severity = maxSeverity(existing.issue.Severity, finding.Severity)
+		if finding.UpdatedAt.Before(existing.issue.FirstSeen) {
+			existing.issue.FirstSeen = finding.UpdatedAt
+		}
+		if finding.UpdatedAt.Equal(existing.issue.LastSeen) || finding.UpdatedAt.After(existing.issue.LastSeen) {
+			existing.issue.LastSeen = finding.UpdatedAt
+			existing.issue.Message = finding.Message
+		}
+		existing.entityKeys[finding.EntityKey] = struct{}{}
+		existing.issue.AffectedEntityCount = len(existing.entityKeys)
+	}
+
+	result := make([]Issue, 0, len(issues))
+	for _, grouped := range issues {
+		grouped.issue.Findings = sortValidationFindings(grouped.issue.Findings)
+		grouped.issue.Count, grouped.issue.ViolationCount, grouped.issue.ImprovementCount, grouped.issue.InformationCount = distinctIssueCounts(grouped.issue.Findings)
+		grouped.issue.TargetLabel = issueDisplayTarget(grouped.issue)
+		result = append(result, grouped.issue)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ViolationCount != result[j].ViolationCount {
+			return result[i].ViolationCount > result[j].ViolationCount
+		}
+		if result[i].ImprovementCount != result[j].ImprovementCount {
+			return result[i].ImprovementCount > result[j].ImprovementCount
+		}
+		if result[i].InformationCount != result[j].InformationCount {
+			return result[i].InformationCount > result[j].InformationCount
+		}
+		if result[i].Count != result[j].Count {
+			return result[i].Count > result[j].Count
+		}
+		if result[i].ServiceName != result[j].ServiceName {
+			return result[i].ServiceName < result[j].ServiceName
+		}
+		if result[i].TargetLabel != result[j].TargetLabel {
+			return result[i].TargetLabel < result[j].TargetLabel
+		}
+		return result[i].LastSeen.After(result[j].LastSeen)
+	})
+
+	return result
+}
+
+func distinctIssueCounts(findings []Finding) (total int, violations int, improvements int, information int) {
+	seen := make(map[string]struct{}, len(findings))
+	for _, finding := range findings {
+		key := findingVariantKey(finding)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		total += 1
+		switch finding.Severity {
+		case SeverityViolation:
+			violations += 1
+		case SeverityImprovement:
+			improvements += 1
+		case SeverityInformation:
+			information += 1
+		}
+	}
+	return total, violations, improvements, information
+}
+
+func findingVariantKey(finding Finding) string {
+	parts := []string{string(finding.Severity), finding.RuleID, finding.Message}
+	if len(finding.Context) > 0 {
+		keys := make([]string, 0, len(finding.Context))
+		for key := range finding.Context {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			parts = append(parts, key+"="+fmt.Sprint(finding.Context[key]))
+		}
+	}
+	return strings.Join(parts, "\x1f")
+}
+
+func issueDisplayTarget(issue Issue) string {
+	switch issue.SignalType {
+	case "resource":
+		if attributeName, ok := uniqueFindingContextValue(issue.Findings, "attribute_name"); ok {
+			return attributeName
+		}
+	case "log":
+		if issue.TargetLabel == "Log records" {
+			if body, ok := uniqueLogBody(issue.Findings); ok {
+				return body
+			}
+		}
+	}
+	return issue.TargetLabel
+}
+
+func uniqueFindingContextValue(findings []Finding, key string) (string, bool) {
+	var value string
+	for _, finding := range findings {
+		if finding.Context == nil {
+			continue
+		}
+		raw, ok := finding.Context[key]
+		if !ok {
+			continue
+		}
+		stringValue := stringifyContextValue(raw)
+		if stringValue == "" {
+			continue
+		}
+		if value == "" {
+			value = stringValue
+			continue
+		}
+		if value != stringValue {
+			return "", false
+		}
+	}
+	return value, value != ""
+}
+
+func uniqueLogBody(findings []Finding) (string, bool) {
+	var body string
+	for _, finding := range findings {
+		if finding.Signal.LogBody == "" {
+			continue
+		}
+		if body == "" {
+			body = finding.Signal.LogBody
+			continue
+		}
+		if body != finding.Signal.LogBody {
+			return "", false
+		}
+	}
+	return body, body != ""
+}
+
+func sortValidationFindings(findings []Finding) []Finding {
+	sorted := append([]Finding(nil), findings...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if severityRank(sorted[j].Severity) != severityRank(sorted[i].Severity) {
+			return severityRank(sorted[j].Severity) > severityRank(sorted[i].Severity)
+		}
+		if sorted[i].Signal.ServiceName != sorted[j].Signal.ServiceName {
+			return sorted[i].Signal.ServiceName < sorted[j].Signal.ServiceName
+		}
+		leftLabel := formatSignalLabel(sorted[i])
+		rightLabel := formatSignalLabel(sorted[j])
+		if leftLabel != rightLabel {
+			return leftLabel < rightLabel
+		}
+		return sorted[j].UpdatedAt.After(sorted[i].UpdatedAt)
+	})
+	return sorted
+}
+
+func issueKey(finding Finding) string {
+	signalType := normalizeSignalType(finding.Signal.Type)
+	serviceName := finding.Signal.ServiceName
+	scopeName := finding.Signal.ScopeName
+
+	switch signalType {
+	case "span":
+		return "span:" + serviceName + ":" + finding.RuleID + ":" + finding.Signal.SpanName
+	case "metric":
+		return "metric:" + serviceName + ":" + scopeName + ":" + finding.Signal.MetricName
+	case "log":
+		if isBodySpecificLogRule(finding) {
+			return "log:" + serviceName + ":" + scopeName + ":" + finding.RuleID + ":" + finding.Signal.LogBody
+		}
+		return "log:" + serviceName + ":" + scopeName + ":" + finding.RuleID
+	case "resource":
+		return "resource:" + serviceName + ":" + finding.RuleID
+	default:
+		return signalType + ":" + serviceName + ":" + scopeName + ":" + finding.RuleID + ":" + issueTargetLabel(finding)
+	}
+}
+
+func issueTargetLabel(finding Finding) string {
+	switch normalizeSignalType(finding.Signal.Type) {
+	case "span":
+		if finding.Signal.SpanName != "" {
+			return finding.Signal.SpanName
+		}
+		return "Unnamed span"
+	case "metric":
+		if finding.Signal.MetricName != "" {
+			return finding.Signal.MetricName
+		}
+		return "Unnamed metric"
+	case "log":
+		if isBodySpecificLogRule(finding) && finding.Signal.LogBody != "" {
+			return finding.Signal.LogBody
+		}
+		if finding.Signal.ServiceName != "" {
+			return finding.Signal.ServiceName + " logs"
+		}
+		if finding.Signal.ScopeName != "" {
+			return finding.Signal.ScopeName + " logs"
+		}
+		return "Log records"
+	case "resource":
+		if finding.Signal.ServiceName != "" {
+			return finding.Signal.ServiceName
+		}
+		return "Resource"
+	default:
+		return formatSignalLabel(finding)
+	}
+}
+
+func formatSignalLabel(finding Finding) string {
+	switch normalizeSignalType(finding.Signal.Type) {
+	case "span":
+		if finding.Signal.SpanName != "" {
+			return finding.Signal.SpanName
+		}
+		if finding.Signal.SpanID != "" {
+			return finding.Signal.SpanID
+		}
+		return "span"
+	case "metric":
+		if finding.Signal.MetricName != "" {
+			return finding.Signal.MetricName
+		}
+		return "metric"
+	case "log":
+		if finding.Signal.LogBody != "" {
+			return finding.Signal.LogBody
+		}
+		return "log"
+	case "resource":
+		if finding.Signal.ServiceName != "" {
+			return finding.Signal.ServiceName
+		}
+		return "resource"
+	default:
+		if finding.Signal.Type != "" {
+			return finding.Signal.Type
+		}
+		return "signal"
+	}
+}
+
+func normalizeSignalType(signalType string) string {
+	switch strings.ToLower(signalType) {
+	case "span_event":
+		return "span"
+	default:
+		return strings.ToLower(signalType)
+	}
+}
+
+func isBodySpecificLogRule(finding Finding) bool {
+	if normalizeSignalType(finding.Signal.Type) != "log" {
+		return false
+	}
+	parts := make([]string, 0, 2+len(finding.Context)*2)
+	parts = append(parts, finding.RuleID, finding.Message)
+	for key, value := range finding.Context {
+		parts = append(parts, key, stringifyContextValue(value))
+	}
+	haystack := strings.ToLower(strings.Join(parts, " "))
+	return strings.Contains(haystack, "log body") ||
+		strings.Contains(haystack, "log.body") ||
+		strings.Contains(haystack, "body") ||
+		strings.Contains(haystack, "message")
+}
+
+func stringifyContextValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func (s *Store) Subscribe() (int, <-chan Signal) {
+	ch := make(chan Signal, 8)
+	s.subMu.Lock()
+	id := s.nextSubID
+	s.nextSubID++
+	s.subscribers[id] = ch
+	s.subMu.Unlock()
+	return id, ch
+}
+
+func (s *Store) Unsubscribe(id int) {
+	s.subMu.Lock()
+	ch, ok := s.subscribers[id]
+	delete(s.subscribers, id)
+	s.subMu.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+func (s *Store) notify(sig Signal) {
+	s.subMu.Lock()
+	defer s.subMu.Unlock()
+	for _, ch := range s.subscribers {
+		select {
+		case ch <- sig:
+		default:
+		}
+	}
+}
+
+func (s *Store) summaryLocked() Summary {
+	severityCounts := map[string]int{
+		string(SeverityInformation): 0,
+		string(SeverityImprovement): 0,
+		string(SeverityViolation):   0,
+	}
+	highestCounts := map[string]int{
+		string(SeverityInformation): 0,
+		string(SeverityImprovement): 0,
+		string(SeverityViolation):   0,
+	}
+	signalCounts := make(map[string]int)
+	totalAdvisories := 0
+
+	for _, entity := range s.entities {
+		if entity.HighestSeverity != "" {
+			highestCounts[string(entity.HighestSeverity)]++
+		}
+		if entity.Signal.Type != "" {
+			signalCounts[entity.Signal.Type]++
+		}
+		for _, finding := range entity.Findings {
+			severityCounts[string(finding.Severity)]++
+			totalAdvisories++
+		}
+	}
+
+	if len(s.stats.AdviceLevelCounts) > 0 {
+		for key, value := range s.stats.AdviceLevelCounts {
+			severityCounts[key] = value
+		}
+	}
+	if len(s.stats.HighestAdviceLevelCounts) > 0 {
+		for key, value := range s.stats.HighestAdviceLevelCounts {
+			highestCounts[key] = value
+		}
+	}
+	if len(s.stats.TotalEntitiesByType) > 0 {
+		signalCounts = cloneIntMap(s.stats.TotalEntitiesByType)
+	}
+
+	totalEntities := len(s.entities)
+	if s.stats.TotalEntities > 0 {
+		totalEntities = s.stats.TotalEntities
+	}
+	if s.stats.TotalAdvisories > 0 {
+		totalAdvisories = s.stats.TotalAdvisories
+	}
+
+	needsRun := false
+	switch s.status {
+	case StatusIdle, StatusError:
+		needsRun = true
+	case StatusReady:
+		needsRun = s.stale
+	}
+
+	return Summary{
+		Enabled:               s.status != StatusDisabled,
+		Ready:                 s.status == StatusReady && !s.stale,
+		Status:                s.status,
+		Message:               s.message,
+		LastError:             s.lastError,
+		HasResult:             s.hasResult,
+		Stale:                 s.stale,
+		NeedsRun:              needsRun,
+		ActiveRunID:           s.activeRunID,
+		ResultRunID:           s.resultRunID,
+		LastRunStartedAt:      s.lastRunStartedAt,
+		LastRunCompletedAt:    s.lastRunCompletedAt,
+		LastTelemetryAt:       s.lastTelemetryAt,
+		TotalEntities:         totalEntities,
+		TotalAdvisories:       totalAdvisories,
+		NoAdviceCount:         s.stats.NoAdviceCount,
+		SeverityCounts:        severityCounts,
+		HighestSeverityCounts: highestCounts,
+		SignalCounts:          signalCounts,
+		UpdatedAt:             s.updated,
+	}
+}
+
+func cloneIntMap(values map[string]int) map[string]int {
+	if len(values) == 0 {
+		return map[string]int{}
+	}
+	out := make(map[string]int, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}

--- a/observer/internal/validator/store_test.go
+++ b/observer/internal/validator/store_test.go
@@ -1,0 +1,327 @@
+package validator
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStoreSummaryAndQuery(t *testing.T) {
+	store := NewStore()
+	store.SetRuntimeStatus(StatusReady, "ready")
+	store.UpsertEntity(Entity{
+		Key:             "span:trace-1:span-1",
+		HighestSeverity: SeverityViolation,
+		Signal:          SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+		UpdatedAt:       time.Unix(10, 0),
+		Findings: []Finding{
+			{
+				EntityKey: "span:trace-1:span-1",
+				Source:    "weaver",
+				RuleID:    "missing_attribute",
+				Severity:  SeverityViolation,
+				Message:   "missing attribute",
+				Signal:    SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+				UpdatedAt: time.Unix(10, 0),
+			},
+		},
+	})
+
+	summary := store.Summary()
+	if !summary.Ready {
+		t.Fatalf("expected store to be ready")
+	}
+	if summary.TotalEntities != 1 {
+		t.Fatalf("expected 1 entity, got %d", summary.TotalEntities)
+	}
+	if summary.SeverityCounts["violation"] != 1 {
+		t.Fatalf("expected violation count 1, got %d", summary.SeverityCounts["violation"])
+	}
+
+	findings := store.QueryFindings(Query{ServiceName: "checkout"})
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "missing_attribute" {
+		t.Fatalf("unexpected rule id: %s", findings[0].RuleID)
+	}
+}
+
+func TestStoreMarksResultsStaleAfterTelemetryChange(t *testing.T) {
+	store := NewStore()
+	store.SetRuntimeStatus(StatusIdle, "Validation has not been run yet")
+
+	store.StartRun("run-1", time.Unix(10, 0))
+	ok := store.CompleteRun("run-1", map[string]Entity{
+		"metric:checkout::http.server.duration": {
+			Key:             "metric:checkout::http.server.duration",
+			HighestSeverity: SeverityImprovement,
+			Signal:          SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+			UpdatedAt:       time.Unix(11, 0),
+			Findings: []Finding{{
+				EntityKey: "metric:checkout::http.server.duration",
+				Source:    "weaver",
+				RuleID:    "deprecated",
+				Severity:  SeverityImprovement,
+				Message:   "deprecated metric",
+				Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "http.server.duration"},
+				UpdatedAt: time.Unix(11, 0),
+			}},
+		},
+	}, weaverStats{}, time.Unix(11, 0))
+	if !ok {
+		t.Fatal("expected run completion to be accepted")
+	}
+
+	store.MarkTelemetryChanged(time.Unix(12, 0))
+	summary := store.Summary()
+	if !summary.HasResult {
+		t.Fatal("expected stored result to remain available")
+	}
+	if !summary.Stale {
+		t.Fatal("expected result to be marked stale")
+	}
+	if !summary.NeedsRun {
+		t.Fatal("expected stale result to require rerun")
+	}
+	if summary.Ready {
+		t.Fatal("expected stale result to report ready=false")
+	}
+}
+
+func TestStoreFailedRerunPreservesPreviousResult(t *testing.T) {
+	store := NewStore()
+	store.SetRuntimeStatus(StatusIdle, "Validation has not been run yet")
+	store.StartRun("run-1", time.Unix(10, 0))
+	store.CompleteRun("run-1", map[string]Entity{
+		"span:trace-1:span-1": {
+			Key:             "span:trace-1:span-1",
+			HighestSeverity: SeverityViolation,
+			Signal:          SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+			UpdatedAt:       time.Unix(11, 0),
+			Findings: []Finding{{
+				EntityKey: "span:trace-1:span-1",
+				Source:    "weaver",
+				RuleID:    "missing_attribute",
+				Severity:  SeverityViolation,
+				Message:   "missing attribute",
+				Signal:    SignalRef{Type: "span", ServiceName: "checkout", TraceID: "trace-1", SpanID: "span-1", SpanName: "GET /orders"},
+				UpdatedAt: time.Unix(11, 0),
+			}},
+		},
+	}, weaverStats{}, time.Unix(11, 0))
+
+	store.StartRun("run-2", time.Unix(12, 0))
+	if !store.FailRun("run-2", "validation failed", time.Unix(13, 0)) {
+		t.Fatal("expected rerun failure to be recorded")
+	}
+
+	summary := store.Summary()
+	if summary.Status != StatusError {
+		t.Fatalf("expected error status, got %s", summary.Status)
+	}
+	if !summary.HasResult {
+		t.Fatal("expected previous successful result to remain available")
+	}
+	if summary.TotalAdvisories != 1 {
+		t.Fatalf("expected previous advisory count to remain, got %d", summary.TotalAdvisories)
+	}
+	if summary.LastError != "validation failed" {
+		t.Fatalf("expected last error to be preserved, got %q", summary.LastError)
+	}
+}
+
+func TestStoreSnapshotWithoutLimitReturnsAllFindings(t *testing.T) {
+	store := NewStore()
+	store.SetRuntimeStatus(StatusReady, "ready")
+
+	findings := make([]Finding, 0, 3)
+	for i := 0; i < 3; i++ {
+		findings = append(findings, Finding{
+			EntityKey: "metric:checkout::jvm.thread.count",
+			Source:    "weaver",
+			RuleID:    "rule-" + string(rune('a'+i)),
+			Severity:  SeverityViolation,
+			Message:   "finding",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "jvm.thread.count"},
+			UpdatedAt: time.Unix(int64(10+i), 0),
+		})
+	}
+
+	store.UpsertEntity(Entity{
+		Key:             "metric:checkout::jvm.thread.count",
+		HighestSeverity: SeverityViolation,
+		Signal:          SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "jvm.thread.count"},
+		UpdatedAt:       time.Unix(12, 0),
+		Findings:        findings,
+	})
+
+	full := store.Snapshot(0)
+	if len(full.Findings) != 3 {
+		t.Fatalf("expected all findings in unlimited snapshot, got %d", len(full.Findings))
+	}
+
+	limited := store.Snapshot(2)
+	if len(limited.Findings) != 2 {
+		t.Fatalf("expected limited snapshot to respect limit, got %d", len(limited.Findings))
+	}
+}
+
+func TestBuildIssuesIncludesSeverityBreakdownAndSortsBySeverityCounts(t *testing.T) {
+	issues := buildIssues([]Finding{
+		{
+			EntityKey: "metric:checkout::metric-a",
+			RuleID:    "rule-a",
+			Severity:  SeverityViolation,
+			Message:   "violation",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-a"},
+			UpdatedAt: time.Unix(10, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-a",
+			RuleID:    "rule-a-info-1",
+			Severity:  SeverityInformation,
+			Message:   "information",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-a"},
+			UpdatedAt: time.Unix(11, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-a",
+			RuleID:    "rule-a-info-2",
+			Severity:  SeverityInformation,
+			Message:   "information",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-a"},
+			UpdatedAt: time.Unix(12, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-b",
+			RuleID:    "rule-b-1",
+			Severity:  SeverityViolation,
+			Message:   "violation",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-b"},
+			UpdatedAt: time.Unix(10, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-b",
+			RuleID:    "rule-b-2",
+			Severity:  SeverityViolation,
+			Message:   "violation",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-b"},
+			UpdatedAt: time.Unix(11, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-b",
+			RuleID:    "rule-b-3",
+			Severity:  SeverityInformation,
+			Message:   "information",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-b"},
+			UpdatedAt: time.Unix(12, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-c",
+			RuleID:    "rule-c-1",
+			Severity:  SeverityViolation,
+			Message:   "violation",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-c"},
+			UpdatedAt: time.Unix(10, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-c",
+			RuleID:    "rule-c-2",
+			Severity:  SeverityViolation,
+			Message:   "violation",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-c"},
+			UpdatedAt: time.Unix(11, 0),
+		},
+		{
+			EntityKey: "metric:checkout::metric-c",
+			RuleID:    "rule-c-3",
+			Severity:  SeverityImprovement,
+			Message:   "improvement",
+			Signal:    SignalRef{Type: "metric", ServiceName: "checkout", MetricName: "metric-c"},
+			UpdatedAt: time.Unix(12, 0),
+		},
+	})
+
+	if len(issues) != 3 {
+		t.Fatalf("expected 3 issues, got %d", len(issues))
+	}
+	if issues[0].TargetLabel != "metric-c" {
+		t.Fatalf("expected metric-c first by violation and improvement tie-breakers, got %s", issues[0].TargetLabel)
+	}
+	if issues[0].ViolationCount != 2 || issues[0].ImprovementCount != 1 || issues[0].InformationCount != 0 {
+		t.Fatalf("unexpected severity counts for metric-c: %+v", issues[0])
+	}
+	if issues[1].TargetLabel != "metric-b" {
+		t.Fatalf("expected metric-b second by information tie-breaker, got %s", issues[1].TargetLabel)
+	}
+	if issues[2].TargetLabel != "metric-a" {
+		t.Fatalf("expected metric-a last because it has fewer violations, got %s", issues[2].TargetLabel)
+	}
+}
+
+func TestBuildIssuesCountsDistinctCorrectiveVariants(t *testing.T) {
+	issues := buildIssues([]Finding{
+		{
+			EntityKey: "metric:orders::http.server.request.count",
+			RuleID:    "missing_metric",
+			Severity:  SeverityViolation,
+			Message:   "Metric does not exist in the registry.",
+			Signal:    SignalRef{Type: "metric", MetricName: "http.server.request.count"},
+			UpdatedAt: time.Unix(10, 0),
+		},
+		{
+			EntityKey: "metric:payments::http.server.request.count",
+			RuleID:    "missing_metric",
+			Severity:  SeverityViolation,
+			Message:   "Metric does not exist in the registry.",
+			Signal:    SignalRef{Type: "metric", MetricName: "http.server.request.count"},
+			UpdatedAt: time.Unix(11, 0),
+		},
+		{
+			EntityKey: "metric:payments::http.server.request.count",
+			RuleID:    "missing_description",
+			Severity:  SeverityImprovement,
+			Message:   "Metric should include a description.",
+			Signal:    SignalRef{Type: "metric", MetricName: "http.server.request.count"},
+			UpdatedAt: time.Unix(12, 0),
+		},
+	})
+
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 grouped issue, got %d", len(issues))
+	}
+	if issues[0].Count != 2 {
+		t.Fatalf("expected 2 distinct corrective variants, got %d", issues[0].Count)
+	}
+	if issues[0].ViolationCount != 1 {
+		t.Fatalf("expected 1 distinct violation, got %d", issues[0].ViolationCount)
+	}
+	if issues[0].ImprovementCount != 1 {
+		t.Fatalf("expected 1 distinct improvement, got %d", issues[0].ImprovementCount)
+	}
+	if issues[0].AffectedEntityCount != 2 {
+		t.Fatalf("expected 2 affected entities, got %d", issues[0].AffectedEntityCount)
+	}
+}
+
+func TestBuildIssuesUsesResourceAttributeNameWhenUnique(t *testing.T) {
+	issues := buildIssues([]Finding{{
+		EntityKey: "resource:",
+		RuleID:    "not_stable",
+		Severity:  SeverityViolation,
+		Message:   "Attribute 'deployment.environment.name' is not stable; stability = development.",
+		Context: map[string]any{
+			"attribute_name": "deployment.environment.name",
+			"stability":      "development",
+		},
+		Signal:    SignalRef{Type: "resource"},
+		UpdatedAt: time.Unix(10, 0),
+	}})
+
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].TargetLabel != "deployment.environment.name" {
+		t.Fatalf("expected resource target label to use unique attribute name, got %s", issues[0].TargetLabel)
+	}
+}

--- a/observer/internal/validator/types.go
+++ b/observer/internal/validator/types.go
@@ -1,0 +1,161 @@
+package validator
+
+import "time"
+
+type Signal string
+
+const SignalValidation Signal = "validation"
+
+type RuntimeStatus string
+
+const (
+	StatusDisabled RuntimeStatus = "disabled"
+	StatusIdle     RuntimeStatus = "idle"
+	StatusRunning  RuntimeStatus = "running"
+	StatusReady    RuntimeStatus = "ready"
+	StatusError    RuntimeStatus = "error"
+)
+
+type Severity string
+
+const (
+	SeverityInformation Severity = "information"
+	SeverityImprovement Severity = "improvement"
+	SeverityViolation   Severity = "violation"
+)
+
+type SignalRef struct {
+	Type        string `json:"type"`
+	ServiceName string `json:"serviceName,omitempty"`
+	TraceID     string `json:"traceId,omitempty"`
+	SpanID      string `json:"spanId,omitempty"`
+	SpanName    string `json:"spanName,omitempty"`
+	MetricName  string `json:"metricName,omitempty"`
+	ScopeName   string `json:"scopeName,omitempty"`
+	LogBody     string `json:"logBody,omitempty"`
+}
+
+type Finding struct {
+	EntityKey string         `json:"entityKey"`
+	Source    string         `json:"source"`
+	RuleID    string         `json:"ruleId"`
+	Severity  Severity       `json:"severity"`
+	Message   string         `json:"message"`
+	Context   map[string]any `json:"context,omitempty"`
+	Signal    SignalRef      `json:"signal"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+}
+
+type Entity struct {
+	Key             string    `json:"key"`
+	HighestSeverity Severity  `json:"highestSeverity"`
+	Signal          SignalRef `json:"signal"`
+	Findings        []Finding `json:"findings"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+type Summary struct {
+	Enabled               bool           `json:"enabled"`
+	Ready                 bool           `json:"ready"`
+	Status                RuntimeStatus  `json:"status"`
+	Message               string         `json:"message,omitempty"`
+	LastError             string         `json:"lastError,omitempty"`
+	HasResult             bool           `json:"hasResult"`
+	Stale                 bool           `json:"stale"`
+	NeedsRun              bool           `json:"needsRun"`
+	ActiveRunID           string         `json:"activeRunId,omitempty"`
+	ResultRunID           string         `json:"resultRunId,omitempty"`
+	LastRunStartedAt      time.Time      `json:"lastRunStartedAt,omitempty"`
+	LastRunCompletedAt    time.Time      `json:"lastRunCompletedAt,omitempty"`
+	LastTelemetryAt       time.Time      `json:"lastTelemetryAt,omitempty"`
+	TotalEntities         int            `json:"totalEntities"`
+	TotalAdvisories       int            `json:"totalAdvisories"`
+	NoAdviceCount         int            `json:"noAdviceCount"`
+	SeverityCounts        map[string]int `json:"severityCounts"`
+	HighestSeverityCounts map[string]int `json:"highestSeverityCounts"`
+	SignalCounts          map[string]int `json:"signalCounts"`
+	UpdatedAt             time.Time      `json:"updatedAt"`
+}
+
+type Issue struct {
+	Key                 string    `json:"key"`
+	Severity            Severity  `json:"severity"`
+	Message             string    `json:"message"`
+	SignalType          string    `json:"signalType"`
+	TargetLabel         string    `json:"targetLabel"`
+	ServiceName         string    `json:"serviceName,omitempty"`
+	ScopeName           string    `json:"scopeName,omitempty"`
+	Count               int       `json:"count"`
+	ViolationCount      int       `json:"violationCount"`
+	ImprovementCount    int       `json:"improvementCount"`
+	InformationCount    int       `json:"informationCount"`
+	AffectedEntityCount int       `json:"affectedEntityCount"`
+	FirstSeen           time.Time `json:"firstSeen"`
+	LastSeen            time.Time `json:"lastSeen"`
+	Findings            []Finding `json:"findings"`
+}
+
+type Snapshot struct {
+	Summary  Summary   `json:"summary"`
+	Findings []Finding `json:"findings"`
+	Issues   []Issue   `json:"issues"`
+}
+
+type AnalysisBasis string
+
+const (
+	AnalysisBasisFreshRun    AnalysisBasis = "fresh_run"
+	AnalysisBasisLatestFresh AnalysisBasis = "latest_fresh_result"
+	AnalysisBasisStaleResult AnalysisBasis = "stale_result"
+)
+
+type Analysis struct {
+	AnalysisBasis   AnalysisBasis `json:"analysisBasis"`
+	AnalysisMessage string        `json:"analysisMessage,omitempty"`
+	Summary         Summary       `json:"summary"`
+	Findings        []Finding     `json:"findings"`
+	Issues          []Issue       `json:"issues"`
+}
+
+type Query struct {
+	ServiceName string
+	SignalType  string
+	Severity    string
+	RuleID      string
+	TraceID     string
+	SpanID      string
+	MetricName  string
+	LogBody     string
+	Limit       int
+}
+
+type weaverStats struct {
+	AdviceLevelCounts        map[string]int `json:"advice_level_counts"`
+	HighestAdviceLevelCounts map[string]int `json:"highest_advice_level_counts"`
+	NoAdviceCount            int            `json:"no_advice_count"`
+	TotalAdvisories          int            `json:"total_advisories"`
+	TotalEntities            int            `json:"total_entities"`
+	TotalEntitiesByType      map[string]int `json:"total_entities_by_type"`
+}
+
+type RunStats = weaverStats
+
+func severityRank(severity Severity) int {
+	switch severity {
+	case SeverityViolation:
+		return 3
+	case SeverityImprovement:
+		return 2
+	case SeverityInformation:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func maxSeverity(a, b Severity) Severity {
+	if severityRank(b) > severityRank(a) {
+		return b
+	}
+	return a
+}

--- a/observer/internal/web/server.go
+++ b/observer/internal/web/server.go
@@ -7,18 +7,26 @@ import (
 	"strings"
 
 	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 )
 
 // Register adds WebSocket, static file, and SPA routes to the given mux.
 // It returns a cleanup function that should be called on shutdown to
 // unsubscribe from the store.
-func Register(mux *http.ServeMux, s *store.Store) func() {
-	mux.HandleFunc("GET /api/ws", wsHandler(s))
+func Register(mux *http.ServeMux, s *store.Store, v *validator.Store) func() {
+	mux.HandleFunc("GET /api/ws", wsHandler(s, v))
 
 	subID, ch := s.Subscribe()
 	go func() {
 		for sig := range ch {
-			broadcastSignal(s, sig)
+			broadcastSignal(s, v, string(sig))
+		}
+	}()
+
+	validationSubID, validationCh := v.Subscribe()
+	go func() {
+		for range validationCh {
+			broadcastSignal(s, v, string(validator.SignalValidation))
 		}
 	}()
 
@@ -40,5 +48,8 @@ func Register(mux *http.ServeMux, s *store.Store) func() {
 		_, _ = w.Write(index)
 	})
 
-	return func() { s.Unsubscribe(subID) }
+	return func() {
+		s.Unsubscribe(subID)
+		v.Unsubscribe(validationSubID)
+	}
 }

--- a/observer/internal/web/websocket.go
+++ b/observer/internal/web/websocket.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 )
 
 const (
@@ -38,8 +39,9 @@ type ServerMessage struct {
 // ── Connection state ─────────────────────────────────────
 
 type conn struct {
-	ws    *websocket.Conn
-	store *store.Store
+	ws        *websocket.Conn
+	store     *store.Store
+	validator *validator.Store
 
 	mu     sync.Mutex
 	closed sync.Once
@@ -65,7 +67,7 @@ var (
 	conns   = make(map[*conn]struct{})
 )
 
-func broadcastSignal(s *store.Store, sig store.Signal) {
+func broadcastSignal(s *store.Store, v *validator.Store, sig string) {
 	connsMu.Lock()
 	snapshot := make([]*conn, 0, len(conns))
 	for c := range conns {
@@ -74,13 +76,13 @@ func broadcastSignal(s *store.Store, sig store.Signal) {
 	connsMu.Unlock()
 
 	for _, c := range snapshot {
-		c.onStoreSignal(sig)
+		c.onSignal(sig)
 	}
 }
 
 // ── HTTP handler ─────────────────────────────────────────
 
-func wsHandler(s *store.Store) http.HandlerFunc {
+func wsHandler(s *store.Store, v *validator.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ws, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
@@ -89,11 +91,12 @@ func wsHandler(s *store.Store) http.HandlerFunc {
 		}
 
 		c := &conn{
-			ws:      ws,
-			store:   s,
-			pending: make(map[string]bool),
-			timers:  make(map[string]*time.Timer),
-			done:    make(chan struct{}),
+			ws:        ws,
+			store:     s,
+			validator: v,
+			pending:   make(map[string]bool),
+			timers:    make(map[string]*time.Timer),
+			done:      make(chan struct{}),
 		}
 
 		connsMu.Lock()
@@ -195,6 +198,7 @@ func (c *conn) pushAll() {
 	c.queryAndSend("metrics")
 	c.queryAndSend("logs")
 	c.queryAndSend("stats")
+	c.queryAndSend("validation")
 }
 
 func (c *conn) queryAndSend(signal string) {
@@ -209,6 +213,8 @@ func (c *conn) queryAndSend(signal string) {
 		data = c.store.QueryLogs(100)
 	case "stats":
 		data = c.store.Stats()
+	case "validation":
+		data = c.validator.Snapshot(0)
 	}
 
 	c.sendMsg(ServerMessage{Type: "update", Signal: signal, Data: data})
@@ -216,7 +222,7 @@ func (c *conn) queryAndSend(signal string) {
 
 // ── Store signal → throttled push ────────────────────────
 
-func (c *conn) onStoreSignal(sig store.Signal) {
+func (c *conn) onSignal(sig string) {
 	c.mu.Lock()
 
 	if !c.subscribed {
@@ -224,11 +230,17 @@ func (c *conn) onStoreSignal(sig store.Signal) {
 		return
 	}
 
-	signals := []string{string(sig)}
-	// Always include stats on any signal change.
-	signals = append(signals, "stats")
+	signals := []string{sig}
+	if sig != "validation" {
+		signals = append(signals, "stats")
+	}
 
 	if c.paused {
+		if sig == "validation" {
+			c.mu.Unlock()
+			c.throttledPush("validation", true)
+			return
+		}
 		if !c.pausedNotified {
 			c.pausedNotified = true
 			c.mu.Unlock()
@@ -241,14 +253,14 @@ func (c *conn) onStoreSignal(sig store.Signal) {
 	c.mu.Unlock()
 
 	for _, s := range signals {
-		c.throttledPush(s)
+		c.throttledPush(s, false)
 	}
 }
 
-func (c *conn) throttledPush(signal string) {
+func (c *conn) throttledPush(signal string, allowWhilePaused bool) {
 	c.mu.Lock()
 
-	if !c.subscribed || c.paused {
+	if !c.subscribed || (c.paused && !allowWhilePaused) {
 		c.mu.Unlock()
 		return
 	}
@@ -269,7 +281,7 @@ func (c *conn) throttledPush(signal string) {
 		c.mu.Unlock()
 
 		if hasPending {
-			c.throttledPush(signal)
+			c.throttledPush(signal, allowWhilePaused)
 		}
 	})
 	c.mu.Unlock()

--- a/observer/internal/web/websocket_test.go
+++ b/observer/internal/web/websocket_test.go
@@ -1,0 +1,69 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
+)
+
+func TestPausedConnectionStillReceivesValidationUpdates(t *testing.T) {
+	s := store.New()
+	v := validator.NewStore()
+
+	mux := http.NewServeMux()
+	cleanup := Register(mux, s, v)
+	defer cleanup()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+
+	var msg ServerMessage
+	if err := conn.ReadJSON(&msg); err != nil {
+		t.Fatalf("read connected message: %v", err)
+	}
+	if msg.Type != "connected" {
+		t.Fatalf("expected connected message, got %#v", msg)
+	}
+
+	if err := conn.WriteJSON(ClientMessage{Type: "subscribe"}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Fatalf("read initial snapshot message: %v", err)
+		}
+		if msg.Type != "update" {
+			t.Fatalf("expected initial update message, got %#v", msg)
+		}
+	}
+
+	if err := conn.WriteJSON(ClientMessage{Type: "pause"}); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+
+	v.SetRuntimeStatus(validator.StatusIdle, "Validation has not been run yet")
+
+	if err := conn.ReadJSON(&msg); err != nil {
+		t.Fatalf("read validation update while paused: %v", err)
+	}
+	if msg.Type != "update" || msg.Signal != "validation" {
+		t.Fatalf("expected validation update while paused, got %#v", msg)
+	}
+}


### PR DESCRIPTION
## Summary
Add validation workflows to the Telemetry Explorer, including the bundled validator runtime, validation REST and MCP flows, and a dedicated Validation tab in the UI.

## What Changed
- bundle the Weaver validator runtime into the packaged Observer build
- add validator manager, store, normalization, export, and service layers
- add REST validation endpoints for summary, latest snapshot, run, refresh, analyze, and findings
- add MCP validation tools for status, analyze, and refresh
- add validation state to the telemetry client and wire it through the Explorer
- add a dedicated Validation tab with grouped issues and signal-specific filtering
- connect validation results back into traces, spans, and logs where relevant
- keep validation updates live even while the telemetry stream is paused
- document the validation workflow and public API surfaces

## Tests
- `make build`
- `make test`
- `cd extension && npm run test:all`
- `cd observer/client && npm test -- --run src/AppView.test.tsx src/components/FindingsTab.test.tsx src/validation/utils.test.ts src/logs/LogsTab.test.tsx src/traces/TracesTab.test.tsx src/traces/TracesTab.style.test.tsx`

## Verification
- started the built Observer with the bundled validator runtime
- sent continuous OTLP traces, metrics, and logs into the local receiver
- triggered a live validation run and confirmed retained validation results
- verified the Validation tab rendered real issues
- verified Metrics and Traces continued to render live telemetry during the same run


