### PR TITLE
Fix release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,12 @@ project_name: obstudio
 
 before:
   hooks:
-    - cd observer && go run ./cmd/stage-skills
-    - cd observer && go run ./cmd/build-client
+    - cmd: go run ./cmd/stage-skills
+      dir: observer
+    - cmd: npm ci
+      dir: observer/client
+    - cmd: go run ./cmd/build-client
+      dir: observer
 
 builds:
   - dir: observer

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help: ## Show available targets
 # --- Client build ---
 
 build-client: ## Build React client into Go static assets
+	cd $(GO_DIR)/client && npm ci
 	cd $(GO_DIR) && $(GO) run ./cmd/build-client
 
 stage-skills: ## Stage skills into observer for embedding


### PR DESCRIPTION
 use goreleaser dir hooks and add npm ci to clientbuild

GoReleaser before hooks failed because `cd` is not a standalone executable. Switch to the `cmd`/`dir` hook syntax so each command runs in the correct working directory. Also add `npm ci` to install client dependencies before the client build in both the Makefile and GoReleaser pipeline.

Made-with: Cursor