### PR TITLE
Add streamable HTTP MCP support

### DIFF
--- a/observer/cmd/obstudio/install.go
+++ b/observer/cmd/obstudio/install.go
@@ -124,9 +124,11 @@ func runInstall(target, sharedURL string) error {
 		if autodetectedSharedURL {
 			source = "detected shared observer URL"
 		}
-		if err := validateSharedURL(resolvedSharedURL, source); err != nil {
+		normalizedSharedURL, err := normalizeSharedURL(resolvedSharedURL, source)
+		if err != nil {
 			return err
 		}
+		resolvedSharedURL = normalizedSharedURL
 	}
 
 	home := userHome()
@@ -413,6 +415,28 @@ func validateSharedURL(raw, source string) error {
 		return fmt.Errorf("invalid %s: %s is missing a host", source, raw)
 	}
 	return nil
+}
+
+func normalizeSharedURL(raw, source string) (string, error) {
+	if err := validateSharedURL(raw, source); err != nil {
+		return "", err
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid %s: %w", source, err)
+	}
+
+	trimmedPath := strings.TrimRight(parsed.Path, "/")
+	switch {
+	case trimmedPath == "":
+		parsed.Path = "/mcp"
+	case strings.HasSuffix(trimmedPath, "/mcp"):
+		parsed.Path = trimmedPath
+	default:
+		parsed.Path = trimmedPath + "/mcp"
+	}
+	return parsed.String(), nil
 }
 
 func extractFS(src fs.FS, destDir string) error {

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -222,6 +222,37 @@ func TestValidateSharedURL(t *testing.T) {
 	}
 }
 
