### PR TITLE
Feature/auto pause

### DIFF
--- a/observer/client/src/AppView.test.tsx
+++ b/observer/client/src/AppView.test.tsx
@@ -126,7 +126,7 @@ describe("AppView validation tab", () => {
     fireEvent.click(validationTab);
 
     expect(screen.getAllByText("Validation").length).toBeGreaterThan(0);
-    expect(screen.getByText("1 issues")).toBeTruthy();
+    expect(screen.getByText("1 issue")).toBeTruthy();
     expect(screen.getByText("Services")).toBeTruthy();
     expect(screen.queryByText(/occurrences/i)).toBeNull();
     expect(container.querySelector(".metric-summary")).toBeTruthy();
@@ -137,7 +137,7 @@ describe("AppView validation tab", () => {
     expect(screen.getAllByText("http.server.duration").length).toBeGreaterThan(0);
 
     const tablist = screen.getByRole("tablist", { name: "Validation signals" });
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Spans" }));
+    fireEvent.click(within(tablist).getByRole("tab", { name: /^Spans/ }));
     expect(screen.getAllByText("GET /orders").length).toBeGreaterThan(0);
   });
 
@@ -164,5 +164,17 @@ describe("AppView validation tab", () => {
     expect(tracesTab.querySelector(".tab-button__count")).toBeTruthy();
     expect(logsTab.querySelector(".tab-button__count")).toBeTruthy();
     expect(container.querySelector(".tab-button__glyph")).toBeNull();
+  });
+
+  it("does not pause the stream when switching tabs", () => {
+    const telemetry = makeTelemetryHandle([makeFinding({})]);
+
+    render(<AppView telemetry={telemetry} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /traces/i }));
+    fireEvent.click(screen.getByRole("tab", { name: /logs/i }));
+
+    expect(telemetry.pause).not.toHaveBeenCalled();
+    expect(telemetry.toggle).not.toHaveBeenCalled();
   });
 });

--- a/observer/client/src/AppView.tsx
+++ b/observer/client/src/AppView.tsx
@@ -19,7 +19,7 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
   const [activeTab, setActiveTab] = useState<AppTab>(() => initialTabFromLocation());
   const [showHelp, setShowHelp] = useState(false);
 
-  const { state, paused, hasNewUpdates, pause, resume, toggle } = telemetry;
+  const { state, paused, hasNewUpdates, resume, toggle } = telemetry;
   const validationSummary = state.validation?.summary ?? null;
   const validationFindings = state.validation?.findings ?? [];
   const backendValidationIssues = state.validation?.issues ?? [];
@@ -171,14 +171,12 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
           <MetricsTab
             metrics={state.metrics ?? []}
             telemetryError={state.error}
