### PR TITLE
Fix observer-local make entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
           cache-dependency-path: observer/go.sum
 
       - name: go vet
-        run: make vet
+        run: make -C observer vet
 
       - name: Build binary
-        run: make build
+        run: make -C observer build
 
       - name: Run tests
-        run: make test
+        run: make -C observer test
 
   extension:
     name: Extension – unit & integration tests

--- a/extension/src/test/extension-vscode.test.ts
+++ b/extension/src/test/extension-vscode.test.ts
@@ -28,6 +28,8 @@ type FileSnapshot = {
 	filePath: string;
 };
 
+const sharedObserverStartupRetries = 5;
+
 async function waitFor<T>(load: () => Promise<T>, ready: (value: T) => boolean, timeoutMs: number): Promise<T> {
 	const deadline = Date.now() + timeoutMs;
 	let last: T | undefined;
@@ -83,10 +85,39 @@ async function getAvailablePort(): Promise<number> {
 	});
 }
 
-async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
+function isRetryableSharedObserverStartupFailure(stderr: string): boolean {
+	return /\bEADDRINUSE\b/i.test(stderr) || /\baddress already in use\b/i.test(stderr);
+}
+
+async function terminateChild(child: cp.ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.killed) {
+		return;
+	}
+	child.kill();
+	await Promise.race([
+		new Promise<void>((resolve) => {
+			child.once('exit', () => resolve());
+		}),
+		new Promise<void>((resolve) => {
+			setTimeout(() => {
+				if (child.exitCode === null && !child.killed) {
+					child.kill('SIGKILL');
+				}
+				resolve();
+			}, 2_000);
+		}),
+	]);
+}
+
+async function waitForHttpOrExit(url: string, child: cp.ChildProcess, timeoutMs: number): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	let lastError: unknown;
+
 	while (Date.now() < deadline) {
+		if (child.exitCode !== null || child.killed) {
+			throw new Error(`Observer exited before becoming ready at ${url}.`);
+		}
+
 		try {
 			await new Promise<void>((resolve, reject) => {
 				http.get(url, (response) => {
@@ -100,6 +131,10 @@ async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
 			await new Promise((resolve) => setTimeout(resolve, 200));
 		}
 	}
+
+	if (child.exitCode !== null || child.killed) {
+		throw new Error(`Observer exited before becoming ready at ${url}.`);
+	}
 	if (lastError instanceof Error) {
 		throw lastError;
 	}
@@ -107,44 +142,49 @@ async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
 }
 
 async function startSharedObserver(binaryPath: string): Promise<SharedObserverHandle> {
-	const port = await getAvailablePort();
-	const grpcPort = await getAvailablePort();
-	const httpPort = await getAvailablePort();
-	const baseUrl = `http://127.0.0.1:${port}`;
-	const child = cp.spawn(binaryPath, [], {
-		env: {
-			...process.env,
-			HOST: '127.0.0.1',
-			PORT: String(port),
-			OTLP_GRPC_PORT: String(grpcPort),
-			OTLP_HTTP_PORT: String(httpPort),
-		},
-		stdio: 'pipe',
-	});
-	let stderr = '';
-	child.stderr?.on('data', (chunk: Buffer | string) => {
-		stderr += chunk.toString();
-	});
+	let lastFailure: Error | undefined;
 
-	try {
-		await waitForHttp(baseUrl, 10_000);
-	} catch (error) {
-		child.kill();
-		throw new Error(`shared observer failed to start: ${error instanceof Error ? error.message : String(error)}\n${stderr}`);
+	for (let attempt = 1; attempt <= sharedObserverStartupRetries; attempt += 1) {
+		const port = await getAvailablePort();
+		const grpcPort = await getAvailablePort();
+		const httpPort = await getAvailablePort();
+		const baseUrl = `http://127.0.0.1:${port}`;
+		const child = cp.spawn(binaryPath, [], {
+			env: {
+				...process.env,
+				HOST: '127.0.0.1',
+				PORT: String(port),
+				OTLP_GRPC_PORT: String(grpcPort),
+				OTLP_HTTP_PORT: String(httpPort),
+			},
+			stdio: 'pipe',
+		});
+		let stderr = '';
+		child.stderr?.on('data', (chunk: Buffer | string) => {
+			stderr += chunk.toString();
+		});
+
+		try {
+			await waitForHttpOrExit(baseUrl, child, 10_000);
+			return {
+				baseUrl,
+				dispose: async () => {
+					await terminateChild(child);
+				},
+			};
+		} catch (error) {
+			await terminateChild(child);
+			lastFailure = new Error(
+				`shared observer failed to start: ${error instanceof Error ? error.message : String(error)}\n${stderr}`,
+			);
+			if (attempt < sharedObserverStartupRetries && isRetryableSharedObserverStartupFailure(stderr)) {
+				continue;
+			}
+			throw lastFailure;
+		}
 	}
 
-	return {
-		baseUrl,
-		dispose: async () => {
-			if (child.exitCode !== null || child.killed) {
-				return;
-			}
-			child.kill();
-			await new Promise<void>((resolve) => {
-				child.once('exit', () => resolve());
-			});
-		},
-	};
+	throw lastFailure ?? new Error('shared observer failed to start');
 }
 
 async function startSlowSharedObserver(delayMs: number): Promise<SharedObserverHandle> {
@@ -293,6 +333,23 @@ async function requestJson(url: string, method: 'GET' | 'POST'): Promise<any> {
 }
 
 suite('VS Code Host', () => {
+	test('shared observer startup retries port collisions', () => {
+		assert.equal(
+			isRetryableSharedObserverStartupFailure(
+				'failed to start OTLP receiver: listen tcp 127.0.0.1:45621: bind: address already in use',
+			),
+			true,
+		);
+		assert.equal(
+			isRetryableSharedObserverStartupFailure('spawn failed: EADDRINUSE'),
+			true,
+		);
+		assert.equal(
+			isRetryableSharedObserverStartupFailure('shared observer failed to start: connect ECONNREFUSED 127.0.0.1:36715'),
+			false,
+		);
+	});
+
 	test('openObserver reuses configured shared backend and configures MCP targets', async function () {
 		this.timeout(30_000);
 

--- a/observer/Makefile
+++ b/observer/Makefile
@@ -1,0 +1,12 @@
+# Keep the root Makefile as the single source of truth for build logic.
+ROOT_DIR := ..
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+
+help:
+	@$(MAKE) -C $(ROOT_DIR) help
+
+%:
+	@$(MAKE) -C $(ROOT_DIR) $@

--- a/observer/README.md
+++ b/observer/README.md
@@ -10,6 +10,10 @@ agents), and a browser-based Telemetry Explorer.
 make run
 ```
 
+Run this either from the repository root or from `observer/`. The
+`observer/Makefile` delegates to the repo-root build so the commands stay
+in sync.
+
 This builds and starts the collector on default ports:
 
 | Service | URL |
@@ -94,7 +98,8 @@ AI agents can query telemetry via JSON-RPC at `/mcp`:
 
 ## Make Targets
 
-All targets run from the repository root:
+Targets are defined in the repository root and are also available from
+`observer/` via the delegating `Makefile`:
 
 | Target | Description |
 |---|---|


### PR DESCRIPTION

Add a thin observer/Makefile that forwards targets to the repo-root Makefile, so the documented make commands work when run from inside observer/ as well as from the repository root.

Update observer/README.md to reflect that supported workflow, and update the observer CI job to run through make -C observer ... so the nested entrypoint remains covered.