+func TestNormalizeSharedURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{name: "base URL", raw: "http://127.0.0.1:3000", expected: "http://127.0.0.1:3000/mcp"},
+		{name: "base URL with slash", raw: "http://127.0.0.1:3000/", expected: "http://127.0.0.1:3000/mcp"},
+		{name: "existing mcp URL", raw: "http://127.0.0.1:3000/mcp", expected: "http://127.0.0.1:3000/mcp"},
+		{name: "subpath", raw: "https://example.com/obstudio", expected: "https://example.com/obstudio/mcp"},
+		{name: "subpath mcp", raw: "https://example.com/obstudio/mcp", expected: "https://example.com/obstudio/mcp"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := normalizeSharedURL(tc.raw, "--shared-url")
+			if err != nil {
+				t.Fatalf("normalizeSharedURL(%q) returned error: %v", tc.raw, err)
+			}
+			if got != tc.expected {
+				t.Fatalf("normalizeSharedURL(%q) = %q, want %q", tc.raw, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestValidateSharedURLIncludesSourceLabel(t *testing.T) {
 	t.Parallel()
 

--- a/observer/internal/mcp/http.go
+++ b/observer/internal/mcp/http.go
@@ -16,12 +16,10 @@ import (
 	"github.com/signalfx/obstudio/observer/internal/store"
 )
 
-type httpSession struct {
-}
-
 type httpHandler struct {
 	dispatcher *Dispatcher
-	sessions   sync.Map
+	// TODO: expire abandoned sessions if we see real accumulation in long-lived use.
+	sessions sync.Map
 }
 
 // Register adds the MCP HTTP endpoints to the given ServeMux.
@@ -99,6 +97,8 @@ func (h *httpHandler) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sessionID := strings.TrimSpace(r.Header.Get("Mcp-Session-Id"))
+	// Keep direct POST compatibility for existing clients that never open an SSE
+	// stream or send a session header after initialize.
 	if req.Method != "initialize" && sessionID != "" && !h.sessionExists(sessionID) {
 		http.NotFound(w, r)
 		return
@@ -112,7 +112,7 @@ func (h *httpHandler) handle(w http.ResponseWriter, r *http.Request) {
 
 	if req.Method == "initialize" {
 		sessionID = generateSessionID()
-		h.sessions.Store(sessionID, &httpSession{})
+		h.sessions.Store(sessionID, struct{}{})
 		w.Header().Set("Mcp-Session-Id", sessionID)
 	}
 

--- a/observer/internal/mcp/http.go
+++ b/observer/internal/mcp/http.go
@@ -5,13 +5,19 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/signalfx/obstudio/observer/internal/store"
 )
+
+type httpSession struct {
+}
 
 type httpHandler struct {
 	dispatcher *Dispatcher
@@ -21,23 +27,80 @@ type httpHandler struct {
 // Register adds the MCP HTTP endpoints to the given ServeMux.
 func Register(mux *http.ServeMux, s *store.Store, params ...any) {
 	h := &httpHandler{dispatcher: NewDispatcher(s, params...)}
+	mux.HandleFunc("GET /mcp", h.handleStream)
 	mux.HandleFunc("POST /mcp", h.handle)
+	mux.HandleFunc("DELETE /mcp", h.handleDelete)
 	mux.HandleFunc("OPTIONS /mcp", h.handleOptions)
 }
 
 func (h *httpHandler) handleOptions(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Allow", "OPTIONS, POST")
+	w.Header().Set("Allow", "GET, POST, DELETE, OPTIONS")
 	setCORSHeaders(w)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *httpHandler) handle(w http.ResponseWriter, r *http.Request) {
+func (h *httpHandler) handleStream(w http.ResponseWriter, r *http.Request) {
+	if !originAllowed(r) {
+		http.Error(w, "origin not allowed", http.StatusForbidden)
+		return
+	}
+
+	sessionID := strings.TrimSpace(r.Header.Get("Mcp-Session-Id"))
+	// Streamable HTTP clients may establish the SSE stream before sending
+	// initialize, so a missing session ID is allowed here.
+	if sessionID != "" && !h.sessionExists(sessionID) {
+		http.NotFound(w, r)
+		return
+	}
+
 	setCORSHeaders(w)
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, ": connected\n\n")
+	flusher.Flush()
+
+	keepAlive := time.NewTicker(30 * time.Second)
+	defer keepAlive.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-keepAlive.C:
+			_, _ = io.WriteString(w, ": keepalive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+func (h *httpHandler) handle(w http.ResponseWriter, r *http.Request) {
+	if !originAllowed(r) {
+		http.Error(w, "origin not allowed", http.StatusForbidden)
+		return
+	}
+
+	setCORSHeaders(w)
 
 	var req jsonRPCRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(rpcError(nil, -32700, "Parse error"))
+		return
+	}
+
+	sessionID := strings.TrimSpace(r.Header.Get("Mcp-Session-Id"))
+	if req.Method != "initialize" && sessionID != "" && !h.sessionExists(sessionID) {
+		http.NotFound(w, r)
 		return
 	}
 
@@ -48,19 +111,69 @@ func (h *httpHandler) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Method == "initialize" {
-		sessionID := generateSessionID()
-		h.sessions.Store(sessionID, true)
+		sessionID = generateSessionID()
+		h.sessions.Store(sessionID, &httpSession{})
 		w.Header().Set("Mcp-Session-Id", sessionID)
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+func (h *httpHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
+	if !originAllowed(r) {
+		http.Error(w, "origin not allowed", http.StatusForbidden)
+		return
+	}
+
+	setCORSHeaders(w)
+	sessionID := strings.TrimSpace(r.Header.Get("Mcp-Session-Id"))
+	if sessionID == "" {
+		http.Error(w, "missing Mcp-Session-Id header", http.StatusBadRequest)
+		return
+	}
+	if !h.sessionExists(sessionID) {
+		http.NotFound(w, r)
+		return
+	}
+
+	h.sessions.Delete(sessionID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *httpHandler) sessionExists(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	_, ok := h.sessions.Load(sessionID)
+	return ok
 }
 
 func setCORSHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id")
 	w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+}
+
+func originAllowed(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		// Non-browser local clients like Codex and Claude do not send Origin.
+		return true
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	switch parsed.Hostname() {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 func generateSessionID() string {

--- a/observer/internal/mcp/http_test.go
+++ b/observer/internal/mcp/http_test.go
@@ -1,0 +1,227 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/signalfx/obstudio/observer/internal/store"
+)
+
+func newHTTPTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	Register(mux, store.New())
+	return httptest.NewServer(mux)
+}
+
+func TestHTTPGetStreamReturnsEventStream(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("expected text/event-stream, got %q", got)
+	}
+
+	line, err := bufio.NewReader(resp.Body).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read first SSE line: %v", err)
+	}
+	if strings.TrimSpace(line) != ": connected" {
+		t.Fatalf("expected initial SSE comment, got %q", line)
+	}
+}
+
+func TestHTTPInitializeReturnsSessionIDAndSupportsSessionRequests(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	initialize := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+		},
+	}
+	body, _ := json.Marshal(initialize)
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/mcp", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new initialize request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("initialize /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	sessionID := resp.Header.Get("Mcp-Session-Id")
+	if sessionID == "" {
+		t.Fatalf("expected Mcp-Session-Id header")
+	}
+
+	var initResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&initResp); err != nil {
+		t.Fatalf("decode initialize response: %v", err)
+	}
+	if initResp["result"] == nil {
+		t.Fatalf("expected initialize result")
+	}
+
+	toolsList := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	}
+	toolsBody, _ := json.Marshal(toolsList)
+
+	req, err = http.NewRequest(http.MethodPost, server.URL+"/mcp", bytes.NewReader(toolsBody))
+	if err != nil {
+		t.Fatalf("new tools/list request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tools/list /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var toolsResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&toolsResp); err != nil {
+		t.Fatalf("decode tools/list response: %v", err)
+	}
+
+	result, ok := toolsResp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got %T", toolsResp["result"])
+	}
+	tools, ok := result["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		t.Fatalf("expected non-empty tools array")
+	}
+}
+
+func TestHTTPDeleteTerminatesSession(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	initialize := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+		},
+	}
+	body, _ := json.Marshal(initialize)
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/mcp", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new initialize request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("initialize /mcp: %v", err)
+	}
+	sessionID := resp.Header.Get("Mcp-Session-Id")
+	resp.Body.Close()
+	if sessionID == "" {
+		t.Fatalf("expected Mcp-Session-Id header")
+	}
+
+	req, err = http.NewRequest(http.MethodDelete, server.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatalf("new delete request: %v", err)
+	}
+	req.Header.Set("Mcp-Session-Id", sessionID)
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete /mcp: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+
+	toolsList := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	}
+	toolsBody, _ := json.Marshal(toolsList)
+
+	req, err = http.NewRequest(http.MethodPost, server.URL+"/mcp", bytes.NewReader(toolsBody))
+	if err != nil {
+		t.Fatalf("new tools/list request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tools/list /mcp after delete: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 after deleting session, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPRejectsRemoteOrigins(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for remote origin, got %d", resp.StatusCode)
+	}
+}

