### PR TITLE
Fix validation signal tab behavior

### DIFF
--- a/observer/client/src/components/FindingsTab.test.tsx
+++ b/observer/client/src/components/FindingsTab.test.tsx
@@ -213,6 +213,122 @@ describe("FindingsTab", () => {
     expect(within(master as HTMLElement).getByText("not_stable")).toBeTruthy();
   });
 
+  it("shows per-tab counts for the currently filtered rows and keeps span rows reachable", () => {
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "metric:checkout:http.server.duration",
+            ruleId: "unit_mismatch",
+            severity: "violation",
+            message: "Unit should be s.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "otel",
+              metricName: "http.server.duration",
+            },
+          }),
+          makeFinding({
+            entityKey: "span:trace-2:span-2",
+            ruleId: "missing_http_method",
+            severity: "information",
+            message: "missing http.method",
+            signal: {
+              type: "span",
+              serviceName: "checkout",
+              traceId: "trace-2",
+              spanId: "span-2",
+              spanName: "POST /orders",
+            },
+          }),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    fireEvent.change(view.container.querySelector(".validation-panel__select") as HTMLSelectElement, {
+      target: { value: "information" },
+    });
+
+    const tablist = view.getByRole("tablist", { name: "Validation signals" });
+    const metricsTab = within(tablist).getByRole("tab", { name: /^Metrics/ });
+    const spansTab = within(tablist).getByRole("tab", { name: /^Spans/ });
+
+    expect(metricsTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("0");
+    expect(spansTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("1");
+    expect(spansTab.getAttribute("aria-selected")).toBe("true");
+    expect(view.queryByText("No metrics validation issues match the current filters.")).toBeNull();
+
+    const master = view.container.querySelector(".findings-tab__master");
+    expect(master?.classList.contains("findings-tab__master--span")).toBe(true);
+    expect(within(master as HTMLElement).getByText("POST /orders")).toBeTruthy();
+  });
+
+  it("auto-selects the first non-empty tab when results arrive before any explicit tab choice", () => {
+    const view = render(<FindingsTab issues={[]} summary={makeSummary()} />);
+
+    let tablist = view.getByRole("tablist", { name: "Validation signals" });
+    expect(within(tablist).getByRole("tab", { name: /^Metrics/ }).getAttribute("aria-selected")).toBe("true");
+    expect(view.getByText("No metrics validation issues match the current filters.")).toBeTruthy();
+
+    view.rerender(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "span:trace-2:span-2",
+            signal: {
+              type: "span",
+              serviceName: "checkout",
+              traceId: "trace-2",
+              spanId: "span-2",
+              spanName: "POST /orders",
+            },
+          }),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    tablist = view.getByRole("tablist", { name: "Validation signals" });
+    const spansTab = within(tablist).getByRole("tab", { name: /^Spans/ });
+    expect(spansTab.getAttribute("aria-selected")).toBe("true");
+    expect(within(view.container.querySelector(".findings-tab__master") as HTMLElement).getByText("POST /orders")).toBeTruthy();
+  });
+
+  it("keeps an empty validation tab selected and shows its empty state", () => {
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([
+          makeFinding({
+            entityKey: "metric:checkout:http.server.duration",
+            ruleId: "unit_mismatch",
+            severity: "violation",
+            message: "Unit should be s.",
+            signal: {
+              type: "metric",
+              serviceName: "checkout",
+              scopeName: "otel",
+              metricName: "http.server.duration",
+            },
+          }),
+        ])}
+        summary={makeSummary()}
+      />,
+    );
+
+    const tablist = view.getByRole("tablist", { name: "Validation signals" });
+    const resourcesTab = within(tablist).getByRole("tab", { name: /^Resources/ });
+
+    expect(resourcesTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("0");
+
+    fireEvent.click(resourcesTab);
+
+    expect(resourcesTab.getAttribute("aria-selected")).toBe("true");
+    expect(view.getByText("No resources validation issues match the current filters.")).toBeTruthy();
+    expect(view.container.querySelector(".findings-tab__master")).toBeNull();
+  });
+
   it("does not render generic detail titles or subtitles in any validation subtab", () => {
     const view = render(
       <FindingsTab

--- a/observer/client/src/components/FindingsTab.tsx
+++ b/observer/client/src/components/FindingsTab.tsx
@@ -51,18 +51,23 @@ const defaultFilters: ValidationFilters = {
 export function FindingsTab({ issues, summary }: ValidationTabProps): React.ReactElement {
   const [filters, setFilters] = useState<ValidationFilters>(defaultFilters);
   const [activeSignalTab, setActiveSignalTab] = useState<ValidationSignalTab>(() => firstAvailableSignal(issues));
+  const [hasExplicitSignalTabSelection, setHasExplicitSignalTabSelection] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const signalFilteredIssues = useMemo(
+    () => filterValidationIssues(issues, { ...filters, signalType: "" }),
+    [issues, filters],
+  );
   const signalIssueCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const tab of signalTabs) {
-      counts[tab.key] = issues.filter((issue) => normalizeSignalType(issue.signalType) === tab.key).length;
+      counts[tab.key] = signalFilteredIssues.filter((issue) => normalizeSignalType(issue.signalType) === tab.key).length;
     }
     return counts;
-  }, [issues]);
-  const availableSignalTabs = useMemo(
-    () => signalTabs.filter((tab) => signalIssueCounts[tab.key] > 0),
+  }, [signalFilteredIssues]);
+  const firstAvailableFilteredSignal = useMemo(
+    () => signalTabs.find((tab) => signalIssueCounts[tab.key] > 0)?.key ?? "metric",
     [signalIssueCounts],
   );
   const activeSignalDefinition = signalTabs.find((tab) => tab.key === activeSignalTab) ?? signalTabs[0];
@@ -80,13 +85,10 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
   const actionLabel = hasResult ? "Re-run Validation" : "Run Validation";
 
   useEffect(() => {
-    if (availableSignalTabs.length === 0) {
-      return;
+    if (!hasExplicitSignalTabSelection && activeSignalTab !== firstAvailableFilteredSignal) {
+      setActiveSignalTab(firstAvailableFilteredSignal);
     }
-    if (!availableSignalTabs.some((tab) => tab.key === activeSignalTab)) {
-      setActiveSignalTab(availableSignalTabs[0]?.key ?? "metric");
-    }
-  }, [activeSignalTab, availableSignalTabs]);
+  }, [activeSignalTab, firstAvailableFilteredSignal, hasExplicitSignalTabSelection]);
 
   useEffect(() => {
     if (filteredIssues.length === 0) {
@@ -178,10 +180,13 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
                 className={tab.key === activeSignalTab ? "findings-tab__signal-tab is-active" : "findings-tab__signal-tab"}
                 aria-selected={tab.key === activeSignalTab}
                 data-has-issues={count > 0 ? "true" : "false"}
-                onClick={() => setActiveSignalTab(tab.key)}
+                onClick={() => {
+                  setHasExplicitSignalTabSelection(true);
+                  setActiveSignalTab(tab.key);
+                }}
               >
                 {tab.label}
-                {count > 0 ? <span className="findings-tab__signal-count">{count}</span> : null}
+                <span className="findings-tab__signal-count">{count}</span>
               </button>
             );
           })}


### PR DESCRIPTION
## Summary
Fix Validation sub-tab behavior so counts respect active filters, zero-count tabs still show `0`, empty tabs stay selected when clicked, and fresh validation results still auto-select the first non-empty signal before the user makes an explicit tab choice.

## Verification
- `cd observer/client && npm test -- --run src/components/FindingsTab.test.tsx src/AppView.test.tsx`
- `make build`
- built and installed the VSIX
- ran the installed Observer bundle under live OTLP load
- read the DOM for Metrics, Traces, Logs, and Validation from the installed package