### PR TITLE
Improve logs explorer side-panel UX

### DIFF
--- a/observer/client/src/logs/LogsTab.test.tsx
+++ b/observer/client/src/logs/LogsTab.test.tsx
@@ -94,11 +94,20 @@ describe("LogsTab", () => {
         logs={[
           {
             id: "1",
-            timeUnixNano: "1712700000000000000",
-            severityText: "INFO",
+            timeUnixNano: "2024-04-09T22:00:00.000000019Z",
+            severityNumber: 10,
+            severityText: "Informational",
             body: "checkout started",
-            attributes: {},
-            resource: { serviceName: "checkout", attributes: {} },
+            attributes: {
+              "demo.case": "checkout started",
+            },
+            resource: {
+              serviceName: "checkout",
+              attributes: {
+                "service.name": "checkout",
+                "deployment.environment": "prod",
+              },
+            },
             scope: { name: "otel" },
             traceId: "trace-1",
             spanId: "span-1",
@@ -109,10 +118,23 @@ describe("LogsTab", () => {
 
     fireEvent.click(container.querySelector(".data-table__row--logs") as HTMLElement);
 
+    expect(screen.getByRole("heading", { name: "Summary" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Message" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Attributes" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Resource Attributes" })).toBeTruthy();
+    expect(screen.getByText("2024-04-09T22:00:00.000000019Z")).toBeTruthy();
+    expect(screen.getAllByText("INFO2 (Informational)")).toHaveLength(2);
+    expect(screen.getByText("Severity Number")).toBeTruthy();
+    expect(screen.getByText("Severity Text")).toBeTruthy();
+    expect(screen.getByText("demo.case")).toBeTruthy();
+    expect(screen.queryByText("service.name")).toBeNull();
+    expect(screen.getByText("deployment.environment")).toBeTruthy();
     expect(screen.queryByText("Validation")).toBeNull();
     expect(screen.getByRole("button", { name: "Close panel" })).toBeTruthy();
     expect(screen.getAllByRole("combobox", { name: "Filter logs by severity" }).length).toBeGreaterThan(0);
+
+    const headings = Array.from(container.querySelectorAll(".log-detail__heading")).map((node) => node.textContent);
+    expect(headings).toEqual(["Summary", "Message", "Trace Correlation", "Attributes", "Resource Attributes", "Scope"]);
   });
 
   it("falls back to severityNumber when severityText is missing", () => {

--- a/observer/client/src/logs/LogsTab.tsx
+++ b/observer/client/src/logs/LogsTab.tsx
@@ -266,6 +266,28 @@ export function LogsTab({ logs }: LogsTabProps): React.ReactElement {
               {detailTab === "overview" ? (
                 <div className="log-detail">
                   <div className="log-detail__section">
+                    <h4 className="log-detail__heading">Summary</h4>
+                    <div className="span-details__detail-row">
+                      <span className="span-details__detail-label">Timestamp</span>
+                      <span className="span-details__detail-value" style={{ fontFamily: '"Cascadia Code", monospace', fontSize: "11px" }}>
+                        {selectedLog.timeUnixNano || "--"}
+                      </span>
+                    </div>
+                    {selectedLog.severityNumber !== undefined ? (
+                      <div className="span-details__detail-row">
+                        <span className="span-details__detail-label">Severity Number</span>
+                        <span className="span-details__detail-value">{selectedLog.severityNumber}</span>
+                      </div>
+                    ) : null}
+                    {selectedLog.severityText ? (
+                      <div className="span-details__detail-row">
+                        <span className="span-details__detail-label">Severity Text</span>
+                        <span className="span-details__detail-value">{selectedLog.severityText}</span>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="log-detail__section">
                     <h4 className="log-detail__heading">Message</h4>
                     <pre className="log-detail__body">{selectedLog.body}</pre>
                   </div>
@@ -290,19 +312,37 @@ export function LogsTab({ logs }: LogsTabProps): React.ReactElement {
                     </div>
                   ) : null}
 
-                  {selectedLog.resource ? (
+                  {Object.keys(selectedLog.attributes ?? {}).length > 0 ? (
                     <div className="log-detail__section">
-                      <h4 className="log-detail__heading">Resource</h4>
-                      {selectedLog.resource.serviceName ? (
-                        <div className="span-details__detail-row">
-                          <span className="span-details__detail-label">Service</span>
-                          <span className="span-details__detail-value">{selectedLog.resource.serviceName}</span>
-                        </div>
-                      ) : null}
-                      {Object.keys(selectedLog.resource?.attributes ?? {}).length > 0 ? (
+                      <h4 className="log-detail__heading">Attributes</h4>
                         <table className="log-detail__attrs">
                           <tbody>
-                            {Object.entries(selectedLog.resource?.attributes ?? {}).map(([k, v]) => (
+                            {Object.entries(selectedLog.attributes ?? {}).map(([k, v]) => (
+                              <tr key={k}>
+                                <td className="log-detail__attr-key">{k}</td>
+                                <td className="log-detail__attr-val">{String(v)}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                    </div>
+                  ) : null}
+
+                  {hasLogResourceDetails(selectedLog) ? (
+                    <div className="log-detail__section">
+                      <h4 className="log-detail__heading">Resource Attributes</h4>
+                      {selectedLog.resource.schemaUrl ? (
+                        <div className="span-details__detail-row">
+                          <span className="span-details__detail-label">Schema URL</span>
+                          <span className="span-details__detail-value" style={{ fontFamily: '"Cascadia Code", monospace', fontSize: "11px" }}>
+                            {selectedLog.resource.schemaUrl}
+                          </span>
+                        </div>
+                      ) : null}
+                      {Object.keys(resourceDetailAttributes(selectedLog)).length > 0 ? (
+                        <table className="log-detail__attrs">
+                          <tbody>
+                            {Object.entries(resourceDetailAttributes(selectedLog)).map(([k, v]) => (
                               <tr key={k}>
                                 <td className="log-detail__attr-key">{k}</td>
                                 <td className="log-detail__attr-val">{String(v)}</td>
@@ -326,24 +366,6 @@ export function LogsTab({ logs }: LogsTabProps): React.ReactElement {
                       </div>
                     </div>
                   ) : null}
-
-                  <div className="log-detail__section">
-                    <h4 className="log-detail__heading">Attributes</h4>
-                    {Object.keys(selectedLog.attributes ?? {}).length > 0 ? (
-                      <table className="log-detail__attrs">
-                        <tbody>
-                          {Object.entries(selectedLog.attributes ?? {}).map(([k, v]) => (
-                            <tr key={k}>
-                              <td className="log-detail__attr-key">{k}</td>
-                              <td className="log-detail__attr-val">{String(v)}</td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    ) : (
-                      <p className="log-detail__empty">No attributes</p>
-                    )}
-                  </div>
                 </div>
               ) : (
                 <div className="log-detail">
@@ -365,4 +387,16 @@ function formatTimestamp(ts: string): string {
   const d = new Date(ts);
   if (isNaN(d.getTime())) return "--";
   return d.toISOString().slice(11, 23);
+}
+
+function resourceDetailAttributes(record: LogRecord): Record<string, unknown> {
+  const attributes = { ...(record.resource?.attributes ?? {}) };
+  if (attributes["service.name"] === record.resource?.serviceName) {
+    delete attributes["service.name"];
+  }
+  return attributes;
+}
+
+function hasLogResourceDetails(record: LogRecord): boolean {
+  return Boolean(record.resource?.schemaUrl) || Object.keys(resourceDetailAttributes(record)).length > 0;
 }


### PR DESCRIPTION
## Summary
- align the logs explorer severity display with the OpenTelemetry logs data model
- improve the logs side-panel information hierarchy
- remove duplicated log metadata from the detail view

## Changes
- show exact normalized short names from `SeverityNumber`, such as `TRACE3`, `INFO2`, and `ERROR3`
- show both severity fields when both are present, for example `TRACE3 (ERROR)` and `ERROR (SEVERE)`
- use normalized severity for filtering when `SeverityNumber` is present, and fall back to `SeverityText` only when the number is absent
- add a metadata-first `Summary` section in the log detail panel
- keep `Message` separate from summary metadata
- expose `Severity Number` and `Severity Text` explicitly in the detail panel
- move log `Attributes` ahead of `Resource Attributes` and `Scope`
- rename `Resource` to `Resource Attributes`
- dedupe `service.name` from resource attributes when it matches the panel subtitle
- hide empty attribute sections instead of rendering placeholders

## Verification
- `npm test -- src/logs/LogsTab.test.tsx`
- `npm run typecheck`
-  manual testing