-            onInteract={pause}
           />
         ) : null}
         {activeTab === "traces" ? (
           <TracesTab
             telemetryError={state.error}
             traces={state.traces ?? []}
-            onInteract={pause}
             validationFindings={validationFindings}
             validationIndex={validationIndex}
           />
@@ -186,7 +184,6 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
         {activeTab === "logs" ? (
           <LogsTab
             logs={state.logs ?? []}
-            onInteract={pause}
           />
         ) : null}
         {activeTab === "validation" ? (

--- a/observer/client/src/components/FindingsTab.test.tsx
+++ b/observer/client/src/components/FindingsTab.test.tsx
@@ -98,8 +98,14 @@ describe("FindingsTab", () => {
     );
 
     const tablist = view.getByRole("tablist", { name: "Validation signals" });
-    expect(within(tablist).getByRole("tab", { name: "Metrics" }).getAttribute("aria-selected")).toBe("true");
-    expect(within(tablist).getByRole("tab", { name: "Spans" }).getAttribute("aria-selected")).toBe("false");
+    const metricsTab = within(tablist).getByRole("tab", { name: /^Metrics/ });
+    const spansTab = within(tablist).getByRole("tab", { name: /^Spans/ });
+    expect(metricsTab.getAttribute("aria-selected")).toBe("true");
+    expect(spansTab.getAttribute("aria-selected")).toBe("false");
+
+    // Signal tabs show issue counts
+    expect(metricsTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("1");
+    expect(spansTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("1");
 
     const head = view.container.querySelector(".findings-tab__head");
     expect(head).toBeTruthy();
@@ -183,14 +189,14 @@ describe("FindingsTab", () => {
 
     const tablist = view.getByRole("tablist", { name: "Validation signals" });
 
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Spans" }));
+    fireEvent.click(within(tablist).getByRole("tab", { name: /^Spans/ }));
     let head = view.container.querySelector(".findings-tab__head");
     expect(within(head as HTMLElement).getByText("Span")).toBeTruthy();
     let master = view.container.querySelector(".findings-tab__master");
     expect(master?.classList.contains("findings-tab__master--span")).toBe(true);
     expect(within(master as HTMLElement).getByText("GET /orders")).toBeTruthy();
 
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Logs" }));
+    fireEvent.click(within(tablist).getByRole("tab", { name: /^Logs/ }));
     head = view.container.querySelector(".findings-tab__head");
     expect(within(head as HTMLElement).getByText("Example")).toBeTruthy();
     master = view.container.querySelector(".findings-tab__master");
@@ -198,7 +204,7 @@ describe("FindingsTab", () => {
     expect(within(master as HTMLElement).getByText("Cache hit for order ORD-1781")).toBeTruthy();
     expect(within(master as HTMLElement).getByText("missing_attribute")).toBeTruthy();
 
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Resources" }));
+    fireEvent.click(within(tablist).getByRole("tab", { name: /^Resources/ }));
     head = view.container.querySelector(".findings-tab__head");
     expect(within(head as HTMLElement).getByText("Attribute")).toBeTruthy();
     master = view.container.querySelector(".findings-tab__master");
@@ -254,7 +260,7 @@ describe("FindingsTab", () => {
     expect(detailPanel.querySelector(".findings-tab__detail-heading")?.textContent).toBe("GET /orders");
 
     const tablist = view.getByRole("tablist", { name: "Validation signals" });
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Logs" }));
+    fireEvent.click(within(tablist).getByRole("tab", { name: /^Logs/ }));
     master = view.container.querySelector(".findings-tab__master");
     fireEvent.click(within(master as HTMLElement).getByText("Cache hit for order ORD-1781").closest("button") as HTMLElement);
     detailPanel = view.container.querySelector("#validation-issue-detail") as HTMLElement;
@@ -262,7 +268,7 @@ describe("FindingsTab", () => {
     expect(detailPanel.querySelector(".detail-panel__subtitle")).toBeNull();
     expect(detailPanel.querySelector(".findings-tab__detail-heading")?.textContent).toBe("Cache hit for order ORD-1781");
 
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Resources" }));
+    fireEvent.click(within(tablist).getByRole("tab", { name: /^Resources/ }));
     master = view.container.querySelector(".findings-tab__master");
     fireEvent.click(within(master as HTMLElement).getByText("deployment.environment.name").closest("button") as HTMLElement);
     detailPanel = view.container.querySelector("#validation-issue-detail") as HTMLElement;
@@ -367,7 +373,7 @@ describe("FindingsTab", () => {
     );
 
     const tablist = view.getByRole("tablist", { name: "Validation signals" });
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Resources" }));
+    fireEvent.click(within(tablist).getByRole("tab", { name: /^Resources/ }));
 
     const master = view.container.querySelector(".findings-tab__master");
     fireEvent.click(within(master as HTMLElement).getByText("deployment.environment.name").closest("button") as HTMLElement);

--- a/observer/client/src/components/FindingsTab.tsx
+++ b/observer/client/src/components/FindingsTab.tsx
@@ -54,9 +54,16 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const signalIssueCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const tab of signalTabs) {
+      counts[tab.key] = issues.filter((issue) => normalizeSignalType(issue.signalType) === tab.key).length;
+    }
+    return counts;
+  }, [issues]);
   const availableSignalTabs = useMemo(
-    () => signalTabs.filter((tab) => issues.some((issue) => normalizeSignalType(issue.signalType) === tab.key)),
-    [issues],
+    () => signalTabs.filter((tab) => signalIssueCounts[tab.key] > 0),
+    [signalIssueCounts],
   );
   const activeSignalDefinition = signalTabs.find((tab) => tab.key === activeSignalTab) ?? signalTabs[0];
 
@@ -135,7 +142,7 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
     <section className="tab-panel findings-tab">
       <div className="panel-toolbar findings-tab__header">
         <div className="findings-tab__header-meta">
-          {showResultState ? <span className="findings-tab__header-count">{filteredIssues.length} issues</span> : null}
+          {showResultState ? <span className="findings-tab__header-count">{filteredIssues.length} {filteredIssues.length === 1 ? "issue" : "issues"}</span> : null}
           {showResultState && completedAt ? <span className="findings-tab__header-separator" aria-hidden="true">·</span> : null}
           {completedAt ? <span className="findings-tab__header-timestamp">Validated {formatTimestamp(completedAt)}</span> : null}
         </div>
@@ -162,7 +169,7 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
         </select>
         <div className="findings-tab__signal-tabs" role="tablist" aria-label="Validation signals">
           {signalTabs.map((tab) => {
-            const hasIssues = issues.some((issue) => normalizeSignalType(issue.signalType) === tab.key);
+            const count = signalIssueCounts[tab.key] ?? 0;
             return (
               <button
                 key={tab.key}
@@ -170,10 +177,11 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
                 role="tab"
                 className={tab.key === activeSignalTab ? "findings-tab__signal-tab is-active" : "findings-tab__signal-tab"}
                 aria-selected={tab.key === activeSignalTab}
-                data-has-issues={hasIssues ? "true" : "false"}
+                data-has-issues={count > 0 ? "true" : "false"}
                 onClick={() => setActiveSignalTab(tab.key)}
               >
                 {tab.label}
+                {count > 0 ? <span className="findings-tab__signal-count">{count}</span> : null}
               </button>
             );
           })}

--- a/observer/client/src/layout/DetailPanel.test.tsx
+++ b/observer/client/src/layout/DetailPanel.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DetailPanel } from "./DetailPanel";
+
+afterEach(() => cleanup());
+
+describe("DetailPanel", () => {
+  it("does not reset scroll when only the panel body rerenders", () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    const view = render(
+      <DetailPanel title="Metric" subtitle="checkout" onClose={() => undefined}>
+        <div>first</div>
+      </DetailPanel>,
+    );
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <DetailPanel title="Metric" subtitle="checkout" onClose={() => undefined}>
+        <div>second</div>
+      </DetailPanel>,
+    );
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets scroll when the panel target changes", () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    const view = render(
+      <DetailPanel title="Metric A" subtitle="checkout" onClose={() => undefined}>
+        <div>first</div>
+      </DetailPanel>,
+    );
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <DetailPanel title="Metric B" subtitle="checkout" onClose={() => undefined}>
+        <div>second</div>
+      </DetailPanel>,
+    );
+
+    expect(scrollTo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/observer/client/src/layout/DetailPanel.tsx
+++ b/observer/client/src/layout/DetailPanel.tsx
@@ -21,7 +21,7 @@ export function DetailPanel({
 
   useEffect(() => {
     bodyRef.current?.scrollTo(0, 0);
-  }, [title, subtitle, headerMode, children]);
+  }, [title, subtitle, headerMode]);
 
   return (
     <div className={headerMode === "close-only" ? "detail-panel detail-panel--close-only" : "detail-panel"}>

--- a/observer/client/src/logs/LogsTab.test.tsx
+++ b/observer/client/src/logs/LogsTab.test.tsx
@@ -67,7 +67,6 @@ describe("LogsTab", () => {
             scope: { name: "otel" },
           },
         ]}
-        onInteract={vi.fn()}
       />,
     );
 
@@ -100,7 +99,6 @@ describe("LogsTab", () => {
             spanId: "span-1",
           },
         ]}
-        onInteract={vi.fn()}
       />,
     );
 

--- a/observer/client/src/logs/LogsTab.tsx
+++ b/observer/client/src/logs/LogsTab.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { LogRecord } from "../api/types";
 import { DetailPanel } from "../layout";
 
 interface LogsTabProps {
   logs: LogRecord[];
-  onInteract?: () => void;
 }
 
 type DetailTab = "overview" | "json";
@@ -24,7 +23,7 @@ function logKey(r: LogRecord): string {
 }
 
 /** Logs tab with virtualized table and detail panel for selected log records. */
-export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement {
+export function LogsTab({ logs }: LogsTabProps): React.ReactElement {
   const [query, setQuery] = useState("");
   const [severityFilter, setSeverityFilter] = useState("");
   const [selectedLog, setSelectedLog] = useState<LogRecord | null>(null);
@@ -51,10 +50,6 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
       return haystack.includes(trimmedQuery);
     });
   }, [logs, query, severityFilter]);
-  const handleInteract = useCallback(() => {
-    onInteract?.();
-  }, [onInteract]);
-
   // Invalidate selection when the selected log is no longer in the snapshot
   // (e.g., after store clear, WebSocket reconnect, or eviction from the buffer).
   useEffect(() => {
@@ -80,7 +75,6 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
     <section className="tab-panel" role="tabpanel">
       <div
         className={`signal-view${selectedLog ? " signal-view--with-panel" : ""}`}
-        onPointerDownCapture={handleInteract}
       >
         <div className="signal-view__content">
           {logs.length > 0 ? (
@@ -134,7 +128,6 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
                     onClick={() => {
                       setSelectedLog(r);
                       setDetailTab("overview");
-                      onInteract?.();
                     }}
                     type="button"
                     style={{

--- a/observer/client/src/metrics/MetricsTab.test.tsx
+++ b/observer/client/src/metrics/MetricsTab.test.tsx
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import React from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { MetricsTab } from "./MetricsTab";
 
 afterEach(() => cleanup());
@@ -46,7 +46,6 @@ describe("MetricsTab", () => {
           },
         ]}
         telemetryError={null}
-        onInteract={vi.fn()}
       />,
     );
 
@@ -65,8 +64,7 @@ describe("MetricsTab", () => {
     expect(screen.queryByText("db.client.connections.usage")).toBeNull();
   });
 
-  it("renders metrics in alphabetical order and pauses live updates on interaction", () => {
-    const onInteract = vi.fn();
+  it("renders metrics in alphabetical order", () => {
     const { container } = render(
       <MetricsTab
         metrics={[
@@ -92,7 +90,6 @@ describe("MetricsTab", () => {
           },
         ]}
         telemetryError={null}
-        onInteract={onInteract}
       />,
     );
 
@@ -111,12 +108,9 @@ describe("MetricsTab", () => {
     expect(container.querySelector(".metric-card__disclosure")).toBeNull();
     expect(container.textContent).toContain("gauge/ms");
     expect(container.textContent).not.toContain("svc");
-
-    fireEvent.pointerDown(screen.getByRole("button", { name: /alpha\.metric/i }));
-    expect(onInteract).toHaveBeenCalled();
   });
 
-  it("renders expanded series rows with separate service and dimension text", () => {
+  it("opens the full metric view in a side panel with series rows", () => {
     const { container } = render(
       <MetricsTab
         metrics={[
@@ -143,17 +137,181 @@ describe("MetricsTab", () => {
           },
         ]}
         telemetryError={null}
-        onInteract={vi.fn()}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /http\.server\.duration/i }));
 
+    expect(screen.getByRole("heading", { name: "http.server.duration" })).toBeTruthy();
+    expect(screen.getByText("Series (1)")).toBeTruthy();
+    expect(container.querySelector(".ts-chart")).toBeTruthy();
     expect(container.querySelector(".metrics-explorer__series-service")?.textContent).toBe("api-gateway");
     expect(container.querySelector(".metrics-explorer__series-attr")?.textContent).toBe("http.route=/api/orders/{id}");
     expect(container.querySelector(".metrics-explorer__series-value")?.textContent).toBe("8.18");
     expect(container.querySelector(".metrics-explorer__series-points")?.textContent).toBe("1 pts");
     expect(container.querySelector(".metric-card__description")?.classList.contains("explorer-row__secondary")).toBe(true);
+  });
+
+  it("shows selected series detail inside the metric side panel", () => {
+    render(
+      <MetricsTab
+        metrics={[
+          {
+            name: "http.server.duration",
+            description: "Request duration",
+            unit: "ms",
+            type: "histogram",
+            serviceName: "api-gateway",
+            scopeName: "otel",
+            dataPointCount: 2,
+            dataPoints: [
+              {
+                name: "http.server.duration",
+                type: "histogram",
+                unit: "ms",
+                timeUnixNano: "1",
+                attributes: { "http.route": "/api/orders/{id}" },
+                resource: { serviceName: "api-gateway", attributes: { "service.instance.id": "instance-1" } },
+                scope: { name: "otel", version: "1.0.0" },
+                value: 8.18,
+              },
+              {
+                name: "http.server.duration",
+                type: "histogram",
+                unit: "ms",
+                timeUnixNano: "2",
+                attributes: { "http.route": "/api/orders/{id}" },
+                resource: { serviceName: "api-gateway", attributes: { "service.instance.id": "instance-1" } },
+                scope: { name: "otel", version: "1.0.0" },
+                value: 10.25,
+              },
+            ],
+          },
+        ]}
+        telemetryError={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /http\.server\.duration/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /api-gateway/i })[0] as HTMLElement);
+
+    expect(screen.getByRole("heading", { name: "http.server.duration" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close panel" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Clear series selection" })).toBeTruthy();
+    expect(screen.getByText("Scope")).toBeTruthy();
+    expect(screen.getByText("Resource")).toBeTruthy();
+    expect(screen.getByText("service.instance.id:")).toBeTruthy();
+  });
+
+  it("keeps metric series order stable across live value updates and appends new series at the end", () => {
+    const initialMetrics = [
+      {
+        name: "http.server.duration",
+        description: "Request duration",
+        unit: "ms",
+        type: "histogram",
+        serviceName: "api-gateway",
+        scopeName: "otel",
+        dataPointCount: 2,
+        dataPoints: [
+          {
+            name: "http.server.duration",
+            type: "histogram",
+            unit: "ms",
+            timeUnixNano: "1",
+            attributes: { "http.route": "/api/orders" },
+            resource: { serviceName: "checkout", attributes: {} },
+            scope: { name: "otel" },
+            value: 8.18,
+          },
+          {
+            name: "http.server.duration",
+            type: "histogram",
+            unit: "ms",
+            timeUnixNano: "2",
+            attributes: { "http.route": "/api/orders/{id}" },
+            resource: { serviceName: "payments", attributes: {} },
+            scope: { name: "otel" },
+            value: 10.25,
+          },
+        ],
+      },
+    ];
+    const { container, rerender } = render(<MetricsTab metrics={initialMetrics} telemetryError={null} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /http\.server\.duration/i }));
+
+    const initialRows = Array.from(container.querySelectorAll(".metrics-explorer__series-row"))
+      .map((node) => ({
+        service: node.querySelector(".metrics-explorer__series-service")?.textContent,
+        dimension: node.querySelector(".metrics-explorer__series-attr")?.textContent,
+        value: node.querySelector(".metrics-explorer__series-value")?.textContent,
+      }));
+    expect(initialRows).toEqual([
+      { service: "checkout", dimension: "http.route=/api/orders", value: "8.18" },
+      { service: "payments", dimension: "http.route=/api/orders/{id}", value: "10.25" },
+    ]);
+
+    rerender(
+      <MetricsTab
+        metrics={[
+          {
+            name: "http.server.duration",
+            description: "Request duration",
+            unit: "ms",
+            type: "histogram",
+            serviceName: "api-gateway",
+            scopeName: "otel",
+            dataPointCount: 3,
+            dataPoints: [
+              {
+                name: "http.server.duration",
+                type: "histogram",
+                unit: "ms",
+                timeUnixNano: "3",
+                attributes: { "http.route": "/api/orders/{id}" },
+                resource: { serviceName: "payments", attributes: {} },
+                scope: { name: "otel" },
+                value: 100.25,
+              },
+              {
+                name: "http.server.duration",
+                type: "histogram",
+                unit: "ms",
+                timeUnixNano: "4",
+                attributes: { "http.route": "/api/orders" },
+                resource: { serviceName: "checkout", attributes: {} },
+                scope: { name: "otel" },
+                value: 18.18,
+              },
+              {
+                name: "http.server.duration",
+                type: "histogram",
+                unit: "ms",
+                timeUnixNano: "5",
+                attributes: { "http.route": "/api/inventory" },
+                resource: { serviceName: "inventory", attributes: {} },
+                scope: { name: "otel" },
+                value: 3.5,
+              },
+            ],
+          },
+        ]}
+        telemetryError={null}
+      />,
+    );
+
+    const updatedRows = Array.from(container.querySelectorAll(".metrics-explorer__series-row"))
+      .map((node) => ({
+        service: node.querySelector(".metrics-explorer__series-service")?.textContent,
+        dimension: node.querySelector(".metrics-explorer__series-attr")?.textContent,
+        value: node.querySelector(".metrics-explorer__series-value")?.textContent,
+      }));
+    expect(updatedRows).toEqual([
+      { service: "checkout", dimension: "http.route=/api/orders", value: "18.18" },
+      { service: "payments", dimension: "http.route=/api/orders/{id}", value: "100.25" },
+      { service: "inventory", dimension: "http.route=/api/inventory", value: "3.50" },
+    ]);
   });
 
   it("keeps the shared row separator on metric rows", async () => {
@@ -177,7 +335,6 @@ describe("MetricsTab", () => {
           },
         ]}
         telemetryError={null}
-        onInteract={vi.fn()}
       />,
     );
 

--- a/observer/client/src/metrics/MetricsTab.tsx
+++ b/observer/client/src/metrics/MetricsTab.tsx
@@ -1,26 +1,24 @@
-import React, { useState, useMemo, useEffect, useCallback } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import { TimeSeriesChart } from "./TimeSeriesChart";
-import { useMetricTimeSeries } from "./useMetricTimeSeries";
+import { useMetricTimeSeries, type MetricSeries } from "./useMetricTimeSeries";
 import type { MetricGroup } from "../api/types";
+import { DetailPanel } from "../layout";
 import { TELEMETRY_SERIES_COLORS } from "../palette";
 
 interface MetricsTabProps {
   metrics: MetricGroup[];
   telemetryError: string | null;
-  onInteract?: () => void;
 }
 
 type DisplayType = "lines" | "bars" | "area";
 
 /** Metrics tab with expandable metric cards and time series charts. */
-export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabProps): React.ReactElement {
+export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.ReactElement {
   const [query, setQuery] = useState("");
   const [expandedMetric, setExpandedMetric] = useState<string | null>(null);
   const [selectedSeriesKey, setSelectedSeriesKey] = useState<string | null>(null);
   const [displayType, setDisplayType] = useState<DisplayType>("lines");
-  const handleInteract = useCallback(() => {
-    onInteract?.();
-  }, [onInteract]);
+  const seriesOrderRef = useRef<Map<string, string[]>>(new Map());
 
   const { allSeries, metricList } = useMetricTimeSeries(metrics);
   const visibleMetricList = useMemo(() => {
@@ -44,11 +42,31 @@ export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabPr
 
   const expandedSeries = useMemo(() => {
     if (!expandedMetric) return [];
-    return allSeries.filter((s) => s.metricName === expandedMetric);
+    const currentSeries = allSeries.filter((s) => s.metricName === expandedMetric);
+    const previousOrder = seriesOrderRef.current.get(expandedMetric) ?? [];
+    const currentKeys = new Set(currentSeries.map((series) => series.key));
+    const nextOrder = [
+      ...previousOrder.filter((key) => currentKeys.has(key)),
+      ...currentSeries.map((series) => series.key).filter((key) => !previousOrder.includes(key)),
+    ];
+    seriesOrderRef.current.set(expandedMetric, nextOrder);
+
+    const seriesByKey = new Map(currentSeries.map((series) => [series.key, series] as const));
+    return nextOrder
+      .map((key) => seriesByKey.get(key))
+      .filter((series): series is MetricSeries => series !== undefined);
   }, [allSeries, expandedMetric]);
+  const expandedMeta = useMemo(
+    () => (expandedMetric
+      ? visibleMetricList.find((metric) => metric.name === expandedMetric)
+        ?? metricList.find((metric) => metric.name === expandedMetric)
+        ?? null
+      : null),
+    [expandedMetric, metricList, visibleMetricList],
+  );
 
   const selectedDetail = selectedSeriesKey
-    ? allSeries.find((s) => s.key === selectedSeriesKey) ?? null
+    ? expandedSeries.find((s) => s.key === selectedSeriesKey) ?? null
     : null;
 
   const stats = useMemo(() => {
@@ -63,6 +81,47 @@ export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabPr
       latest: selectedDetail.latest,
     };
   }, [selectedDetail]);
+  const selectedAttributes = useMemo(
+    () => stableEntries(selectedDetail?.attributes ?? {}),
+    [selectedDetail],
+  );
+  const selectedResourceAttributes = useMemo(
+    () => stableEntries(selectedDetail?.resource.attributes ?? {}),
+    [selectedDetail],
+  );
+  const selectedSubtitle = useMemo(() => {
+    if (!selectedDetail) {
+      return undefined;
+    }
+    const serviceName = selectedDetail.resource.serviceName;
+    const dimensions = selectedAttributes.map(([key, value]) => `${key}=${String(value)}`);
+    if (serviceName && dimensions.length > 0) {
+      return `${serviceName} · ${dimensions.join(", ")}`;
+    }
+    if (serviceName) {
+      return serviceName;
+    }
+    if (dimensions.length > 0) {
+      return dimensions.join(", ");
+    }
+    return "(no dimensions)";
+  }, [selectedAttributes, selectedDetail]);
+  const metricSubtitle = useMemo(() => {
+    if (!expandedMeta) {
+      return undefined;
+    }
+    const parts: string[] = [];
+    if (expandedMeta.description) {
+      parts.push(expandedMeta.description);
+    }
+    if (expandedMeta.serviceCount > 1) {
+      parts.push(`${expandedMeta.serviceCount} services`);
+    } else if (expandedMeta.serviceName && expandedMeta.serviceName !== "unknown") {
+      parts.push(expandedMeta.serviceName);
+    }
+    return parts.join(" · ") || undefined;
+  }, [expandedMeta]);
+  const hasDetail = Boolean(expandedMeta);
 
   useEffect(() => {
     if (!expandedMetric) return;
@@ -73,154 +132,169 @@ export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabPr
   }, [expandedMetric, visibleMetricList]);
 
   return (
-    <section className="tab-panel" role="tabpanel" onPointerDownCapture={handleInteract}>
-      {telemetryError ? (
-        <p className="explorer__status explorer__status--error">{telemetryError}</p>
-      ) : null}
+    <section className="tab-panel" role="tabpanel">
+      <div className={`signal-view${hasDetail ? " signal-view--with-panel" : ""}`}>
+        <div className="signal-view__content">
+          {telemetryError ? (
+            <p className="explorer__status explorer__status--error">{telemetryError}</p>
+          ) : null}
 
-      {metricList.length > 0 ? (
-        <div className="explorer__toolbar explorer__toolbar--controls">
-          <input
-            className="explorer__input"
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search metric, description, type, unit, or service"
-          />
+          {metricList.length > 0 ? (
+            <div className="explorer__toolbar explorer__toolbar--controls">
+              <input
+                className="explorer__input"
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search metric, description, type, unit, or service"
+              />
+            </div>
+          ) : null}
+
+          {metricList.length === 0 && metrics.length === 0 ? (
+            <p className="explorer__status explorer__status--empty" style={{ padding: "40px 20px" }}>
+              No metrics received yet. Send OTLP telemetry to port 4318 to begin exploring.
+            </p>
+          ) : visibleMetricList.length === 0 ? (
+            <p className="metrics-explorer__empty" style={{ padding: "24px 20px" }}>
+              No metrics match the current filters.
+            </p>
+          ) : null}
+
+          {visibleMetricList.length > 0 ? (
+            <div className="data-table__head data-table__head--metrics metrics-card-list__head">
+              <span className="data-table__th">Metric</span>
+              <span className="data-table__th">Description</span>
+              <span className="data-table__th">Type / Unit</span>
+            </div>
+          ) : null}
+
+          <div className="metrics-card-list">
+            {visibleMetricList.map((m) => {
+              const isExpanded = expandedMetric === m.name;
+
+              return (
+                <div key={m.name} className="metric-card">
+                  <button
+                    className={`data-table__row data-table__row--metrics metric-card__header ${isExpanded ? "metric-card__header--active" : ""}`}
+                    onClick={() => {
+                      setExpandedMetric(isExpanded ? null : m.name);
+                      setSelectedSeriesKey(null);
+                    }}
+                    type="button"
+                  >
+                    <span className="data-table__td data-table__td--metric-name metric-card__info">
+                      <span className="metric-card__name explorer-row__primary">{m.name}</span>
+                    </span>
+                    <span className="data-table__td data-table__td--metric-description">
+                      <span className="metric-card__description explorer-row__secondary">{m.description || "--"}</span>
+                    </span>
+                    <span className="data-table__td data-table__td--metric-meta">
+                      <span className="data-table__cell-content data-table__cell-content--meta metric-card__meta">
+                        <span className={`metric-card__badge metric-type metric-type--${m.type}`}>{m.type}</span>
+                        <span className="metric-card__meta-separator explorer-row__secondary">/</span>
+                        <span className="metric-card__unit explorer-row__secondary">{m.unit || "--"}</span>
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              );
+            })}
+          </div>
         </div>
-      ) : null}
 
-      {metricList.length === 0 && metrics.length === 0 ? (
-        <p className="explorer__status explorer__status--empty" style={{ padding: "40px 20px" }}>
-          No metrics received yet. Send OTLP telemetry to port 4318 to begin exploring.
-        </p>
-      ) : visibleMetricList.length === 0 ? (
-        <p className="metrics-explorer__empty" style={{ padding: "24px 20px" }}>
-          No metrics match the current filters.
-        </p>
-      ) : null}
-
-      {visibleMetricList.length > 0 ? (
-        <div className="data-table__head data-table__head--metrics metrics-card-list__head">
-          <span className="data-table__th">Metric</span>
-          <span className="data-table__th">Description</span>
-          <span className="data-table__th">Type / Unit</span>
-        </div>
-      ) : null}
-
-      <div className="metrics-card-list">
-        {visibleMetricList.map((m) => {
-          const isExpanded = expandedMetric === m.name;
-          const series = isExpanded ? expandedSeries : [];
-          const expandedMeta = isExpanded ? m : null;
-
-          return (
-            <div key={m.name} className="metric-card">
-              <button
-                className={`data-table__row data-table__row--metrics metric-card__header ${isExpanded ? "metric-card__header--active" : ""}`}
-                onClick={() => {
-                  setExpandedMetric(isExpanded ? null : m.name);
-                  setSelectedSeriesKey(null);
-                }}
-                type="button"
-              >
-                <span className="data-table__td data-table__td--metric-name metric-card__info">
-                  <span className="metric-card__name explorer-row__primary">{m.name}</span>
-                </span>
-                <span className="data-table__td data-table__td--metric-description">
-                  <span className="metric-card__description explorer-row__secondary">{m.description || "--"}</span>
-                </span>
-                <span className="data-table__td data-table__td--metric-meta">
-                  <span className="data-table__cell-content data-table__cell-content--meta metric-card__meta">
-                    <span className={`metric-card__badge metric-type metric-type--${m.type}`}>{m.type}</span>
-                    <span className="metric-card__meta-separator explorer-row__secondary">/</span>
-                    <span className="metric-card__unit explorer-row__secondary">{m.unit || "--"}</span>
+        {expandedMeta ? (
+          <div className="signal-view__panel signal-view__panel--metrics">
+            <DetailPanel
+              title={expandedMeta.name}
+              subtitle={metricSubtitle}
+              onClose={() => {
+                setExpandedMetric(null);
+                setSelectedSeriesKey(null);
+              }}
+            >
+              <div className="metrics-panel">
+                <div className="series-detail__tags">
+                  <span className={`series-detail__tag series-detail__tag--type metric-type metric-type--${expandedMeta.type}`}>
+                    {expandedMeta.type}
                   </span>
-                </span>
-              </button>
+                  {expandedMeta.unit ? <span className="series-detail__tag">{expandedMeta.unit}</span> : null}
+                  <span className="series-detail__tag">{expandedSeries.length} series</span>
+                </div>
 
-              {isExpanded && expandedMeta ? (
-                <div className="metric-card__body">
-                  {/* Display controls */}
-                  <div className="metrics-explorer__controls">
-                    <div className="metrics-explorer__display">
-                      <span className="metrics-explorer__control-label">Display</span>
-                      {(["lines", "bars", "area"] as DisplayType[]).map((dt) => (
+                <div className="metrics-explorer__controls">
+                  <div className="metrics-explorer__display">
+                    <span className="metrics-explorer__control-label">Display</span>
+                    {(["lines", "bars", "area"] as DisplayType[]).map((dt) => (
+                      <button
+                        key={dt}
+                        className={`pill pill--small ${displayType === dt ? "pill--accent" : "pill--muted"}`}
+                        onClick={() => setDisplayType(dt)}
+                        type="button"
+                      >
+                        {dt.charAt(0).toUpperCase() + dt.slice(1)}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="metrics-explorer__query-series">{expandedSeries.length} series</span>
+                </div>
+
+                <div className="metrics-explorer__chart">
+                  <TimeSeriesChart
+                    series={expandedSeries}
+                    displayType={displayType}
+                    selectedKey={selectedSeriesKey}
+                    onSelectSeries={setSelectedSeriesKey}
+                  />
+                </div>
+
+                <div className="metrics-explorer__detail">
+                  <div className="metrics-explorer__detail-header">
+                    <span className="metrics-explorer__detail-title">Series ({expandedSeries.length})</span>
+                  </div>
+                  <div className="metrics-explorer__detail-body">
+                    {expandedSeries.map((s, i) => {
+                      const attrs = stableEntries(s.attributes ?? {});
+                      const svcName = s.resource?.serviceName;
+                      return (
                         <button
-                          key={dt}
-                          className={`pill pill--small ${displayType === dt ? "pill--accent" : "pill--muted"}`}
-                          onClick={() => setDisplayType(dt)}
+                          key={s.key}
+                          className="metrics-explorer__series-row"
+                          onClick={() => setSelectedSeriesKey(selectedSeriesKey === s.key ? null : s.key)}
                           type="button"
+                          style={{ width: "100%", border: 0, background: selectedSeriesKey === s.key ? "var(--accent-soft)" : "transparent", cursor: "pointer", textAlign: "left", font: "inherit" }}
                         >
-                          {dt.charAt(0).toUpperCase() + dt.slice(1)}
+                          <span className="metrics-explorer__series-dot" style={{ background: TELEMETRY_SERIES_COLORS[i % TELEMETRY_SERIES_COLORS.length] }} />
+                          <span className="metrics-explorer__series-attrs">
+                            {svcName ? <span className="metrics-explorer__series-service">{svcName}</span> : null}
+                            {attrs.length > 0 ? (
+                              <span className="metrics-explorer__series-dimensions">
+                                {attrs.map(([k, v]) => (
+                                  <span key={k} className="metrics-explorer__series-attr">
+                                    {k}={String(v)}
+                                  </span>
+                                ))}
+                              </span>
+                            ) : !svcName ? <span className="metrics-explorer__series-no-attrs">(no dimensions)</span> : null}
+                          </span>
+                          <span className="metrics-explorer__series-value">{formatNumber(s.latest)}</span>
+                          <span className="metrics-explorer__series-points">{s.points.length} pts</span>
                         </button>
-                      ))}
-                    </div>
-                    <span className="metrics-explorer__query-series">{series.length} series</span>
+                      );
+                    })}
                   </div>
+                </div>
 
-                  {/* Chart */}
-                  <div className="metrics-explorer__chart">
-                    <TimeSeriesChart
-                      series={series}
-                      displayType={displayType}
-                      selectedKey={selectedSeriesKey}
-                      onSelectSeries={setSelectedSeriesKey}
-                    />
-                  </div>
-
-                  {/* Series list */}
-                  <div className="metrics-explorer__detail">
-                    <div className="metrics-explorer__detail-header">
-                      <span className="metrics-explorer__detail-title">Series ({series.length})</span>
+                {selectedDetail ? (
+                  <div className="series-detail series-detail--panel">
+                    <div className="series-detail__header">
+                      <div className="series-detail__title">{selectedSubtitle}</div>
+                      <button className="series-detail__close" onClick={() => setSelectedSeriesKey(null)} type="button" aria-label="Clear series selection">
+                        &times;
+                      </button>
                     </div>
-                    <div className="metrics-explorer__detail-body">
-                      {series.map((s, i) => {
-                        const attrs = Object.entries(s.attributes ?? {});
-                        const svcName = s.resource?.serviceName;
-                        return (
-                          <button
-                            key={s.key}
-                            className="metrics-explorer__series-row"
-                            onClick={() => setSelectedSeriesKey(selectedSeriesKey === s.key ? null : s.key)}
-                            type="button"
-                            style={{ width: "100%", border: 0, background: selectedSeriesKey === s.key ? "var(--accent-soft)" : "transparent", cursor: "pointer", textAlign: "left", font: "inherit" }}
-                          >
-                            <span className="metrics-explorer__series-dot" style={{ background: TELEMETRY_SERIES_COLORS[i % TELEMETRY_SERIES_COLORS.length] }} />
-                            <span className="metrics-explorer__series-attrs">
-                              {svcName ? <span className="metrics-explorer__series-service">{svcName}</span> : null}
-                              {attrs.length > 0 ? (
-                                <span className="metrics-explorer__series-dimensions">
-                                  {attrs.map(([k, v]) => (
-                                    <span key={k} className="metrics-explorer__series-attr">
-                                      {k}={String(v)}
-                                    </span>
-                                  ))}
-                                </span>
-                              ) : !svcName ? <span className="metrics-explorer__series-no-attrs">(no dimensions)</span> : null}
-                            </span>
-                            <span className="metrics-explorer__series-value">{formatNumber(s.latest)}</span>
-                            <span className="metrics-explorer__series-points">{s.points.length} pts</span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
 
-                  {/* Selected series detail */}
-                  {selectedDetail && stats ? (
-                    <div className="series-detail">
-                      <div className="series-detail__header">
-                        <div className="series-detail__title">
-                          {selectedDetail.resource?.serviceName
-                            ? selectedDetail.resource.serviceName
-                            : null}
-                          {Object.entries(selectedDetail.attributes ?? {}).length > 0
-                            ? (selectedDetail.resource?.serviceName ? " · " : "") + Object.entries(selectedDetail.attributes ?? {}).map(([k, v]) => `${k}=${v}`).join(", ")
-                            : !selectedDetail.resource?.serviceName ? "(no dimensions)" : null}
-                        </div>
-                        <button className="series-detail__close" onClick={() => setSelectedSeriesKey(null)} type="button">&times;</button>
-                      </div>
+                    {stats ? (
                       <div className="series-detail__stats">
                         <div className="stat-card">
                           <span className="stat-card__label">Latest</span>
@@ -243,18 +317,60 @@ export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabPr
                           <span className="stat-card__value">{stats.count}</span>
                         </div>
                       </div>
+                    ) : null}
+
+                    <div className="series-detail__tags">
+                      <span className="series-detail__tag series-detail__tag--type">{selectedDetail.type}</span>
+                      {selectedDetail.unit ? <span className="series-detail__tag">{selectedDetail.unit}</span> : null}
+                      {selectedDetail.temporality ? <span className="series-detail__tag">{selectedDetail.temporality}</span> : null}
+                      {selectedDetail.isMonotonic ? <span className="series-detail__tag">monotonic</span> : null}
+                    </div>
+
+                    {selectedDetail.description ? <p className="series-detail__desc">{selectedDetail.description}</p> : null}
+
+                    <div className="series-detail__section">
+                      <div className="series-detail__section-title">Dimensions</div>
                       <div className="series-detail__tags">
-                        <span className="series-detail__tag series-detail__tag--type">{selectedDetail.type}</span>
-                        {selectedDetail.unit ? <span className="series-detail__tag">{selectedDetail.unit}</span> : null}
-                        {selectedDetail.temporality ? <span className="series-detail__tag">{selectedDetail.temporality}</span> : null}
+                        {selectedAttributes.length > 0 ? (
+                          selectedAttributes.map(([key, value]) => (
+                            <span key={key} className="series-detail__dim-tag">
+                              <span className="series-detail__dim-key">{key}:</span>
+                              {String(value)}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="series-detail__tag">(no dimensions)</span>
+                        )}
                       </div>
                     </div>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
+
+                    {selectedResourceAttributes.length > 0 ? (
+                      <div className="series-detail__section">
+                        <div className="series-detail__section-title">Resource</div>
+                        <div className="series-detail__tags">
+                          {selectedResourceAttributes.map(([key, value]) => (
+                            <span key={key} className="series-detail__dim-tag">
+                              <span className="series-detail__dim-key">{key}:</span>
+                              {String(value)}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+
+                    <div className="series-detail__section">
+                      <div className="series-detail__section-title">Scope</div>
+                      <div className="series-detail__tags">
+                        <span className="series-detail__tag">{selectedDetail.scope.name}</span>
+                        {selectedDetail.scope.version ? <span className="series-detail__tag">v{selectedDetail.scope.version}</span> : null}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </DetailPanel>
+          </div>
+        ) : null}
       </div>
     </section>
   );
@@ -264,4 +380,8 @@ function formatNumber(v: number): string {
   if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
   if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
   return v % 1 === 0 ? String(v) : v.toFixed(2);
+}
+
+function stableEntries(attributes: Record<string, unknown>): Array<[string, unknown]> {
+  return Object.entries(attributes).sort(([left], [right]) => left.localeCompare(right));
 }

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -2157,6 +2157,10 @@ code {
   background: var(--app-bg);
 }
 
+.signal-view__panel--metrics {
+  width: 560px;
+}
+
 /* ======================================
    Explorer Layout (legacy, used when sidebar is needed)
    ====================================== */
@@ -3057,6 +3061,10 @@ code {
     width: 340px;
   }
 
+  .signal-view__panel--metrics {
+    width: 420px;
+  }
+
   .explorer--with-panel {
     grid-template-columns: minmax(0, 1fr) 340px;
   }
@@ -3718,6 +3726,11 @@ code {
 .series-detail {
   border-top: 2px solid var(--accent);
   background: var(--chrome);
+}
+
+.series-detail--panel {
+  border-top: 0;
+  background: transparent;
 }
 
 .series-detail__header {
@@ -4882,6 +4895,27 @@ code {
   border-color: rgba(0, 122, 204, 0.3);
   background: rgba(0, 122, 204, 0.12);
   color: var(--text);
+}
+
+.findings-tab__signal-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  margin-left: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-soft);
+}
+
+.findings-tab__signal-tab.is-active .findings-tab__signal-count {
+  background: rgba(0, 122, 204, 0.2);
+  color: var(--blue);
 }
 
 .findings-tab__detail-grid {

--- a/observer/client/src/traces/TracesTab.style.test.tsx
+++ b/observer/client/src/traces/TracesTab.style.test.tsx
@@ -57,7 +57,6 @@ describe("TracesTab row layout", () => {
           { traceId: "trace-1234567890ab", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "error" },
         ]}
         telemetryError={null}
-        onInteract={vi.fn()}
         validationFindings={[]}
         validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,
@@ -91,7 +90,6 @@ describe("TracesTab row layout", () => {
           { traceId: "trace-ok-456", rootSpanName: "GET /health", serviceName: "api-gateway", spanCount: 1, durationMs: 5, status: "ok" },
         ]}
         telemetryError={null}
-        onInteract={vi.fn()}
         validationFindings={[]}
         validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,

--- a/observer/client/src/traces/TracesTab.test.tsx
+++ b/observer/client/src/traces/TracesTab.test.tsx
@@ -29,7 +29,6 @@ describe("TracesTab", () => {
           { traceId: "trace-2", rootSpanName: "POST /charge", serviceName: "payments", spanCount: 5, durationMs: 88, status: "error" },
         ]}
         telemetryError={null}
-        onInteract={vi.fn()}
         validationFindings={[]}
         validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,
@@ -50,7 +49,6 @@ describe("TracesTab", () => {
           { traceId: "trace-missing", rootSpanName: "GET /ready", serviceName: "api", spanCount: 1, status: "ok" } as any,
         ]}
         telemetryError={null}
-        onInteract={vi.fn()}
         validationFindings={[]}
         validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
       />,

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -12,13 +12,12 @@ import { lookupSpanValidation } from "../validation/utils";
 interface TracesTabProps {
   traces: TraceSummary[];
   telemetryError: string | null;
-  onInteract?: () => void;
   validationFindings: ValidationFinding[];
   validationIndex: ValidationIndex;
 }
 
 /** Traces tab with virtualized table and waterfall detail panel. */
-export function TracesTab({ traces, telemetryError, onInteract, validationFindings, validationIndex }: TracesTabProps): React.ReactElement {
+export function TracesTab({ traces, telemetryError, validationFindings, validationIndex }: TracesTabProps): React.ReactElement {
   const [query, setQuery] = useState("");
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
   const [traceDetail, setTraceDetail] = useState<TraceDetail | null>(null);
@@ -30,10 +29,6 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
   const fetchIdRef = useRef(0);
   const traceDetailRef = useRef(traceDetail);
   traceDetailRef.current = traceDetail;
-  const handleInteract = useCallback(() => {
-    onInteract?.();
-  }, [onInteract]);
-
   const loadTraceDetail = useCallback(async (traceId: string, mode: "panel" | "background" = "panel") => {
     const fetchId = ++fetchIdRef.current;
     if (mode === "panel") {
@@ -67,11 +62,10 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
     setTraceDetail(null);
     setDetailError(null);
     setDetailLoading(false);
-    onInteract?.();
     if (traceId) {
       void loadTraceDetail(traceId, "panel");
     }
-  }, [loadTraceDetail, onInteract]);
+  }, [loadTraceDetail]);
 
   const shortcuts = useMemo(() => ({
     Escape: () => {
@@ -142,7 +136,6 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
     <section className="tab-panel" role="tabpanel">
       <div
         className={`signal-view${hasDetail ? " signal-view--with-panel" : ""}`}
-        onPointerDownCapture={handleInteract}
       >
         <div className="signal-view__content">
           {traces.length > 0 ? (


### PR DESCRIPTION
## Summary
Remove interaction-driven auto-pause, keep pause manual only, and move the full metric view into the same side-panel pattern used by traces and logs.

## What Changed
- remove auto-pause behavior triggered by trace and log interactions
- keep pause explicit and show queued updates while paused
- move the full metric view into the side panel instead of expanding inline in the list
- stop detail panels from resetting scroll on live rerenders
- keep metric series ordering stable so existing rows do not jump as values change and new rows append at the end
- update client tests for the new metrics interaction model and pause behavior

## Why
The previous behavior paused the live stream implicitly during navigation, and metrics used a different interaction model from the rest of the Explorer. This change makes pause explicit, keeps the layout consistent across tabs, and removes live-update jitter in the metrics panel.

## Verification
- `make test`
- `cd extension && npm run test:all`
- `cd extension && npm run build:vsix`
- installed the packaged VS Code extension and verified it loads
- started the built Observer under live OTLP traces, metrics, and logs
- read the DOM for Metrics, Traces, Logs, and Validation
- verified the metrics side panel, traces panel, logs panel, and manual pause behavior in the browser
Closes #46
Closes #45  