### PR TITLE
Eliminate non-existent http.server.request.count/error metrics

### DIFF
--- a/evals/golden/go/chi-basic/inventory.md
+++ b/evals/golden/go/chi-basic/inventory.md
@@ -45,7 +45,7 @@
 - auto_instrumentation_packages:
   - "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 - oob_span_count: 1
-- oob_metric_count: 3
+- oob_metric_count: 1
 - derived_metric_count: 1
 - custom_metric_count: 4
 - sli_count: >= 8

--- a/evals/golden/go/chi-basic/inventory.md
+++ b/evals/golden/go/chi-basic/inventory.md
@@ -26,8 +26,6 @@
 | Signal Name | Type | Category | Component | SLIs | Unit | Status | Verified |
 |-------------|------|----------|-----------|------|------|--------|----------|
 | `http.server.request.duration` | Histogram | Derived | HTTP Server | HTTP request latency | s | | |
-| `http.server.request.count` | Counter | OOB | HTTP Server | HTTP request throughput | {requests} | | |
-| `http.server.error.count` | Counter | OOB | HTTP Server | HTTP error rate | {errors} | | |
 | `http.server.active_requests` | UpDownCounter | OOB | HTTP Server | HTTP server saturation | {requests} | | |
 | `tasks.created.count` | Counter | Custom | Business Logic | Task creation rate | {tasks} | | |
 | `tasks.completed.count` | Counter | Custom | Business Logic | Task completion rate | {tasks} | | |

--- a/evals/golden/go/kvstore/inventory.md
+++ b/evals/golden/go/kvstore/inventory.md
@@ -32,8 +32,6 @@
 | Signal Name | Type | Category | Component | SLIs | Unit | Status | Verified |
 |-------------|------|----------|-----------|------|------|--------|----------|
 | `http.server.request.duration` | Histogram | Derived | HTTP Server | HTTP request latency | s | | |
-| `http.server.request.count` | Counter | OOB | HTTP Server | HTTP request throughput | {requests} | | |
-| `http.server.error.count` | Counter | OOB | HTTP Server | HTTP error rate | {errors} | | |
 | `kvstore.get.duration` | Histogram | Custom | KV Store | KV get latency | ms | | |
 | `kvstore.set.count` | Counter | Custom | KV Store | KV set throughput | {operations} | | |
 | `kvstore.delete.count` | Counter | Custom | KV Store | KV delete throughput | {operations} | | |

--- a/evals/golden/go/kvstore/inventory.md
+++ b/evals/golden/go/kvstore/inventory.md
@@ -55,7 +55,7 @@
 - auto_instrumentation_packages:
   - "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 - oob_span_count: 1
-- oob_metric_count: 2
+- oob_metric_count: 0
 - derived_metric_count: 1
 - custom_metric_count: 7
 - custom_span_count: 4

--- a/evals/golden/node/express-basic/inventory.md
+++ b/evals/golden/node/express-basic/inventory.md
@@ -46,7 +46,7 @@
   - "@opentelemetry/instrumentation-express"
   - "@opentelemetry/instrumentation-http"
 - oob_span_count: 1
-- oob_metric_count: 3
+- oob_metric_count: 1
 - derived_metric_count: 1
 - custom_metric_count: 4
 - sli_count: >= 8

--- a/evals/golden/node/express-basic/inventory.md
+++ b/evals/golden/node/express-basic/inventory.md
@@ -26,8 +26,6 @@
 | Signal Name | Type | Category | Component | SLIs | Unit | Status | Verified |
 |-------------|------|----------|-----------|------|------|--------|----------|
 | `http.server.request.duration` | Histogram | Derived | HTTP Server | HTTP request latency | s | | |
-| `http.server.request.count` | Counter | OOB | HTTP Server | HTTP request throughput | {requests} | | |
-| `http.server.error.count` | Counter | OOB | HTTP Server | HTTP error rate | {errors} | | |
 | `http.server.active_requests` | UpDownCounter | OOB | HTTP Server | HTTP server saturation | {requests} | | |
 | `tasks.created.count` | Counter | Custom | Business Logic | Task creation rate | {tasks} | | |
 | `tasks.completed.count` | Counter | Custom | Business Logic | Task completion rate | {tasks} | | |

--- a/evals/golden/python/flask-basic/inventory.md
+++ b/evals/golden/python/flask-basic/inventory.md
@@ -45,7 +45,7 @@
 - auto_instrumentation_packages:
   - opentelemetry-instrumentation-flask
 - oob_span_count: 1
-- oob_metric_count: 3
+- oob_metric_count: 1
 - derived_metric_count: 1
 - custom_metric_count: 4
 - sli_count: >= 8

--- a/evals/golden/python/flask-basic/inventory.md
+++ b/evals/golden/python/flask-basic/inventory.md
@@ -26,8 +26,6 @@
 | Signal Name | Type | Category | Component | SLIs | Unit | Status | Verified |
 |-------------|------|----------|-----------|------|------|--------|----------|
 | `http.server.request.duration` | Histogram | Derived | HTTP Server | HTTP request latency | s | | |
-| `http.server.request.count` | Counter | OOB | HTTP Server | HTTP request throughput | {requests} | | |
-| `http.server.error.count` | Counter | OOB | HTTP Server | HTTP error rate | {errors} | | |
 | `http.server.active_requests` | UpDownCounter | OOB | HTTP Server | HTTP server saturation | {requests} | | |
 | `tasks.created.count` | Counter | Custom | Business Logic | Task creation rate | {tasks} | | |
 | `tasks.completed.count` | Counter | Custom | Business Logic | Task completion rate | {tasks} | | |

--- a/skills/references/signal-mapping-guide.md
+++ b/skills/references/signal-mapping-guide.md
@@ -84,7 +84,7 @@ double-counting and reduces instrumentation effort.
 
 ### Naming conventions
 
-- Use dots as separators: `http.server.request.count`
+- Use dots as separators: `http.server.request.duration`
 - Include units in the metric name or unit field: `duration` (seconds), `size` (bytes), `count`
 - Standard suffixes: `.count`, `.duration`, `.total`, `.size`
 - Prefix with component: `http.`, `db.`, `broker.`, `cache.`


### PR DESCRIPTION
We had references to http.server.request.count and http.server.error.count referenced from a few places.

This resulted in this metric being created by the skill in the instrumented code.

There is no such Otel metric, it should not be created. Deleting.