### PR TITLE
Fix Claude Code MCP config install path

### DIFF
--- a/extension/src/test/extension-vscode.test.ts
+++ b/extension/src/test/extension-vscode.test.ts
@@ -361,10 +361,10 @@ suite('VS Code Host', () => {
 		const originalHome = process.env.HOME;
 		const originalUserProfile = process.env.USERPROFILE;
 		const codexConfigPath = path.join(tempHome, '.codex', 'config.toml');
-		const claudeConfigPath = path.join(tempHome, '.claude', 'settings.json');
+		const claudeConfigPath = path.join(tempHome, '.claude.json');
 		const cursorConfigPath = path.join(tempHome, '.cursor', 'mcp.json');
 		const originalCodexConfigPath = originalHome ? path.join(originalHome, '.codex', 'config.toml') : '';
-		const originalClaudeConfigPath = originalHome ? path.join(originalHome, '.claude', 'settings.json') : '';
+		const originalClaudeConfigPath = originalHome ? path.join(originalHome, '.claude.json') : '';
 		const originalCursorConfigPath = originalHome ? path.join(originalHome, '.cursor', 'mcp.json') : '';
 		const originalSnapshots = [
 			snapshotFile(originalCodexConfigPath),

--- a/observer/cmd/obstudio/install.go
+++ b/observer/cmd/obstudio/install.go
@@ -66,7 +66,7 @@ var targets = map[string]agentTarget{
 		skillsDir: func(home string) string { return filepath.Join(home, ".claude", "skills", "obstudio") },
 		mcpConfig: mcpConfigTarget{
 			format: mcpConfigJSON,
-			path:   func() string { return filepath.Join(userHome(), ".claude", "settings.json") },
+			path:   func() string { return filepath.Join(userHome(), ".claude.json") },
 		},
 	},
 	"codex": {

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func TestClaudeCodeTargetUsesSettingsJSON(t *testing.T) {
+func TestClaudeCodeTargetUsesClaudeJSON(t *testing.T) {
 	t.Parallel()
 
 	target, ok := targets["claude-code"]
@@ -20,8 +20,8 @@ func TestClaudeCodeTargetUsesSettingsJSON(t *testing.T) {
 	}
 
 	path := target.mcpConfig.path()
-	if !strings.HasSuffix(path, filepath.Join(".claude", "settings.json")) {
-		t.Fatalf("expected Claude Code MCP config path to end with .claude/settings.json, got %q", path)
+	if !strings.HasSuffix(path, ".claude.json") {
+		t.Fatalf("expected Claude Code MCP config path to end with .claude.json, got %q", path)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix Claude Code MCP installation to write the shared `obstudio` server config to Claude’s active user config file.

## What Changed
- write Claude Code MCP config to `~/.claude.json` instead of `~/.claude/settings.json`
- update installer tests for the Claude config path
- update the VS Code host test to check the new Claude MCP config location

## Why
Claude’s CLI reads MCP user registrations from `~/.claude.json`. Writing `obstudio` only into `~/.claude/settings.json` left the server invisible to `claude mcp list` and broke the expected install flow.

## Verification
- `make test`
- `cd extension && npm ci && npm run test:unit && npm run test:integration`
- built `./build/obstudio`
- removed the local Claude `obstudio` registration and reinstalled via:
  - `./build/obstudio install --target=claude-code --shared-url=http://127.0.0.1:3400`
- verified `claude mcp list` showed `obstudio` as connected
- verified a Claude prompt could call `observer_status`
- verified an explicit validation refresh prompt updated the shared validation state and the browser Validation tab reflected the completed run