### PR TITLE
Move release prep logic from goreleaser hooks to Makefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,9 @@ jobs:
           go-version-file: observer/go.mod
           cache-dependency-path: observer/go.sum
 
-      - name: Install client build dependencies
+      - name: Prepare release assets
         timeout-minutes: 10
-        working-directory: observer/client
-        run: npm ci --no-audit --no-fund --verbose
+        run: make release-prep
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,15 +2,6 @@ version: 2
 
 project_name: obstudio
 
-before:
-  hooks:
-    - cmd: go run ./cmd/stage-skills
-      dir: observer
-    - cmd: npm ci
-      dir: observer/client
-    - cmd: go run ./cmd/build-client
-      dir: observer
-
 builds:
   - dir: observer
     main: ./cmd/obstudio

--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,12 @@ vet: stage-skills ## Vet Go source
 
 # --- Release ---
 
-release-local: ## Build release archives locally via GoReleaser (snapshot, no publish)
+release-prep: stage-skills build-client ## Prepare assets for GoReleaser (skills + client)
+
+release-local: release-prep ## Build release archives locally via GoReleaser (snapshot, no publish)
 	goreleaser release --snapshot --clean
 
-release: ## Build and publish a release via GoReleaser (requires GITHUB_TOKEN)
+release: release-prep ## Build and publish a release via GoReleaser (requires GITHUB_TOKEN)
 	goreleaser release --clean
 
 # --- Evals ---


### PR DESCRIPTION
GoReleaser global before.hooks only accepts strings, not cmd/dir maps, which broke the v2.15 CI build. Instead of inlining shell workarounds, consolidate stage-skills + build-client into a `make release-prep` target and call it from both CI and the local release targets.

Made-with: Cursor