### PR TITLE
Improve Telemetry Explorer UI

### DIFF
--- a/observer/client/src/AppView.test.tsx
+++ b/observer/client/src/AppView.test.tsx
@@ -128,7 +128,6 @@ describe("AppView validation tab", () => {
     expect(screen.getAllByText("Validation").length).toBeGreaterThan(0);
     expect(screen.getByText("1 issues")).toBeTruthy();
     expect(screen.getByText("Services")).toBeTruthy();
-    expect(screen.getByText("Telemetry stream")).toBeTruthy();
     expect(screen.queryByText(/occurrences/i)).toBeNull();
     expect(container.querySelector(".metric-summary")).toBeTruthy();
     expect(screen.queryByText("Aggregate Validation")).toBeNull();
@@ -150,17 +149,20 @@ describe("AppView validation tab", () => {
     expect(screen.getByRole("tab", { name: /metrics/i }).getAttribute("aria-selected")).toBe("true");
     expect(container.querySelector(".metric-summary")).toBeTruthy();
     expect(screen.getByText("Services")).toBeTruthy();
-    expect(screen.getByText("Telemetry stream")).toBeTruthy();
   });
 
-  it("renders plain tab labels without letter badges", () => {
+  it("renders tab labels with count badges", () => {
     const telemetry = makeTelemetryHandle([makeFinding({})]);
 
     const { container } = render(<AppView telemetry={telemetry} />);
 
-    expect(screen.getByRole("tab", { name: "Metrics" }).textContent).toBe("Metrics");
-    expect(screen.getByRole("tab", { name: "Traces" }).textContent).toBe("Traces");
-    expect(screen.getByRole("tab", { name: "Logs" }).textContent).toBe("Logs");
+    const metricsTab = screen.getByRole("tab", { name: /metrics/i });
+    const tracesTab = screen.getByRole("tab", { name: /traces/i });
+    const logsTab = screen.getByRole("tab", { name: /logs/i });
+
+    expect(metricsTab.querySelector(".tab-button__count")).toBeTruthy();
+    expect(tracesTab.querySelector(".tab-button__count")).toBeTruthy();
+    expect(logsTab.querySelector(".tab-button__count")).toBeTruthy();
     expect(container.querySelector(".tab-button__glyph")).toBeNull();
   });
 });

--- a/observer/client/src/AppView.tsx
+++ b/observer/client/src/AppView.tsx
@@ -78,12 +78,12 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             {state.error !== null ? (
               <span className="pill pill--error">{state.error}</span>
             ) : null}
-            <span className="pill pill--muted">Telemetry stream</span>
             <button
-              className="pill pill--muted"
+              className="title-bar__help"
               onClick={() => setShowHelp(true)}
               title="Keyboard shortcuts (?)"
-              style={{ cursor: "pointer", border: "1px solid var(--border)" }}
+              type="button"
+              aria-label="Keyboard shortcuts"
             >
               ?
             </button>
@@ -111,10 +111,14 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
               </div>
             ) : null}
             {state.stats.serviceNames?.length ? (
-              <div className="summary-card">
+              <div className="summary-card" title={state.stats.serviceNames.join(", ")}>
                 <p className="summary-card__label">Services</p>
                 <p className="summary-card__value">{state.stats.serviceNames.length}</p>
-                <p className="summary-card__meta">{state.stats.serviceNames.join(", ")}</p>
+                <p className="summary-card__services">
+                  {state.stats.serviceNames.map((name) => (
+                    <span key={name} className="summary-card__service-tag">{name}</span>
+                  ))}
+                </p>
               </div>
             ) : null}
           </div>
@@ -129,6 +133,7 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             onClick={() => switchTab("metrics")}
           >
             Metrics
+            {state.stats?.metricNameCount ? <span className="tab-button__count">{state.stats.metricNameCount}</span> : null}
           </button>
           <button
             type="button"
@@ -138,6 +143,7 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             onClick={() => switchTab("traces")}
           >
             Traces
+            {state.stats?.traceCount ? <span className="tab-button__count">{state.stats.traceCount}</span> : null}
           </button>
           <button
             type="button"
@@ -147,6 +153,7 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             onClick={() => switchTab("logs")}
           >
             Logs
