### PR TITLE
Build and publish the VSIX in CI and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: make -C observer test
 
   extension:
-    name: Extension – unit & integration tests
+    name: Extension – test & package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +63,17 @@ jobs:
       - name: Run VS Code host tests
         working-directory: extension
         run: xvfb-run -a npm run test:host
+
+      - name: Build VSIX
+        working-directory: extension
+        run: npm run build:vsix
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: observability-studio-vsix
+          path: extension/*.vsix
+          if-no-files-found: error
 
   client:
     name: Client – unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    name: GoReleaser
+    name: GoReleaser + VSIX
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +20,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: observer/client/package-lock.json
+          cache-dependency-path: |
+            observer/client/package-lock.json
+            extension/package-lock.json
 
       - name: Pin npm version
         run: |
@@ -36,9 +38,18 @@ jobs:
         timeout-minutes: 10
         run: make release-prep
 
+      - name: Build VSIX
+        timeout-minutes: 20
+        run: make build-vsix
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload VSIX to release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" extension/*.vsix --clobber

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SKILLS_SRC := skills
 
 ABS_BUILD  := $(CURDIR)/$(BUILD_DIR)
 
-.PHONY: help build build-client stage-skills bundle-weaver dev run test test-extension test-client test-all tidy fmt vet test-deterministic eval-fixture eval-llm eval-llm-full release-local release list-skills clean
+.PHONY: help build build-client build-vsix stage-skills bundle-weaver dev run test test-extension test-client test-all tidy fmt vet test-deterministic eval-fixture eval-llm eval-llm-full release-local release list-skills clean
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
@@ -38,6 +38,10 @@ bundle-weaver: ## Fetch the local Weaver validator runtime into build output
 build: stage-skills build-client bundle-weaver ## Build obstudio binary (client + skills embedded)
 	@mkdir -p $(BUILD_DIR)
 	cd $(GO_DIR) && $(GO) build $(GOFLAGS) $(LDFLAGS) -o $(ABS_BUILD)/$(BINARY) $(GO_CMD)
+
+build-vsix: ## Build the VS Code extension package (.vsix)
+	cd extension && npm ci
+	cd extension && npm run build:vsix
 
 run: build ## Build and run the collector
 	$(BUILD_DIR)/$(BINARY)


### PR DESCRIPTION
## Summary
Build the VS Code extension package in GitHub Actions and attach the `.vsix` to GitHub releases.

## What Changed
- add `make build-vsix` as the shared local and CI packaging entrypoint
- update CI so the extension job builds the VSIX after tests and uploads it as a workflow artifact
- update the release workflow so tagged releases build the VSIX before GoReleaser and then upload it as a GitHub release asset
- extend the release job's Node cache inputs to cover both the client and extension lockfiles

## Why
The repo could build the VSIX locally, but GitHub Actions did not produce it as a CI artifact or release asset. This change makes the packaged extension reproducible in automation and downloadable from both workflow runs and tagged releases.

## Verification
- `git diff --check`
- `make build-vsix`
- `cd extension && npm run test:all`
- `cd extension && npm run build:vsix`
- installed `/Users/tithumma/code/splunk/obstudio-vsix-build/extension/observability-studio-0.0.1.vsix` into VS Code successfully

Fixes #44