### PR TITLE
Bundle weaver into local build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SKILLS_SRC := skills
 
 ABS_BUILD  := $(CURDIR)/$(BUILD_DIR)
 
-.PHONY: help build build-client stage-skills dev run test test-extension test-client test-all tidy fmt vet test-deterministic eval-fixture eval-llm eval-llm-full release-local release list-skills clean
+.PHONY: help build build-client stage-skills bundle-weaver dev run test test-extension test-client test-all tidy fmt vet test-deterministic eval-fixture eval-llm eval-llm-full release-local release list-skills clean
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
@@ -31,7 +31,11 @@ dev: ## Watch client files and rebuild on changes (hot reload)
 
 # --- Go build ---
 
-build: stage-skills build-client ## Build obstudio binary (client + skills embedded)
+bundle-weaver: ## Fetch the local Weaver validator runtime into build output
+	@mkdir -p $(BUILD_DIR)
+	cd $(GO_DIR) && $(GO) run ./cmd/fetch-weaver -output $(ABS_BUILD)
+
+build: stage-skills build-client bundle-weaver ## Build obstudio binary (client + skills embedded)
 	@mkdir -p $(BUILD_DIR)
 	cd $(GO_DIR) && $(GO) build $(GOFLAGS) $(LDFLAGS) -o $(ABS_BUILD)/$(BINARY) $(GO_CMD)
 

--- a/observer/cmd/fetch-weaver/main.go
+++ b/observer/cmd/fetch-weaver/main.go
@@ -168,6 +168,9 @@ func ensureCachedBinary(ctx context.Context, target target) (string, error) {
 }
 
 func weaverCacheDir() (string, error) {
+	if override := os.Getenv("OBSTUDIO_WEAVER_CACHE_DIR"); override != "" {
+		return filepath.Join(override, weaverVersion), nil
+	}
 	cacheRoot, err := os.UserCacheDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve user cache dir: %w", err)

--- a/observer/cmd/fetch-weaver/main_test.go
+++ b/observer/cmd/fetch-weaver/main_test.go
@@ -78,3 +78,35 @@ func TestCopyFileCopiesContents(t *testing.T) {
 		t.Fatalf("unexpected destination contents: %q", string(data))
 	}
 }
+
+func TestFetchTargetUsesCachedBinaryFromOverride(t *testing.T) {
+	cacheRoot := t.TempDir()
+	outputDir := t.TempDir()
+	t.Setenv("OBSTUDIO_WEAVER_CACHE_DIR", cacheRoot)
+
+	target, err := findTarget("darwin", "arm64")
+	if err != nil {
+		t.Fatalf("findTarget returned error: %v", err)
+	}
+
+	cacheBinary := filepath.Join(cacheRoot, weaverVersion, target.goos+"-"+target.goarch, target.bundledBinaryName)
+	if err := os.MkdirAll(filepath.Dir(cacheBinary), 0o755); err != nil {
+		t.Fatalf("create cache dir: %v", err)
+	}
+	if err := os.WriteFile(cacheBinary, []byte("cached-weaver"), 0o755); err != nil {
+		t.Fatalf("write cached binary: %v", err)
+	}
+
+	if err := fetchTarget(t.Context(), outputDir, target.goos, target.goarch); err != nil {
+		t.Fatalf("fetchTarget returned error: %v", err)
+	}
+
+	outputBinary := filepath.Join(outputDir, target.bundledBinaryName)
+	data, err := os.ReadFile(outputBinary)
+	if err != nil {
+		t.Fatalf("read output binary: %v", err)
+	}
+	if string(data) != "cached-weaver" {
+		t.Fatalf("unexpected output contents: %q", string(data))
+	}
+}


### PR DESCRIPTION
# Summary
Ensure local `make build` output includes the `weaver` runtime so validation works from the standalone `build/` bundle, not just from the VS Code package.

## What Changed
- update `make build` to fetch and copy `weaver` into `build/` alongside `obstudio`
- add a cache-dir override to `fetch-weaver` so the copy path is testable without network coupling
- add unit coverage for copying the cached runtime into the requested output directory

## Why
Validation was unavailable when running the standalone build because `obstudio` could not find `weaver` beside the binary or on `PATH`. The extension bundle already carried `weaver`; the local build did not.

## Verification
- `make test`
- `cd observer && go test ./cmd/fetch-weaver ./cmd/obstudio ./internal/validator ./internal/api`
- `make build`
- installed the packaged VS Code extension and verified it still works
- started the standalone build from `build/obstudio`
- sent live OTLP traces, metrics, and logs
- read the DOM for Metrics, Traces, Logs, and Validation
- verified validation status became enabled and produced a live result