--- a/observer/internal/mcp/http_test.go
+++ b/observer/internal/mcp/http_test.go
@@ -205,6 +205,117 @@ func TestHTTPDeleteTerminatesSession(t *testing.T) {
 	}
 }
 
+func TestHTTPAllowsPostWithoutSessionForExistingClients(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	toolsList := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+	}
+	body, _ := json.Marshal(toolsList)
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/mcp", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new tools/list request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tools/list /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var toolsResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&toolsResp); err != nil {
+		t.Fatalf("decode tools/list response: %v", err)
+	}
+	if toolsResp["result"] == nil {
+		t.Fatalf("expected tools/list result, got %#v", toolsResp)
+	}
+}
+
+func TestHTTPRejectsMalformedJSONWithRPCParseError(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/mcp", strings.NewReader("{"))
+	if err != nil {
+		t.Fatalf("new malformed request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post malformed json: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Fatalf("expected application/json, got %q", got)
+	}
+
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode parse error response: %v", err)
+	}
+
+	errPayload, ok := payload["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %#v", payload)
+	}
+	if code, ok := errPayload["code"].(float64); !ok || code != -32700 {
+		t.Fatalf("expected parse error code -32700, got %#v", errPayload["code"])
+	}
+}
+
+func TestHTTPDeleteRequiresSessionHeader(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatalf("new delete request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPLocalhostOriginIsAccepted(t *testing.T) {
+	server := newHTTPTestServer(t)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", "http://localhost:3000")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for localhost origin, got %d", resp.StatusCode)
+	}
+}
+
 func TestHTTPRejectsRemoteOrigins(t *testing.T) {
 	server := newHTTPTestServer(t)
 	defer server.Close()


### PR DESCRIPTION
## Summary
Add streamable HTTP MCP support to `obstudio` so shared HTTP MCP works with current Codex and Claude integrations.

## What Changed
- add `GET /mcp` as a real `text/event-stream` endpoint instead of falling through to the UI
- add `DELETE /mcp` session teardown support
- keep the existing `POST /mcp` JSON-RPC flow working for current clients and tests
- normalize `--shared-url` installs so base URLs like `http://127.0.0.1:3000` become `http://127.0.0.1:3000/mcp`
- add transport tests for stream setup, initialize/session reuse, session delete, parse errors, localhost origin acceptance, and remote origin rejection
- document the intentional compatibility behavior for direct `POST /mcp` clients that do not use session headers

## Why
Codex was configured to use `obstudio` as a shared HTTP MCP server, but the server only implemented POST JSON-RPC. `GET /mcp` fell through to the web UI and returned HTML instead of a streamable MCP transport, so Codex failed its MCP handshake. Shared install URLs were also brittle because the installer accepted base REST URLs without normalizing them to `/mcp`.

## Verification
- `cd observer && go test ./internal/mcp ./cmd/obstudio ./internal/integration`
- `make build`
- verified Codex against the live server with:
  - `codex exec -C /Users/tithumma/code/splunk/obstudio-mcp-http "Use the obstudio MCP server. Call observer_status and print a short summary of the current observer status."`
- verified Claude against the live server by registering:
  - `claude mcp add --transport http obstudio http://127.0.0.1:3000/mcp`
  - then running a Claude prompt that called `observer_status`
- verified the UI under live OTLP traces, metrics, and logs by reading the rendered DOM for Metrics, Traces, Logs, and Validation