+            {state.stats?.logCount ? <span className="tab-button__count">{state.stats.logCount}</span> : null}
           </button>
           <button
             type="button"
@@ -156,6 +163,7 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             onClick={() => switchTab("validation")}
           >
             Validation
+            {validationIssues.length > 0 ? <span className="tab-button__count tab-button__count--warn">{validationIssues.length}</span> : null}
           </button>
         </div>
 

--- a/observer/client/src/logs/LogsTab.test.tsx
+++ b/observer/client/src/logs/LogsTab.test.tsx
@@ -71,7 +71,6 @@ describe("LogsTab", () => {
       />,
     );
 
-    expect(screen.getByText("2 logs")).toBeTruthy();
     expect(container.querySelector(".data-table__head--left-cluster-logs")).toBeTruthy();
     expect(container.querySelector(".data-table__body-inner--logs")).toBeTruthy();
     expect(container.querySelector(".data-table__td--timestamp .explorer-row__secondary")).toBeTruthy();

--- a/observer/client/src/logs/LogsTab.tsx
+++ b/observer/client/src/logs/LogsTab.tsx
@@ -85,7 +85,6 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
         <div className="signal-view__content">
           {logs.length > 0 ? (
             <div className="explorer__toolbar explorer__toolbar--controls">
-              <span className="explorer__count">{filteredLogs.length} logs</span>
               <select
                 className="explorer__select"
                 value={severityFilter}
@@ -109,7 +108,7 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
           ) : null}
 
           {logs.length === 0 ? (
-            <p className="explorer__status">Waiting for logs... Send OTLP data to port 4318.</p>
+            <p className="explorer__status explorer__status--empty">No logs received yet. Send OTLP telemetry to port 4318 to begin exploring.</p>
           ) : filteredLogs.length === 0 ? (
             <p className="explorer__status">No logs match the current filters.</p>
           ) : (

--- a/observer/client/src/metrics/MetricsTab.test.tsx
+++ b/observer/client/src/metrics/MetricsTab.test.tsx
@@ -50,7 +50,6 @@ describe("MetricsTab", () => {
       />,
     );
 
-    expect(screen.getByText("3 metrics")).toBeTruthy();
     expect(screen.getByText("Type / Unit")).toBeTruthy();
     expect(screen.getByText("Description")).toBeTruthy();
     expect(screen.queryByRole("combobox")).toBeNull();
@@ -61,7 +60,6 @@ describe("MetricsTab", () => {
       target: { value: "duration" },
     });
 
-    expect(screen.getByText("1 metrics")).toBeTruthy();
     expect(screen.queryByText("http.server.request.count")).toBeNull();
     expect(screen.getByText("http.server.duration")).toBeTruthy();
     expect(screen.queryByText("db.client.connections.usage")).toBeNull();

--- a/observer/client/src/metrics/MetricsTab.tsx
+++ b/observer/client/src/metrics/MetricsTab.tsx
@@ -80,7 +80,6 @@ export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabPr
 
       {metricList.length > 0 ? (
         <div className="explorer__toolbar explorer__toolbar--controls">
-          <span className="explorer__count">{visibleMetricList.length} metrics</span>
           <input
             className="explorer__input"
             type="search"
@@ -92,8 +91,8 @@ export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabPr
       ) : null}
 
       {metricList.length === 0 && metrics.length === 0 ? (
-        <p className="metrics-explorer__empty" style={{ padding: "40px 20px" }}>
-          Waiting for metrics... Send OTLP data to port 4318.
+        <p className="explorer__status explorer__status--empty" style={{ padding: "40px 20px" }}>
+          No metrics received yet. Send OTLP telemetry to port 4318 to begin exploring.
         </p>
       ) : visibleMetricList.length === 0 ? (
         <p className="metrics-explorer__empty" style={{ padding: "24px 20px" }}>

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -45,9 +45,7 @@ body {
   margin: 0;
   height: 100%;
   overflow: hidden;
-  background:
-    radial-gradient(circle at top left, rgba(0, 122, 204, 0.14), transparent 32%),
-    linear-gradient(180deg, #141414 0%, #101010 100%);
+  background: #121212;
 }
 
 #root {
@@ -59,7 +57,7 @@ body {
   height: 100vh;
   min-height: 0;
   overflow: hidden;
-  padding: 16px;
+  padding: 12px;
 }
 
 .app-frame {
@@ -69,48 +67,46 @@ body {
   flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 18px;
+  border-radius: 10px;
   background: var(--app-bg);
-  box-shadow: var(--surface-shadow);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
 }
 
 .title-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 10px 14px;
+  gap: 12px;
+  padding: 8px 14px;
   border-bottom: 1px solid var(--border);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent),
-    var(--chrome);
+  background: var(--chrome);
 }
 
 .title-bar__brand {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
 .title-bar__dot {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   border-radius: 999px;
   background: var(--accent);
-  box-shadow: 0 0 0 5px rgba(0, 122, 204, 0.16);
+  box-shadow: 0 0 0 4px rgba(0, 122, 204, 0.12);
 }
 
 .title-bar__eyebrow {
-  margin: 0 0 3px;
+  margin: 0 0 1px;
   font-size: 9px;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
   color: var(--text-dim);
 }
 
 .title-bar__title {
   margin: 0;
-  font-size: clamp(1.05rem, 1.45vw, 1.25rem);
+  font-size: 14px;
   font-weight: 600;
   line-height: 1.2;
 }
@@ -118,8 +114,31 @@ body {
 .title-bar__meta {
   display: flex;
   align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
+.title-bar__help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.title-bar__help:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
 }
 
 .tab-bar {
@@ -149,10 +168,43 @@ body {
 .tab-button.is-active {
   color: var(--text);
   border-color: var(--accent);
+  background: rgba(0, 122, 204, 0.06);
 }
 
 .tab-button:hover {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.tab-button__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 5px;
+  padding: 0 5px;
+  min-width: 18px;
+  height: 16px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-dim);
+  line-height: 1;
+}
+
+.tab-button.is-active .tab-button__count {
+  background: rgba(0, 122, 204, 0.18);
+  color: var(--blue);
+}
+
+.tab-button__count--warn {
+  background: rgba(220, 180, 90, 0.12);
+  color: var(--yellow);
+}
+
+.tab-button.is-active .tab-button__count--warn {
+  background: rgba(220, 180, 90, 0.18);
+  color: var(--yellow);
 }
 
 .tab-panel {
@@ -233,16 +285,16 @@ body {
 
 .metric-summary {
   display: grid;
-  grid-template-columns: repeat(4, minmax(max-content, 1fr));
-  gap: 8px;
-  padding: 10px 14px;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0;
+  padding: 8px 14px;
   border-bottom: 1px solid var(--border);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent);
 }
 
 .summary-card {
   min-width: 0;
-  padding: 10px 12px;
+  padding: 8px 12px;
   border: none;
   border-radius: 0;
   background: transparent;
@@ -260,24 +312,44 @@ body {
 }
 
 .summary-card__label {
-  font-size: 11px;
+  font-size: 10px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   white-space: nowrap;
   color: var(--text-dim);
 }
 
 .summary-card__value {
-  margin: 6px 0 2px;
-  font-size: clamp(20px, 3vw, 28px);
+  margin: 4px 0 2px;
+  font-size: clamp(18px, 2.5vw, 24px);
   font-weight: 600;
   line-height: 1;
   color: #ffffff;
 }
 
 .summary-card__meta {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--text-soft);
+}
+
+.summary-card__services {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 4px 0 0;
+}
+
+.summary-card__service-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 10px;
+  color: var(--text-soft);
+  white-space: nowrap;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .metric-table {
@@ -2077,7 +2149,7 @@ code {
 .signal-view__panel {
   display: flex;
   flex-direction: column;
-  width: 420px;
+  width: 400px;
   flex-shrink: 0;
   min-height: 0;
   overflow: hidden;
@@ -2153,11 +2225,6 @@ code {
   width: 100%;
 }
 
-.explorer__count {
-  color: var(--text-soft);
-  white-space: nowrap;
-}
-
 .explorer__toolbar--controls {
   justify-content: flex-start;
 }
@@ -2230,6 +2297,13 @@ code {
 .explorer__status--error {
   color: #f48771;
   background: rgba(244, 135, 113, 0.06);
+}
+
+.explorer__status--empty {
+  padding: 32px 20px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 /* ======================================
@@ -3079,21 +3153,21 @@ code {
 .stream-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 12px;
+  gap: 5px;
+  padding: 3px 10px;
   border: 1px solid var(--border);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.03);
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   cursor: pointer;
   transition: background 120ms ease, border-color 120ms ease;
 }
 
 .stream-toggle__icon {
-  font-size: 10px;
+  font-size: 9px;
 }
 
 .stream-toggle--live {
@@ -3117,13 +3191,13 @@ code {
 .pending-badge {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border: 1px solid rgba(79, 193, 255, 0.4);
+  padding: 3px 8px;
+  border: 1px solid rgba(79, 193, 255, 0.3);
   border-radius: 999px;
-  background: rgba(79, 193, 255, 0.12);
+  background: rgba(79, 193, 255, 0.08);
   color: var(--blue);
   font: inherit;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 500;
   cursor: pointer;
   animation: badge-pulse 1.5s ease-in-out infinite;

--- a/observer/client/src/traces/TracesTab.style.test.tsx
+++ b/observer/client/src/traces/TracesTab.style.test.tsx
@@ -63,7 +63,6 @@ describe("TracesTab row layout", () => {
       />,
     );
 
-    expect(screen.getByText("1 traces")).toBeTruthy();
     expect(screen.getByText("Trace ID")).toBeTruthy();
     expect(screen.getByText("Service")).toBeTruthy();
     expect(screen.getByText("Status")).toBeTruthy();
@@ -99,15 +98,12 @@ describe("TracesTab row layout", () => {
     );
 
     const input = view.getByPlaceholderText("Search operation, trace ID, service, or status");
-    expect(view.getByText("2 traces")).toBeTruthy();
 
     fireEvent.change(input, { target: { value: "error" } });
-    expect(view.getByText("1 traces")).toBeTruthy();
     expect(view.getByText("POST /payments")).toBeTruthy();
     expect(view.queryByText("GET /health")).toBeNull();
 
     fireEvent.change(input, { target: { value: "trace-ok-456" } });
-    expect(view.getByText("1 traces")).toBeTruthy();
     expect(view.getByText("GET /health")).toBeTruthy();
     expect(view.queryByText("POST /payments")).toBeNull();
   });

--- a/observer/client/src/traces/TracesTab.test.tsx
+++ b/observer/client/src/traces/TracesTab.test.tsx
@@ -35,8 +35,6 @@ describe("TracesTab", () => {
       />,
     );
 
-    expect(screen.getByText("2 traces")).toBeTruthy();
-
     fireEvent.change(screen.getByPlaceholderText("Search operation, trace ID, service, or status"), {
       target: { value: "missing-service" },
     });

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -147,7 +147,6 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
         <div className="signal-view__content">
           {traces.length > 0 ? (
             <div className="explorer__toolbar explorer__toolbar--controls">
-              <span className="explorer__count">{filteredTraces.length} traces</span>
               <input
                 className="explorer__input"
                 type="search"
@@ -163,7 +162,7 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
           ) : null}
 
           {traces.length === 0 ? (
-            <p className="explorer__status">Waiting for traces... Send OTLP data to port 4318.</p>
+            <p className="explorer__status explorer__status--empty">No traces received yet. Send OTLP telemetry to port 4318 to begin exploring.</p>
           ) : filteredTraces.length === 0 ? (
             <p className="explorer__status">No traces match the current search.</p>
           ) : (


### PR DESCRIPTION
- Remove decorative "Telemetry stream" pill and redundant per-tab count labels ("4 traces", "12 logs", "4 metrics")
- Add inline count badges to tab buttons for at-a-glance signal visibility
- Replace comma-separated service names with truncatable tag pills
- Compact title bar, summary cards, stream toggle, and pending badge
- Flatten frame: reduce border-radius (18px→10px), remove gradients
- Add dedicated help button with proper ARIA label
- Improve empty state messaging across all tabs
- Reduce detail panel default width (420px→400px)
- Remove dead .explorer__count CSS rule
- Update tests to match new UI structure