### PR TITLE
Filters for traces, metrics, and logs

### DIFF
--- a/observer/client/src/FilterBar.tsx
+++ b/observer/client/src/FilterBar.tsx
@@ -1,0 +1,453 @@
+import React, { useEffect, useId, useMemo, useState } from "react";
+
+export type FilterFieldKind = "text" | "number" | "enum" | "datetime";
+
+export interface FilterDefinition {
+  key: string;
+  label?: string;
+  kind: FilterFieldKind;
+  chipLabel?: string;
+  operatorLabels?: OperatorLabels;
+  options?: Array<{ label: string; value: string }>;
+  supportsNot?: boolean;
+  step?: number;
+}
+
+export interface FilterClause {
+  key: string;
+  op: "eq" | "neq";
+  value: string;
+}
+
+interface FilterBarProps {
+  definitions: FilterDefinition[];
+  clauses: FilterClause[];
+  onChange: (nextClauses: FilterClause[]) => void;
+  fieldPlaceholder?: string;
+  onSuggestValues?: (fieldKey: string, prefix: string, signal: AbortSignal) => Promise<string[]>;
+}
+
+interface OperatorLabels {
+  eq: string;
+  neq: string;
+}
+
+const DEFAULT_OPERATOR_LABELS: OperatorLabels = { eq: "=", neq: "!=" };
+
+function resolveOperatorLabels(definition: FilterDefinition): OperatorLabels {
+  return definition.operatorLabels ?? DEFAULT_OPERATOR_LABELS;
+}
+
+function normalizeClauseValue(definition: FilterDefinition, value: string): string {
+  if (definition.kind === "datetime") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  return value.trim();
+}
+
+function nextDraftValue(definition: FilterDefinition, rawValue: string, currentValue: string): string {
+  if (definition.kind !== "number") {
+    return rawValue;
+  }
+  if (rawValue === "") {
+    return "";
+  }
+  const parsed = Number(rawValue);
+  if (!Number.isNaN(parsed) && parsed < 0) {
+    return currentValue;
+  }
+  if (!Number.isNaN(parsed) && definition.step === 1 && !Number.isInteger(parsed)) {
+    return currentValue;
+  }
+  return rawValue;
+}
+
+function chipText(definition: FilterDefinition | undefined, clause: FilterClause): string {
+  const base = definition?.chipLabel ?? definition?.label ?? definition?.key ?? "filter";
+  const labels = definition ? resolveOperatorLabels(definition) : DEFAULT_OPERATOR_LABELS;
+  const op = clause.op === "neq" ? labels.neq : labels.eq;
+  return `${base} ${op} ${clause.value}`;
+}
+
+function valuePlaceholder(definition: FilterDefinition): string {
+  const label = definition.label ?? definition.chipLabel ?? definition.key;
+  if (definition.kind === "datetime") {
+    return `Select ${label}`;
+  }
+  if (definition.kind === "enum") {
+    return `Select ${label}`;
+  }
+  return `Enter ${label}`;
+}
+
+function findExactDefinition(definitions: FilterDefinition[], query: string): FilterDefinition | null {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (normalizedQuery === "") {
+    return null;
+  }
+  return definitions.find((definition) => {
+    const label = definition.label?.toLowerCase() ?? "";
+    return definition.key.toLowerCase() === normalizedQuery || label === normalizedQuery;
+  }) ?? null;
+}
+
+/** Lightweight explicit-filter builder with inline field suggestions and eq/neq operators. */
+export function FilterBar({ definitions, clauses, onChange, fieldPlaceholder, onSuggestValues }: FilterBarProps): React.ReactElement {
+  const [draftQuery, setDraftQuery] = useState("");
+  const [draftKey, setDraftKey] = useState("");
+  const [draftValue, setDraftValue] = useState("");
+  const [draftOp, setDraftOp] = useState<FilterClause["op"] | null>(null);
+  const [fieldFocused, setFieldFocused] = useState(false);
+  const [valueFocused, setValueFocused] = useState(false);
+  const [valueSuggestions, setValueSuggestions] = useState<string[]>([]);
+  const inputId = useId();
+
+  const selectedDefinition = definitions.find((definition) => definition.key === draftKey) ?? null;
+  const canAdd = selectedDefinition !== null && draftOp !== null && draftValue.trim() !== "";
+  const filteredDefinitions = useMemo(() => {
+    if (selectedDefinition) {
+      return [];
+    }
+    const query = draftQuery.trim().toLowerCase();
+    if (query === "") {
+      return definitions;
+    }
+    return definitions
+      .filter((definition) => {
+        const label = definition.label?.toLowerCase() ?? "";
+        return definition.key.toLowerCase().includes(query) || label.includes(query);
+      })
+      .sort((left, right) => {
+        const leftStarts = left.key.toLowerCase().startsWith(query) || (left.label?.toLowerCase().startsWith(query) ?? false);
+        const rightStarts = right.key.toLowerCase().startsWith(query) || (right.label?.toLowerCase().startsWith(query) ?? false);
+        if (leftStarts !== rightStarts) {
+          return leftStarts ? -1 : 1;
+        }
+        return (left.label ?? left.key).localeCompare(right.label ?? right.key);
+      });
+  }, [definitions, draftQuery, selectedDefinition]);
+
+  useEffect(() => {
+    if (!selectedDefinition || selectedDefinition.kind !== "text" || !onSuggestValues || !valueFocused) {
+      setValueSuggestions([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    onSuggestValues(selectedDefinition.key, draftValue, controller.signal)
+      .then((values) => {
+        if (!controller.signal.aborted) {
+          setValueSuggestions(values);
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setValueSuggestions([]);
+        }
+      });
+
+    return () => controller.abort();
+  }, [draftValue, onSuggestValues, selectedDefinition, valueFocused]);
+
+  function resetDraft(): void {
+    setDraftQuery("");
+    setDraftKey("");
+    setDraftValue("");
+    setDraftOp(null);
+    setValueFocused(false);
+    setValueSuggestions([]);
+  }
+
+  function selectDefinition(definition: FilterDefinition): void {
+    setDraftKey(definition.key);
+    setDraftQuery(definition.key);
+    setDraftValue("");
+    setDraftOp("eq");
+    setFieldFocused(false);
+  }
+
+  function commitFieldSelection(): void {
+    if (selectedDefinition) {
+      return;
+    }
+    const exactDefinition = findExactDefinition(definitions, draftQuery);
+    const nextDefinition = exactDefinition ?? filteredDefinitions[0] ?? null;
+    if (!nextDefinition) {
+      return;
+    }
+    selectDefinition(nextDefinition);
+  }
+
+  function addClause(): void {
+    if (!selectedDefinition) {
+      return;
+    }
+    if (!draftOp) {
+      return;
+    }
+    const normalizedValue = normalizeClauseValue(selectedDefinition, draftValue);
+    if (normalizedValue === "") {
+      return;
+    }
+    const nextClause: FilterClause = { key: selectedDefinition.key, op: draftOp, value: normalizedValue };
+    onChange([...clauses.filter((clause) => clause.key !== nextClause.key), nextClause]);
+    resetDraft();
+  }
+
+  function removeClause(key: string): void {
+    onChange(clauses.filter((clause) => clause.key !== key));
+  }
+
+  function renderValueInput(): React.ReactNode {
+    if (!selectedDefinition) {
+      return (
+        <div className="filter-builder__composer">
+          <input
+            id={inputId}
+            className="explorer__input filter-builder__field"
+            value={draftQuery}
+            onChange={(event) => {
+              const nextQuery = event.target.value;
+              setDraftQuery(nextQuery);
+              const exactDefinition = findExactDefinition(definitions, nextQuery);
+              if (exactDefinition) {
+                selectDefinition(exactDefinition);
+                return;
+              }
+              setDraftKey("");
+            }}
+            onFocus={() => setFieldFocused(true)}
+            onBlur={() => {
+              window.setTimeout(() => setFieldFocused(false), 100);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === "Tab") {
+                if (filteredDefinitions.length > 0 || findExactDefinition(definitions, draftQuery)) {
+                  event.preventDefault();
+                  commitFieldSelection();
+                }
+              }
+              if (event.key === "Escape") {
+                setFieldFocused(false);
+              }
+            }}
+            placeholder={fieldPlaceholder ?? "Add filter"}
+            aria-label="Filter field"
+          />
+        </div>
+      );
+    }
+
+    if (selectedDefinition.kind === "enum") {
+      const labels = resolveOperatorLabels(selectedDefinition);
+      return (
+        <div className="filter-builder__composer filter-builder__composer--selected">
+          <span className="filter-builder__token">{selectedDefinition.label ?? selectedDefinition.key}</span>
+          <div className="filter-builder__operators" aria-label="Filter operator">
+            <button
+              className={`filter-builder__operator ${draftOp === "eq" ? "filter-builder__operator--active" : ""}`}
+              onClick={() => setDraftOp("eq")}
+              type="button"
+              aria-label={labels.eq}
+            >
+              {labels.eq}
+            </button>
+            {selectedDefinition.supportsNot !== false ? (
+              <button
+                className={`filter-builder__operator ${draftOp === "neq" ? "filter-builder__operator--active" : ""}`}
+                onClick={() => setDraftOp("neq")}
+                type="button"
+                aria-label={labels.neq}
+              >
+                {labels.neq}
+              </button>
+            ) : null}
+          </div>
+          <select
+            className="explorer__select filter-builder__value"
+            value={draftValue}
+            onChange={(event) => setDraftValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                addClause();
+              }
+              if (event.key === "Backspace" && draftValue === "") {
+                resetDraft();
+              }
+            }}
+            aria-label={`${selectedDefinition.key} value`}
+          >
+            <option value="">Select value</option>
+            {selectedDefinition.options?.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <button
+            className="filter-builder__clear"
+            onClick={resetDraft}
+            type="button"
+            aria-label="Reset filter draft"
+          >
+            ×
+          </button>
+          <button
+            className="filter-builder__apply"
+            onClick={addClause}
+            type="button"
+            disabled={!canAdd}
+            aria-label="Apply filter"
+          >
+            Apply
+          </button>
+        </div>
+      );
+    }
+
+    const labels = resolveOperatorLabels(selectedDefinition);
+    return (
+      <div className="filter-builder__composer filter-builder__composer--selected">
+          <span className="filter-builder__token">{selectedDefinition.label ?? selectedDefinition.key}</span>
+        <div className="filter-builder__operators" aria-label="Filter operator">
+          <button
+            className={`filter-builder__operator ${draftOp === "eq" ? "filter-builder__operator--active" : ""}`}
+            onClick={() => setDraftOp("eq")}
+            type="button"
+            aria-label={labels.eq}
+          >
+            {labels.eq}
+          </button>
+          {selectedDefinition.supportsNot !== false ? (
+            <button
+              className={`filter-builder__operator ${draftOp === "neq" ? "filter-builder__operator--active" : ""}`}
+              onClick={() => setDraftOp("neq")}
+              type="button"
+              aria-label={labels.neq}
+            >
+              {labels.neq}
+            </button>
+          ) : null}
+        </div>
+        <input
+          className="explorer__input filter-builder__value"
+          type={selectedDefinition.kind === "number" ? "number" : selectedDefinition.kind === "datetime" ? "datetime-local" : "text"}
+          value={draftValue}
+          min={selectedDefinition.kind === "number" ? 0 : undefined}
+          step={selectedDefinition.kind === "number" ? selectedDefinition.step ?? "any" : undefined}
+          onChange={(event) => setDraftValue(nextDraftValue(selectedDefinition, event.target.value, draftValue))}
+          onFocus={() => setValueFocused(true)}
+          onBlur={() => {
+            window.setTimeout(() => setValueFocused(false), 100);
+          }}
+          onKeyDown={(event) => {
+            if (selectedDefinition.kind === "number" && (event.key === "-" || (selectedDefinition.step === 1 && event.key === "."))) {
+              event.preventDefault();
+              return;
+            }
+            if (event.key === "Enter") {
+              event.preventDefault();
+              addClause();
+            }
+            if (event.key === "Backspace" && draftValue === "") {
+              resetDraft();
+            }
+          }}
+          placeholder={valuePlaceholder(selectedDefinition)}
+          aria-label={`${selectedDefinition.key} value`}
+        />
+        <button
+          className="filter-builder__clear"
+          onClick={resetDraft}
+          type="button"
+          aria-label="Reset filter draft"
+        >
+          ×
+        </button>
+        <button
+          className="filter-builder__apply"
+          onClick={addClause}
+          type="button"
+          disabled={!canAdd}
+          aria-label="Apply filter"
+        >
+          Apply
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="filter-builder">
+      <div className="filter-builder__controls">
+        {renderValueInput()}
+      </div>
+
+      {!selectedDefinition && fieldFocused && filteredDefinitions.length > 0 ? (
+        <div className="filter-builder__menu" role="listbox" aria-labelledby={inputId}>
+          <div className="filter-builder__menu-section">Indexed Tags</div>
+          {filteredDefinitions.slice(0, 10).map((definition) => (
+            <button
+              key={definition.key}
+              className="filter-builder__menu-item"
+              onMouseDown={(event) => {
+                event.preventDefault();
+                selectDefinition(definition);
+              }}
+              type="button"
+            >
+              <span className="filter-builder__menu-key">{definition.label ?? definition.key}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {selectedDefinition && valueFocused && valueSuggestions.length > 0 ? (
+        <div className="filter-builder__menu" role="listbox" aria-label={`${selectedDefinition.key} suggestions`}>
+          <div className="filter-builder__menu-section">Suggested Values</div>
+          {valueSuggestions.slice(0, 10).map((value) => (
+            <button
+              key={value}
+              className="filter-builder__menu-item"
+              onMouseDown={(event) => {
+                event.preventDefault();
+                setDraftValue(value);
+                setValueFocused(false);
+              }}
+              type="button"
+            >
+              <span className="filter-builder__menu-key">{value}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {clauses.length > 0 ? (
+        <div className="filter-builder__chips" aria-label="Active filters">
+          {clauses.map((clause) => {
+            const definition = definitions.find((candidate) => candidate.key === clause.key);
+            return (
+              <button
+                key={clause.key}
+                className="filter-builder__chip"
+                onClick={() => removeClause(clause.key)}
+                type="button"
+                aria-label={`Remove filter ${clause.key}`}
+                title="Remove filter"
+              >
+                <span>{chipText(definition, clause)}</span>
+                <span className="filter-builder__chip-remove" aria-hidden="true">
+                  ×
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/observer/client/src/api/client.ts
+++ b/observer/client/src/api/client.ts
@@ -1,16 +1,152 @@
-import type { TraceDetail } from "./types";
+import type { LogRecord, MetricGroup, TraceDetail, TraceSummary } from "./types";
 
 const BASE = "";
+type QueryScalar = string | number;
 
-async function fetchJSON<T>(path: string): Promise<T> {
-  const response = await fetch(`${BASE}${path}`);
+async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${BASE}${path}`, init);
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);
   }
   return response.json() as Promise<T>;
 }
 
+function normalizeArrayResponse<T>(value: T[] | null): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+export interface RangeQueryValue {
+  gt?: QueryScalar;
+  gte?: QueryScalar;
+  lt?: QueryScalar;
+  lte?: QueryScalar;
+}
+
+export interface TimeQuery {
+  after?: string;
+  before?: string;
+  from?: string;
+  to?: string;
+}
+
+interface StructuredQuery {
+  filters?: Record<string, QueryScalar | undefined>;
+  notFilters?: Record<string, QueryScalar | undefined>;
+  ranges?: Record<string, RangeQueryValue | undefined>;
+  time?: TimeQuery;
+  limit?: number;
+  query?: string;
+}
+
+export interface MetricsQuery extends StructuredQuery {}
+
+export interface TracesQuery extends StructuredQuery {}
+
+export interface LogsQuery extends StructuredQuery {}
+
+function buildSearchParams(query: StructuredQuery): URLSearchParams {
+  const search = new URLSearchParams();
+  if (query.query) {
+    search.set("query", query.query);
+  }
+  if (query.limit !== undefined) {
+    search.set("limit", String(query.limit));
+  }
+  for (const [key, value] of Object.entries(query.filters ?? {})) {
+    if (value === undefined || value === "") continue;
+    search.set(`filter[${key}][eq]`, String(value));
+  }
+  for (const [key, value] of Object.entries(query.notFilters ?? {})) {
+    if (value === undefined || value === "") continue;
+    search.set(`filter[${key}][neq]`, String(value));
+  }
+  for (const [key, value] of Object.entries(query.ranges ?? {})) {
+    if (!value) continue;
+    if (value.gt !== undefined && value.gt !== "") {
+      search.set(`range[${key}][gt]`, String(value.gt));
+    }
+    if (value.gte !== undefined && value.gte !== "") {
+      search.set(`range[${key}][gte]`, String(value.gte));
+    }
+    if (value.lt !== undefined && value.lt !== "") {
+      search.set(`range[${key}][lt]`, String(value.lt));
+    }
+    if (value.lte !== undefined && value.lte !== "") {
+      search.set(`range[${key}][lte]`, String(value.lte));
+    }
+  }
+  if (query.time?.after) {
+    search.set("time[after]", query.time.after);
+  }
+  if (query.time?.before) {
+    search.set("time[before]", query.time.before);
+  }
+  if (query.time?.from) {
+    search.set("time[from]", query.time.from);
+  }
+  if (query.time?.to) {
+    search.set("time[to]", query.time.to);
+  }
+  return search;
+}
+
+function buildQueryString(query: StructuredQuery): string {
+  const search = buildSearchParams(query);
+  const encoded = search.toString();
+  return encoded ? `?${encoded}` : "";
+}
+
+function buildValueSuggestionsQueryString(field: string, prefix: string, query: StructuredQuery, limit = 20): string {
+  const search = buildSearchParams(query);
+  search.set("field", field);
+  search.set("limit", String(limit));
+  if (prefix.trim() !== "") {
+    search.set("prefix", prefix);
+  }
+  const encoded = search.toString();
+  return encoded ? `?${encoded}` : "";
+}
+
 /** Fetch full trace detail (all spans) for a given trace ID. */
 export async function fetchTraceDetail(traceId: string): Promise<TraceDetail> {
   return fetchJSON(`/api/query/traces/${traceId}`);
+}
+
+/** Fetch trace summaries using the REST query endpoint with optional server-side filters. */
+export async function fetchTraces(query: TracesQuery = {}, signal?: AbortSignal): Promise<TraceSummary[]> {
+  const qs = buildQueryString(query);
+  const data = await fetchJSON<TraceSummary[] | null>(`/api/query/traces${qs}`, { signal });
+  return normalizeArrayResponse(data);
+}
+
+/** Fetch metric groups using the REST query endpoint with optional server-side filters. */
+export async function fetchMetrics(query: MetricsQuery = {}, signal?: AbortSignal): Promise<MetricGroup[]> {
+  const qs = buildQueryString(query);
+  const data = await fetchJSON<MetricGroup[] | null>(`/api/query/metrics${qs}`, { signal });
+  return normalizeArrayResponse(data);
+}
+
+/** Fetch log records using the REST query endpoint with optional server-side filters. */
+export async function fetchLogs(query: LogsQuery = {}, signal?: AbortSignal): Promise<LogRecord[]> {
+  const qs = buildQueryString(query);
+  const data = await fetchJSON<LogRecord[] | null>(`/api/query/logs${qs}`, { signal });
+  return normalizeArrayResponse(data);
+}
+
+async function fetchValueSuggestions(path: string, field: string, prefix: string, query: StructuredQuery = {}, signal?: AbortSignal): Promise<string[]> {
+  const qs = buildValueSuggestionsQueryString(field, prefix, query);
+  const data = await fetchJSON<string[] | null>(`${path}${qs}`, { signal });
+  return normalizeArrayResponse(data);
+}
+
+export async function fetchTraceFilterValues(field: string, prefix: string, query: TracesQuery = {}, signal?: AbortSignal): Promise<string[]> {
+  return fetchValueSuggestions("/api/query/traces/filter-values", field, prefix, query, signal);
+}
+
+export async function fetchMetricFilterValues(field: string, prefix: string, query: MetricsQuery = {}, signal?: AbortSignal): Promise<string[]> {
+  return fetchValueSuggestions("/api/query/metrics/filter-values", field, prefix, query, signal);
+}
+
+export async function fetchLogFilterValues(field: string, prefix: string, query: LogsQuery = {}, signal?: AbortSignal): Promise<string[]> {
+  return fetchValueSuggestions("/api/query/logs/filter-values", field, prefix, query, signal);
 }

--- a/observer/client/src/logs/LogsTab.test.tsx
+++ b/observer/client/src/logs/LogsTab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LogsTab } from "./LogsTab";
 
@@ -21,9 +21,8 @@ vi.mock("@tanstack/react-virtual", () => ({
 }));
 
 describe("LogsTab", () => {
-  afterEach(() => cleanup());
-
   beforeEach(() => {
+    vi.useFakeTimers();
     Object.defineProperty(HTMLElement.prototype, "clientHeight", {
       configurable: true,
       value: 400,
@@ -46,7 +45,29 @@ describe("LogsTab", () => {
       }) as DOMRect;
   });
 
-  it("filters logs from the compact explorer toolbar", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("filters logs from the compact explorer toolbar via the REST query endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "2",
+          timeUnixNano: "1712700000000000001",
+          severityText: "ERROR",
+          body: "payment failed",
+          attributes: {},
+          resource: { serviceName: "payments", attributes: {} },
+          scope: { name: "otel" },
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
     const { container } = render(
       <LogsTab
         logs={[
@@ -75,17 +96,106 @@ describe("LogsTab", () => {
     expect(container.querySelector(".data-table__head--left-cluster-logs")).toBeTruthy();
     expect(container.querySelector(".data-table__body-inner--logs")).toBeTruthy();
     expect(screen.getByText("Severity")).toBeTruthy();
-    expect(screen.getByRole("option", { name: "TRACE" })).toBeTruthy();
-    expect(screen.getByRole("option", { name: "FATAL" })).toBeTruthy();
     expect(container.querySelector(".data-table__td--timestamp .explorer-row__secondary")).toBeTruthy();
     expect(container.querySelector(".data-table__td--service .explorer-row__secondary")).toBeTruthy();
     expect(container.querySelector(".data-table__td--message .explorer-row__primary")).toBeTruthy();
 
-    fireEvent.change(screen.getByPlaceholderText("Search message, service, or trace ID"), {
-      target: { value: "does-not-match" },
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "serviceName" },
     });
+    expect((screen.getByRole("button", { name: "=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
+    fireEvent.change(screen.getByLabelText("serviceName value"), {
+      target: { value: "payments" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
 
-    expect(screen.getByText("No logs match the current filters.")).toBeTruthy();
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/logs?filter%5BserviceName%5D%5Beq%5D=payments", expect.any(Object));
+    expect(screen.getByText("payment failed")).toBeTruthy();
+    expect(screen.queryByText("checkout started")).toBeNull();
+  });
+
+  it("maps the Message filter to bodyContains in the REST query endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "2",
+          timeUnixNano: "1712700000000000001",
+          severityText: "ERROR",
+          body: "payment failed",
+          attributes: {},
+          resource: { serviceName: "payments", attributes: {} },
+          scope: { name: "otel" },
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityText: "INFO",
+            body: "checkout started",
+            attributes: {},
+            resource: { serviceName: "checkout", attributes: {} },
+            scope: { name: "otel" },
+          },
+          {
+            id: "2",
+            timeUnixNano: "1712700000000000001",
+            severityText: "ERROR",
+            body: "payment failed",
+            attributes: {},
+            resource: { serviceName: "payments", attributes: {} },
+            scope: { name: "otel" },
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "Message" },
+    });
+    fireEvent.change(screen.getByLabelText("message value"), {
+      target: { value: "failed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
+
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/logs?filter%5BbodyContains%5D%5Beq%5D=failed", expect.any(Object));
+    expect(screen.getByText("payment failed")).toBeTruthy();
+    expect(screen.queryByText("checkout started")).toBeNull();
+  });
+
+  it("uses whole-number inputs for severity number filters", () => {
+    render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityText: "INFO",
+            body: "checkout started",
+            attributes: {},
+            resource: { serviceName: "checkout", attributes: {} },
+            scope: { name: "otel" },
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "Severity Number" },
+    });
+    const input = screen.getByLabelText("severityNumber value") as HTMLInputElement;
+
+    expect(input.getAttribute("step")).toBe("1");
   });
 
   it("renders the selected log detail without validation overlays", () => {
@@ -131,7 +241,7 @@ describe("LogsTab", () => {
     expect(screen.getByText("deployment.environment")).toBeTruthy();
     expect(screen.queryByText("Validation")).toBeNull();
     expect(screen.getByRole("button", { name: "Close panel" })).toBeTruthy();
-    expect(screen.getAllByRole("combobox", { name: "Filter logs by severity" }).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Filter field")).toBeTruthy();
 
     const headings = Array.from(container.querySelectorAll(".log-detail__heading")).map((node) => node.textContent);
     expect(headings).toEqual(["Summary", "Message", "Trace Correlation", "Attributes", "Resource Attributes", "Scope"]);
@@ -168,13 +278,6 @@ describe("LogsTab", () => {
     expect(severities).toContain("ERROR3");
     expect(severityCells[0]?.classList.contains("sev-badge--error")).toBe(true);
     expect(severityCells[1]?.classList.contains("sev-badge--info")).toBe(true);
-
-    fireEvent.change(container.querySelector('select[aria-label="Filter logs by severity"]') as HTMLElement, {
-      target: { value: "error" },
-    });
-
-    expect(screen.getByText("persistence operation failed")).toBeTruthy();
-    expect(screen.queryByText("checkout started")).toBeNull();
   });
 
   it("shows both severityNumber and severityText when both are present", () => {
@@ -197,12 +300,27 @@ describe("LogsTab", () => {
 
     expect(container.querySelector(".data-table__td--severity .sev-badge")?.textContent).toBe("TRACE3 (ERROR)");
     expect(container.querySelector(".data-table__td--severity .sev-badge")?.classList.contains("sev-badge--default")).toBe(true);
+  });
 
-    fireEvent.change(container.querySelector('select[aria-label="Filter logs by severity"]') as HTMLElement, {
-      target: { value: "trace" },
-    });
+  it("deduplicates identical normalized and text severities", () => {
+    const { container } = render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityNumber: 17,
+            severityText: "ERROR",
+            body: "payment failed",
+            attributes: {},
+            resource: { serviceName: "payments", attributes: {} },
+            scope: { name: "otel" },
+          },
+        ]}
+      />,
+    );
 
-    expect(screen.getByText("persistence operation failed")).toBeTruthy();
+    expect(container.querySelector(".data-table__td--severity .sev-badge")?.textContent).toBe("ERROR");
   });
 
   it("uses text-only fallback when severityNumber is absent", () => {
@@ -264,12 +382,5 @@ describe("LogsTab", () => {
     expect(severityCells[2]?.classList.contains("sev-badge--info")).toBe(true);
     expect(severityCells[3]?.classList.contains("sev-badge--default")).toBe(true);
     expect(severityCells[4]?.classList.contains("sev-badge--default")).toBe(true);
-
-    fireEvent.change(container.querySelector('select[aria-label="Filter logs by severity"]') as HTMLElement, {
-      target: { value: "info" },
-    });
-
-    expect(screen.getByText("informational text")).toBeTruthy();
-    expect(screen.queryByText("warning text")).toBeNull();
   });
 });

--- a/observer/client/src/logs/LogsTab.tsx
+++ b/observer/client/src/logs/LogsTab.tsx
@@ -1,6 +1,8 @@
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { LogRecord } from "../api/types";
+import { fetchLogFilterValues, fetchLogs, type LogsQuery } from "../api/client";
+import { FilterBar, type FilterClause, type FilterDefinition } from "../FilterBar";
 import { DetailPanel } from "../layout";
 
 interface LogsTabProps {
@@ -10,6 +12,62 @@ interface LogsTabProps {
 type DetailTab = "overview" | "json";
 type SeverityBucket = "error" | "warn" | "info" | "default";
 type SeverityFilterValue = "" | "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+
+const LOG_FILTER_DEFINITIONS: FilterDefinition[] = [
+  { key: "scopeName", label: "Scope", kind: "text" },
+  { key: "serviceName", label: "Service", kind: "text" },
+  { key: "message", label: "Message", kind: "text" },
+  { key: "severityNumber", label: "Severity Number", kind: "number", step: 1 },
+  {
+    key: "severityText",
+    label: "Severity",
+    kind: "enum",
+    options: [
+      { label: "TRACE", value: "TRACE" },
+      { label: "DEBUG", value: "DEBUG" },
+      { label: "INFO", value: "INFO" },
+      { label: "WARN", value: "WARN" },
+      { label: "ERROR", value: "ERROR" },
+      { label: "FATAL", value: "FATAL" },
+    ],
+  },
+  { key: "spanId", label: "Span ID", kind: "text" },
+  { key: "traceId", label: "Trace ID", kind: "text" },
+];
+
+const LOG_SUGGESTIBLE_FIELDS = new Set(["serviceName", "scopeName"]);
+
+function assignQueryFilter(query: LogsQuery, clause: FilterClause): void {
+  const targetKey = clause.op === "neq" ? "notFilters" : "filters";
+  query[targetKey] = { ...(query[targetKey] ?? {}), [clause.key]: clause.value };
+}
+
+function buildLogsQuery(clauses: FilterClause[]): LogsQuery {
+  const query: LogsQuery = {};
+  for (const clause of clauses) {
+    switch (clause.key) {
+      case "serviceName":
+        assignQueryFilter(query, clause);
+        break;
+      case "message":
+        query[clause.op === "neq" ? "notFilters" : "filters"] = {
+          ...(query[clause.op === "neq" ? "notFilters" : "filters"] ?? {}),
+          bodyContains: clause.value,
+        };
+        break;
+      case "severityText":
+      case "severityNumber":
+      case "traceId":
+      case "spanId":
+      case "scopeName":
+        assignQueryFilter(query, clause);
+        break;
+      default:
+        break;
+    }
+  }
+  return query;
+}
 
 function severityFromNumber(severityNumber?: number): string {
   if (severityNumber === undefined) return "";
@@ -82,7 +140,12 @@ function severityBucket(record: LogRecord): SeverityBucket {
 function displaySeverity(record: LogRecord): string {
   const severityFromNum = severityFromNumber(record.severityNumber);
   const severityText = record.severityText?.trim();
-  if (severityFromNum && severityText) return `${severityFromNum} (${severityText})`;
+  if (severityFromNum && severityText) {
+    if (severityFromNum.toUpperCase() === severityText.toUpperCase()) {
+      return severityFromNum;
+    }
+    return `${severityFromNum} (${severityText})`;
+  }
   if (severityFromNum) return severityFromNum;
   if (severityText) return severityText;
   return "";
@@ -94,50 +157,71 @@ function logKey(r: LogRecord): string {
 
 /** Logs tab with virtualized table and detail panel for selected log records. */
 export function LogsTab({ logs }: LogsTabProps): React.ReactElement {
-  const [query, setQuery] = useState("");
-  const [severityFilter, setSeverityFilter] = useState("");
+  const [clauses, setClauses] = useState<FilterClause[]>([]);
+  const [serverLogs, setServerLogs] = useState<LogRecord[]>([]);
+  const [isFiltering, setIsFiltering] = useState(false);
+  const [filterError, setFilterError] = useState<string | null>(null);
   const [selectedLog, setSelectedLog] = useState<LogRecord | null>(null);
   const [detailTab, setDetailTab] = useState<DetailTab>("overview");
   const tableRef = useRef<HTMLDivElement>(null);
 
   const selectedKey = useMemo(() => selectedLog ? logKey(selectedLog) : null, [selectedLog]);
-  const filteredLogs = useMemo(() => {
-    const trimmedQuery = query.trim().toLowerCase();
-    return logs.filter((record) => {
-      const severity = displaySeverity(record);
-      const filterValue = severityFilterValue(record);
-      if (severityFilter && filterValue !== severityFilter) {
-        return false;
-      }
-      if (!trimmedQuery) {
-        return true;
-      }
-      const haystack = [
-        severity,
-        filterValue,
-        record.body,
-        record.resource?.serviceName ?? "",
-        record.traceId ?? "",
-      ].join(" ").toLowerCase();
-      return haystack.includes(trimmedQuery);
-    });
-  }, [logs, query, severityFilter]);
+  const activeQuery = useMemo(() => buildLogsQuery(clauses), [clauses]);
+  const suggestLogValues = useCallback((fieldKey: string, prefix: string, signal: AbortSignal) => {
+    if (!LOG_SUGGESTIBLE_FIELDS.has(fieldKey)) {
+      return Promise.resolve<string[]>([]);
+    }
+    return fetchLogFilterValues(fieldKey, prefix, buildLogsQuery(clauses.filter((clause) => clause.key !== fieldKey)), signal);
+  }, [clauses]);
+  const hasActiveFilter = clauses.length > 0;
+  const liveLogs = Array.isArray(logs) ? logs : [];
+  const visibleLogs = hasActiveFilter ? serverLogs : liveLogs;
+
+  useEffect(() => {
+    if (!hasActiveFilter) {
+      setServerLogs([]);
+      setIsFiltering(false);
+      setFilterError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsFiltering(true);
+    fetchLogs(activeQuery, controller.signal)
+      .then((nextLogs) => {
+        if (controller.signal.aborted) return;
+        setServerLogs(nextLogs);
+        setFilterError(null);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setFilterError(error instanceof Error ? error.message : "Failed to filter logs");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsFiltering(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [activeQuery, hasActiveFilter, liveLogs]);
+
   // Invalidate selection when the selected log is no longer in the snapshot
   // (e.g., after store clear, WebSocket reconnect, or eviction from the buffer).
   useEffect(() => {
-    if (selectedKey && !logs.some((r) => logKey(r) === selectedKey)) {
+    if (selectedKey && !liveLogs.some((r) => logKey(r) === selectedKey)) {
       setSelectedLog(null);
     }
-  }, [logs, selectedKey]);
+  }, [liveLogs, selectedKey]);
 
   useEffect(() => {
-    if (selectedKey && !filteredLogs.some((record) => logKey(record) === selectedKey)) {
+    if (selectedKey && !visibleLogs.some((record) => logKey(record) === selectedKey)) {
       setSelectedLog(null);
     }
-  }, [filteredLogs, selectedKey]);
+  }, [selectedKey, visibleLogs]);
 
   const virtualizer = useVirtualizer({
-    count: filteredLogs.length,
+    count: visibleLogs.length,
     getScrollElement: () => tableRef.current,
     estimateSize: () => 36,
     overscan: 10,
@@ -149,35 +233,24 @@ export function LogsTab({ logs }: LogsTabProps): React.ReactElement {
         className={`signal-view${selectedLog ? " signal-view--with-panel" : ""}`}
       >
         <div className="signal-view__content">
-          {logs.length > 0 ? (
+          {liveLogs.length > 0 || hasActiveFilter ? (
             <div className="explorer__toolbar explorer__toolbar--controls">
-              <select
-                className="explorer__select"
-                value={severityFilter}
-                onChange={(event) => setSeverityFilter(event.target.value)}
-                aria-label="Filter logs by severity"
-              >
-                <option value="">All severities</option>
-                <option value="trace">TRACE</option>
-                <option value="debug">DEBUG</option>
-                <option value="info">INFO</option>
-                <option value="warn">WARN</option>
-                <option value="error">ERROR</option>
-                <option value="fatal">FATAL</option>
-              </select>
-              <input
-                className="explorer__input"
-                type="search"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search message, service, or trace ID"
+              <FilterBar
+                definitions={LOG_FILTER_DEFINITIONS}
+                clauses={clauses}
+                onChange={setClauses}
+                onSuggestValues={suggestLogValues}
               />
             </div>
           ) : null}
 
-          {logs.length === 0 ? (
+          {filterError ? (
+            <p className="explorer__status explorer__status--error">{filterError}</p>
+          ) : liveLogs.length === 0 && !hasActiveFilter ? (
             <p className="explorer__status explorer__status--empty">No logs received yet. Send OTLP telemetry to port 4318 to begin exploring.</p>
-          ) : filteredLogs.length === 0 ? (
+          ) : isFiltering && hasActiveFilter && visibleLogs.length === 0 ? (
+            <p className="explorer__status">Updating filtered logs...</p>
+          ) : visibleLogs.length === 0 ? (
             <p className="explorer__status">No logs match the current filters.</p>
           ) : (
             <>
@@ -191,7 +264,7 @@ export function LogsTab({ logs }: LogsTabProps): React.ReactElement {
           <div className="data-table__body" ref={tableRef}>
             <div className="data-table__body-inner data-table__body-inner--logs" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
               {virtualizer.getVirtualItems().map((vi) => {
-                const r = filteredLogs[vi.index];
+                const r = visibleLogs[vi.index];
                 if (!r) return null;
                 const active = selectedKey !== null && logKey(r) === selectedKey;
                 const severity = displaySeverity(r);

--- a/observer/client/src/metrics/MetricsTab.test.tsx
+++ b/observer/client/src/metrics/MetricsTab.test.tsx
@@ -3,14 +3,35 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MetricsTab } from "./MetricsTab";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe("MetricsTab", () => {
-  it("filters metrics from the compact explorer toolbar using the visible columns", () => {
+  it("filters metrics from the compact explorer toolbar via the REST query endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          name: "http.server.duration",
+          description: "Request duration",
+          unit: "ms",
+          type: "histogram",
+          serviceName: "checkout",
+          scopeName: "otel",
+          dataPointCount: 1,
+          dataPoints: [],
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
     render(
       <MetricsTab
         metrics={[
@@ -51,17 +72,68 @@ describe("MetricsTab", () => {
 
     expect(screen.getByText("Type / Unit")).toBeTruthy();
     expect(screen.getByText("Description")).toBeTruthy();
-    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.getByLabelText("Filter field")).toBeTruthy();
     expect(screen.queryByText("Type")).toBeNull();
     expect(screen.queryByText("Unit")).toBeNull();
 
-    fireEvent.change(screen.getByPlaceholderText("Search metric, description, type, unit, or service"), {
-      target: { value: "duration" },
+    const fieldInput = screen.getByLabelText("Filter field");
+    expect(fieldInput.getAttribute("placeholder")).toBe("Add filter");
+    fireEvent.change(fieldInput, { target: { value: "metricName" } });
+    expect((screen.getByRole("button", { name: "=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
+    fireEvent.change(screen.getByLabelText("metricName value"), {
+      target: { value: "http.server.duration" },
     });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
 
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/metrics?filter%5BmetricName%5D%5Beq%5D=http.server.duration", expect.any(Object));
     expect(screen.queryByText("http.server.request.count")).toBeNull();
     expect(screen.getByText("http.server.duration")).toBeTruthy();
     expect(screen.queryByText("db.client.connections.usage")).toBeNull();
+  });
+
+  it("shows server-backed value suggestions for low-cardinality fields", async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.startsWith("/api/query/metrics/filter-values")) {
+        return {
+          ok: true,
+          json: async () => ["checkout"],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => [],
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <MetricsTab
+        metrics={[
+          {
+            name: "http.server.duration",
+            description: "Request duration",
+            unit: "ms",
+            type: "histogram",
+            serviceName: "checkout",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+        ]}
+        telemetryError={null}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), { target: { value: "serviceName" } });
+    fireEvent.focus(screen.getByLabelText("serviceName value"));
+    fireEvent.change(screen.getByLabelText("serviceName value"), { target: { value: "che" } });
+
+    await act(async () => {});
+
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/api/query/metrics/filter-values?field=serviceName"))).toBe(true);
+    expect(screen.getByText("checkout")).toBeTruthy();
   });
 
   it("renders metrics in alphabetical order", () => {
@@ -108,9 +180,10 @@ describe("MetricsTab", () => {
     expect(container.querySelector(".metric-card__disclosure")).toBeNull();
     expect(container.textContent).toContain("gauge/ms");
     expect(container.textContent).not.toContain("svc");
+
   });
 
-  it("opens the full metric view in a side panel with series rows", () => {
+  it("renders selected metric details in the side panel", () => {
     const { container } = render(
       <MetricsTab
         metrics={[
@@ -142,176 +215,13 @@ describe("MetricsTab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /http\.server\.duration/i }));
 
-    expect(screen.getByRole("heading", { name: "http.server.duration" })).toBeTruthy();
-    expect(screen.getByText("Series (1)")).toBeTruthy();
-    expect(container.querySelector(".ts-chart")).toBeTruthy();
+    expect(container.querySelector(".signal-view__panel")).toBeTruthy();
     expect(container.querySelector(".metrics-explorer__series-service")?.textContent).toBe("api-gateway");
     expect(container.querySelector(".metrics-explorer__series-attr")?.textContent).toBe("http.route=/api/orders/{id}");
     expect(container.querySelector(".metrics-explorer__series-value")?.textContent).toBe("8.18");
     expect(container.querySelector(".metrics-explorer__series-points")?.textContent).toBe("1 pts");
     expect(container.querySelector(".metric-card__description")?.classList.contains("explorer-row__secondary")).toBe(true);
-  });
-
-  it("shows selected series detail inside the metric side panel", () => {
-    render(
-      <MetricsTab
-        metrics={[
-          {
-            name: "http.server.duration",
-            description: "Request duration",
-            unit: "ms",
-            type: "histogram",
-            serviceName: "api-gateway",
-            scopeName: "otel",
-            dataPointCount: 2,
-            dataPoints: [
-              {
-                name: "http.server.duration",
-                type: "histogram",
-                unit: "ms",
-                timeUnixNano: "1",
-                attributes: { "http.route": "/api/orders/{id}" },
-                resource: { serviceName: "api-gateway", attributes: { "service.instance.id": "instance-1" } },
-                scope: { name: "otel", version: "1.0.0" },
-                value: 8.18,
-              },
-              {
-                name: "http.server.duration",
-                type: "histogram",
-                unit: "ms",
-                timeUnixNano: "2",
-                attributes: { "http.route": "/api/orders/{id}" },
-                resource: { serviceName: "api-gateway", attributes: { "service.instance.id": "instance-1" } },
-                scope: { name: "otel", version: "1.0.0" },
-                value: 10.25,
-              },
-            ],
-          },
-        ]}
-        telemetryError={null}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /http\.server\.duration/i }));
-    fireEvent.click(screen.getAllByRole("button", { name: /api-gateway/i })[0] as HTMLElement);
-
-    expect(screen.getByRole("heading", { name: "http.server.duration" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Close panel" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Clear series selection" })).toBeTruthy();
-    expect(screen.getByText("Scope")).toBeTruthy();
-    expect(screen.getByText("Resource")).toBeTruthy();
-    expect(screen.getByText("service.instance.id:")).toBeTruthy();
-  });
-
-  it("keeps metric series order stable across live value updates and appends new series at the end", () => {
-    const initialMetrics = [
-      {
-        name: "http.server.duration",
-        description: "Request duration",
-        unit: "ms",
-        type: "histogram",
-        serviceName: "api-gateway",
-        scopeName: "otel",
-        dataPointCount: 2,
-        dataPoints: [
-          {
-            name: "http.server.duration",
-            type: "histogram",
-            unit: "ms",
-            timeUnixNano: "1",
-            attributes: { "http.route": "/api/orders" },
-            resource: { serviceName: "checkout", attributes: {} },
-            scope: { name: "otel" },
-            value: 8.18,
-          },
-          {
-            name: "http.server.duration",
-            type: "histogram",
-            unit: "ms",
-            timeUnixNano: "2",
-            attributes: { "http.route": "/api/orders/{id}" },
-            resource: { serviceName: "payments", attributes: {} },
-            scope: { name: "otel" },
-            value: 10.25,
-          },
-        ],
-      },
-    ];
-    const { container, rerender } = render(<MetricsTab metrics={initialMetrics} telemetryError={null} />);
-
-    fireEvent.click(screen.getByRole("button", { name: /http\.server\.duration/i }));
-
-    const initialRows = Array.from(container.querySelectorAll(".metrics-explorer__series-row"))
-      .map((node) => ({
-        service: node.querySelector(".metrics-explorer__series-service")?.textContent,
-        dimension: node.querySelector(".metrics-explorer__series-attr")?.textContent,
-        value: node.querySelector(".metrics-explorer__series-value")?.textContent,
-      }));
-    expect(initialRows).toEqual([
-      { service: "checkout", dimension: "http.route=/api/orders", value: "8.18" },
-      { service: "payments", dimension: "http.route=/api/orders/{id}", value: "10.25" },
-    ]);
-
-    rerender(
-      <MetricsTab
-        metrics={[
-          {
-            name: "http.server.duration",
-            description: "Request duration",
-            unit: "ms",
-            type: "histogram",
-            serviceName: "api-gateway",
-            scopeName: "otel",
-            dataPointCount: 3,
-            dataPoints: [
-              {
-                name: "http.server.duration",
-                type: "histogram",
-                unit: "ms",
-                timeUnixNano: "3",
-                attributes: { "http.route": "/api/orders/{id}" },
-                resource: { serviceName: "payments", attributes: {} },
-                scope: { name: "otel" },
-                value: 100.25,
-              },
-              {
-                name: "http.server.duration",
-                type: "histogram",
-                unit: "ms",
-                timeUnixNano: "4",
-                attributes: { "http.route": "/api/orders" },
-                resource: { serviceName: "checkout", attributes: {} },
-                scope: { name: "otel" },
-                value: 18.18,
-              },
-              {
-                name: "http.server.duration",
-                type: "histogram",
-                unit: "ms",
-                timeUnixNano: "5",
-                attributes: { "http.route": "/api/inventory" },
-                resource: { serviceName: "inventory", attributes: {} },
-                scope: { name: "otel" },
-                value: 3.5,
-              },
-            ],
-          },
-        ]}
-        telemetryError={null}
-      />,
-    );
-
-    const updatedRows = Array.from(container.querySelectorAll(".metrics-explorer__series-row"))
-      .map((node) => ({
-        service: node.querySelector(".metrics-explorer__series-service")?.textContent,
-        dimension: node.querySelector(".metrics-explorer__series-attr")?.textContent,
-        value: node.querySelector(".metrics-explorer__series-value")?.textContent,
-      }));
-    expect(updatedRows).toEqual([
-      { service: "checkout", dimension: "http.route=/api/orders", value: "18.18" },
-      { service: "payments", dimension: "http.route=/api/orders/{id}", value: "100.25" },
-      { service: "inventory", dimension: "http.route=/api/inventory", value: "3.50" },
-    ]);
+    expect(container.querySelector(".metric-card__body")).toBeNull();
   });
 
   it("keeps the shared row separator on metric rows", async () => {

--- a/observer/client/src/metrics/MetricsTab.tsx
+++ b/observer/client/src/metrics/MetricsTab.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import React, { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import { fetchMetricFilterValues, fetchMetrics, type MetricsQuery } from "../api/client";
+import { FilterBar, type FilterClause, type FilterDefinition } from "../FilterBar";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 import { useMetricTimeSeries, type MetricSeries } from "./useMetricTimeSeries";
 import type { MetricGroup } from "../api/types";
@@ -12,37 +14,62 @@ interface MetricsTabProps {
 
 type DisplayType = "lines" | "bars" | "area";
 
-/** Metrics tab with expandable metric cards and time series charts. */
+const METRIC_FILTER_DEFINITIONS: FilterDefinition[] = [
+  { key: "metricName", label: "Metric", kind: "text" },
+  { key: "scopeName", label: "Scope", kind: "text" },
+  { key: "serviceName", label: "Service", kind: "text" },
+];
+const METRIC_SUGGESTIBLE_FIELDS = new Set(["metricName", "serviceName", "scopeName"]);
+
+function assignQueryFilter(query: MetricsQuery, clause: FilterClause): void {
+  const targetKey = clause.op === "neq" ? "notFilters" : "filters";
+  query[targetKey] = { ...(query[targetKey] ?? {}), [clause.key]: clause.value };
+}
+
+function buildMetricsQuery(clauses: FilterClause[]): MetricsQuery {
+  const query: MetricsQuery = {};
+  for (const clause of clauses) {
+    switch (clause.key) {
+      case "metricName":
+      case "serviceName":
+      case "scopeName":
+        assignQueryFilter(query, clause);
+        break;
+      default:
+        break;
+    }
+  }
+  return query;
+}
+
+/** Metrics tab with list view and a right-side detail panel for the selected metric. */
 export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.ReactElement {
-  const [query, setQuery] = useState("");
+  const [clauses, setClauses] = useState<FilterClause[]>([]);
+  const [serverMetrics, setServerMetrics] = useState<MetricGroup[]>([]);
+  const [isFiltering, setIsFiltering] = useState(false);
+  const [filterError, setFilterError] = useState<string | null>(null);
   const [expandedMetric, setExpandedMetric] = useState<string | null>(null);
   const [selectedSeriesKey, setSelectedSeriesKey] = useState<string | null>(null);
   const [displayType, setDisplayType] = useState<DisplayType>("lines");
   const seriesOrderRef = useRef<Map<string, string[]>>(new Map());
-
-  const { allSeries, metricList } = useMetricTimeSeries(metrics);
+  const activeQuery = useMemo(() => buildMetricsQuery(clauses), [clauses]);
+  const suggestMetricValues = useCallback((fieldKey: string, prefix: string, signal: AbortSignal) => {
+    if (!METRIC_SUGGESTIBLE_FIELDS.has(fieldKey)) {
+      return Promise.resolve<string[]>([]);
+    }
+    return fetchMetricFilterValues(fieldKey, prefix, buildMetricsQuery(clauses.filter((clause) => clause.key !== fieldKey)), signal);
+  }, [clauses]);
+  const hasActiveFilter = clauses.length > 0;
+  const liveMetrics = Array.isArray(metrics) ? metrics : [];
+  const visibleMetrics = hasActiveFilter ? serverMetrics : liveMetrics;
+  const { allSeries, metricList } = useMetricTimeSeries(visibleMetrics);
   const visibleMetricList = useMemo(() => {
-    const trimmedQuery = query.trim().toLowerCase();
-    return [...metricList]
-      .filter((metric) => {
-        if (!trimmedQuery) {
-          return true;
-        }
-        const haystack = [
-          metric.name,
-          metric.description ?? "",
-          metric.serviceName ?? "",
-          metric.type,
-          metric.unit ?? "",
-        ].join(" ").toLowerCase();
-        return haystack.includes(trimmedQuery);
-      })
-      .sort((left, right) => left.name.localeCompare(right.name));
-  }, [metricList, query]);
+    return [...metricList].sort((left, right) => left.name.localeCompare(right.name));
+  }, [metricList]);
 
   const expandedSeries = useMemo(() => {
     if (!expandedMetric) return [];
-    const currentSeries = allSeries.filter((s) => s.metricName === expandedMetric);
+    const currentSeries = allSeries.filter((series) => series.metricName === expandedMetric);
     const previousOrder = seriesOrderRef.current.get(expandedMetric) ?? [];
     const currentKeys = new Set(currentSeries.map((series) => series.key));
     const nextOrder = [
@@ -56,6 +83,7 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
       .map((key) => seriesByKey.get(key))
       .filter((series): series is MetricSeries => series !== undefined);
   }, [allSeries, expandedMetric]);
+
   const expandedMeta = useMemo(
     () => (expandedMetric
       ? visibleMetricList.find((metric) => metric.name === expandedMetric)
@@ -66,21 +94,22 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
   );
 
   const selectedDetail = selectedSeriesKey
-    ? expandedSeries.find((s) => s.key === selectedSeriesKey) ?? null
+    ? expandedSeries.find((series) => series.key === selectedSeriesKey) ?? null
     : null;
 
   const stats = useMemo(() => {
     if (!selectedDetail) return null;
-    const vals = selectedDetail.points.map((p) => p.value);
-    if (vals.length === 0) return null;
+    const values = selectedDetail.points.map((point) => point.value);
+    if (values.length === 0) return null;
     return {
-      min: Math.min(...vals),
-      max: Math.max(...vals),
-      avg: vals.reduce((a, b) => a + b, 0) / vals.length,
-      count: vals.length,
+      min: Math.min(...values),
+      max: Math.max(...values),
+      avg: values.reduce((left, right) => left + right, 0) / values.length,
+      count: values.length,
       latest: selectedDetail.latest,
     };
   }, [selectedDetail]);
+
   const selectedAttributes = useMemo(
     () => stableEntries(selectedDetail?.attributes ?? {}),
     [selectedDetail],
@@ -124,6 +153,35 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
   const hasDetail = Boolean(expandedMeta);
 
   useEffect(() => {
+    if (!hasActiveFilter) {
+      setServerMetrics([]);
+      setIsFiltering(false);
+      setFilterError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsFiltering(true);
+    fetchMetrics(activeQuery, controller.signal)
+      .then((nextMetrics) => {
+        if (controller.signal.aborted) return;
+        setServerMetrics(nextMetrics);
+        setFilterError(null);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setFilterError(error instanceof Error ? error.message : "Failed to filter metrics");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsFiltering(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [activeQuery, hasActiveFilter, liveMetrics]);
+
+  useEffect(() => {
     if (!expandedMetric) return;
     if (!visibleMetricList.some((metric) => metric.name === expandedMetric)) {
       setExpandedMetric(null);
@@ -139,21 +197,28 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
             <p className="explorer__status explorer__status--error">{telemetryError}</p>
           ) : null}
 
-          {metricList.length > 0 ? (
+          {filterError ? (
+            <p className="explorer__status explorer__status--error">{filterError}</p>
+          ) : null}
+
+          {visibleMetricList.length > 0 || hasActiveFilter ? (
             <div className="explorer__toolbar explorer__toolbar--controls">
-              <input
-                className="explorer__input"
-                type="search"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search metric, description, type, unit, or service"
+              <FilterBar
+                definitions={METRIC_FILTER_DEFINITIONS}
+                clauses={clauses}
+                onChange={setClauses}
+                onSuggestValues={suggestMetricValues}
               />
             </div>
           ) : null}
 
-          {metricList.length === 0 && metrics.length === 0 ? (
+          {visibleMetricList.length === 0 && liveMetrics.length === 0 && !hasActiveFilter ? (
             <p className="explorer__status explorer__status--empty" style={{ padding: "40px 20px" }}>
               No metrics received yet. Send OTLP telemetry to port 4318 to begin exploring.
+            </p>
+          ) : isFiltering && hasActiveFilter && visibleMetricList.length === 0 ? (
+            <p className="metrics-explorer__empty" style={{ padding: "24px 20px" }}>
+              Updating filtered metrics...
             </p>
           ) : visibleMetricList.length === 0 ? (
             <p className="metrics-explorer__empty" style={{ padding: "24px 20px" }}>
@@ -170,30 +235,29 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
           ) : null}
 
           <div className="metrics-card-list">
-            {visibleMetricList.map((m) => {
-              const isExpanded = expandedMetric === m.name;
-
+            {visibleMetricList.map((metric) => {
+              const isExpanded = expandedMetric === metric.name;
               return (
-                <div key={m.name} className="metric-card">
+                <div key={metric.name} className="metric-card">
                   <button
                     className={`data-table__row data-table__row--metrics metric-card__header ${isExpanded ? "metric-card__header--active" : ""}`}
                     onClick={() => {
-                      setExpandedMetric(isExpanded ? null : m.name);
+                      setExpandedMetric(isExpanded ? null : metric.name);
                       setSelectedSeriesKey(null);
                     }}
                     type="button"
                   >
                     <span className="data-table__td data-table__td--metric-name metric-card__info">
-                      <span className="metric-card__name explorer-row__primary">{m.name}</span>
+                      <span className="metric-card__name explorer-row__primary">{metric.name}</span>
                     </span>
                     <span className="data-table__td data-table__td--metric-description">
-                      <span className="metric-card__description explorer-row__secondary">{m.description || "--"}</span>
+                      <span className="metric-card__description explorer-row__secondary">{metric.description || "--"}</span>
                     </span>
                     <span className="data-table__td data-table__td--metric-meta">
                       <span className="data-table__cell-content data-table__cell-content--meta metric-card__meta">
-                        <span className={`metric-card__badge metric-type metric-type--${m.type}`}>{m.type}</span>
+                        <span className={`metric-card__badge metric-type metric-type--${metric.type}`}>{metric.type}</span>
                         <span className="metric-card__meta-separator explorer-row__secondary">/</span>
-                        <span className="metric-card__unit explorer-row__secondary">{m.unit || "--"}</span>
+                        <span className="metric-card__unit explorer-row__secondary">{metric.unit || "--"}</span>
                       </span>
                     </span>
                   </button>
@@ -225,14 +289,14 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
                 <div className="metrics-explorer__controls">
                   <div className="metrics-explorer__display">
                     <span className="metrics-explorer__control-label">Display</span>
-                    {(["lines", "bars", "area"] as DisplayType[]).map((dt) => (
+                    {(["lines", "bars", "area"] as DisplayType[]).map((nextDisplayType) => (
                       <button
-                        key={dt}
-                        className={`pill pill--small ${displayType === dt ? "pill--accent" : "pill--muted"}`}
-                        onClick={() => setDisplayType(dt)}
+                        key={nextDisplayType}
+                        className={`pill pill--small ${displayType === nextDisplayType ? "pill--accent" : "pill--muted"}`}
+                        onClick={() => setDisplayType(nextDisplayType)}
                         type="button"
                       >
-                        {dt.charAt(0).toUpperCase() + dt.slice(1)}
+                        {nextDisplayType.charAt(0).toUpperCase() + nextDisplayType.slice(1)}
                       </button>
                     ))}
                   </div>
@@ -253,32 +317,32 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
                     <span className="metrics-explorer__detail-title">Series ({expandedSeries.length})</span>
                   </div>
                   <div className="metrics-explorer__detail-body">
-                    {expandedSeries.map((s, i) => {
-                      const attrs = stableEntries(s.attributes ?? {});
-                      const svcName = s.resource?.serviceName;
+                    {expandedSeries.map((series, index) => {
+                      const attributes = stableEntries(series.attributes ?? {});
+                      const serviceName = series.resource?.serviceName;
                       return (
                         <button
-                          key={s.key}
+                          key={series.key}
                           className="metrics-explorer__series-row"
-                          onClick={() => setSelectedSeriesKey(selectedSeriesKey === s.key ? null : s.key)}
+                          onClick={() => setSelectedSeriesKey(selectedSeriesKey === series.key ? null : series.key)}
                           type="button"
-                          style={{ width: "100%", border: 0, background: selectedSeriesKey === s.key ? "var(--accent-soft)" : "transparent", cursor: "pointer", textAlign: "left", font: "inherit" }}
+                          style={{ width: "100%", border: 0, background: selectedSeriesKey === series.key ? "var(--accent-soft)" : "transparent", cursor: "pointer", textAlign: "left", font: "inherit" }}
                         >
-                          <span className="metrics-explorer__series-dot" style={{ background: TELEMETRY_SERIES_COLORS[i % TELEMETRY_SERIES_COLORS.length] }} />
+                          <span className="metrics-explorer__series-dot" style={{ background: TELEMETRY_SERIES_COLORS[index % TELEMETRY_SERIES_COLORS.length] }} />
                           <span className="metrics-explorer__series-attrs">
-                            {svcName ? <span className="metrics-explorer__series-service">{svcName}</span> : null}
-                            {attrs.length > 0 ? (
+                            {serviceName ? <span className="metrics-explorer__series-service">{serviceName}</span> : null}
+                            {attributes.length > 0 ? (
                               <span className="metrics-explorer__series-dimensions">
-                                {attrs.map(([k, v]) => (
-                                  <span key={k} className="metrics-explorer__series-attr">
-                                    {k}={String(v)}
+                                {attributes.map(([key, value]) => (
+                                  <span key={key} className="metrics-explorer__series-attr">
+                                    {key}={String(value)}
                                   </span>
                                 ))}
                               </span>
-                            ) : !svcName ? <span className="metrics-explorer__series-no-attrs">(no dimensions)</span> : null}
+                            ) : !serviceName ? <span className="metrics-explorer__series-no-attrs">(no dimensions)</span> : null}
                           </span>
-                          <span className="metrics-explorer__series-value">{formatNumber(s.latest)}</span>
-                          <span className="metrics-explorer__series-points">{s.points.length} pts</span>
+                          <span className="metrics-explorer__series-value">{formatNumber(series.latest)}</span>
+                          <span className="metrics-explorer__series-points">{series.points.length} pts</span>
                         </button>
                       );
                     })}
@@ -376,10 +440,10 @@ export function MetricsTab({ metrics, telemetryError }: MetricsTabProps): React.
   );
 }
 
-function formatNumber(v: number): string {
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
-  return v % 1 === 0 ? String(v) : v.toFixed(2);
+function formatNumber(value: number): string {
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value % 1 === 0 ? String(value) : value.toFixed(2);
 }
 
 function stableEntries(attributes: Record<string, unknown>): Array<[string, unknown]> {

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -2233,6 +2233,286 @@ code {
   justify-content: flex-start;
 }
 
+.filter-builder {
+  position: relative;
+  display: flex;
+  flex: 0 1 auto;
+  flex-direction: column;
+  gap: 8px;
+  width: min(100%, 860px);
+  max-width: min(100%, 860px);
+  min-width: 0;
+}
+
+.filter-builder__controls {
+  display: flex;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+}
+
+.filter-builder__composer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  flex: 1 1 360px;
+}
+
+.filter-builder__composer--selected {
+  flex: 0 1 auto;
+  width: min(100%, 640px);
+  max-width: 100%;
+  padding: 3px 4px 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--chrome-2);
+}
+
+.filter-builder__composer--selected .filter-builder__value {
+  flex: 0 1 320px;
+  width: min(100%, 320px);
+  max-width: 320px;
+}
+
+.filter-builder__field,
+.filter-builder__value {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.filter-builder__field {
+  min-width: 180px;
+}
+
+.filter-builder__value {
+  min-width: 100px;
+}
+
+.filter-builder__token {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.filter-builder__hint {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  flex: 1 1 auto;
+  color: var(--text-dim);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.filter-builder__operators {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.filter-builder__operator {
+  min-width: 34px;
+  height: 24px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.filter-builder__operator--active {
+  background: rgba(79, 193, 255, 0.18);
+  color: #ffffff;
+}
+
+.filter-builder__clear {
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.filter-builder__apply {
+  height: 24px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 7px;
+  background: rgba(79, 193, 255, 0.18);
+  color: #ffffff;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.filter-builder__apply:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.filter-builder__apply:not(:disabled):hover {
+  background: rgba(79, 193, 255, 0.26);
+}
+
+.filter-builder__clear:hover,
+.filter-builder__operator:hover {
+  color: #ffffff;
+}
+
+.filter-builder__menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  min-width: 420px;
+  max-width: min(680px, 100%);
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: rgba(23, 25, 29, 0.98);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.42);
+}
+
+.filter-builder__menu-section {
+  padding: 10px 12px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.filter-builder__menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.filter-builder__menu-item:hover {
+  background: rgba(79, 193, 255, 0.08);
+}
+
+.filter-builder__menu-key {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.filter-builder__menu-ops {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.filter-builder__menu-op {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.filter-builder__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.filter-builder__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.filter-builder__chip:hover {
+  border-color: var(--accent);
+}
+
+.filter-builder__chip-remove {
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1;
+}
+
+@media (max-width: 980px) {
+  .filter-builder {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .filter-builder__controls {
+    flex-wrap: wrap;
+  }
+
+  .filter-builder__composer {
+    flex-basis: 100%;
+  }
+
+  .filter-builder__composer--selected {
+    width: 100%;
+  }
+
+  .filter-builder__composer--selected .filter-builder__value {
+    width: auto;
+    max-width: none;
+    flex: 1 1 auto;
+  }
+
+  .filter-builder__menu {
+    min-width: min(100%, 420px);
+  }
+}
+
 .explorer__input,
 .explorer__select {
   height: 28px;

--- a/observer/client/src/traces/TracesTab.style.test.tsx
+++ b/observer/client/src/traces/TracesTab.style.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TracesTab, traceStatusLabel } from "./TracesTab";
 import { SpanDetailsPanel } from "./SpanDetailsPanel";
+import { MetricsTab } from "../metrics/MetricsTab";
 
 declare const require: (id: string) => any;
 declare const process: { cwd(): string };
@@ -24,7 +25,11 @@ vi.mock("@tanstack/react-virtual", () => ({
   }),
 }));
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe("TracesTab row layout", () => {
   beforeEach(() => {
@@ -66,7 +71,14 @@ describe("TracesTab row layout", () => {
     expect(screen.getByText("Service")).toBeTruthy();
     expect(screen.getByText("Status")).toBeTruthy();
     expect(screen.getByText("Duration")).toBeTruthy();
-    expect(screen.getByPlaceholderText("Search operation, trace ID, service, or status")).toBeTruthy();
+    const filterField = screen.getByLabelText("Filter field");
+    expect(filterField).toBeTruthy();
+    fireEvent.focus(filterField);
+    expect(screen.getByText("Indexed Tags")).toBeTruthy();
+    const menu = container.querySelector(".filter-builder__menu");
+    expect(menu?.textContent).toContain("Service");
+    expect(menu?.textContent).toContain("Min Duration");
+    expect(menu?.querySelector(".filter-builder__menu-ops")).toBeNull();
     expect(container.querySelector(".status-dot")).toBeNull();
     expect(container.querySelector(".data-table__head--left-cluster")).toBeTruthy();
     expect(container.querySelector(".data-table__body-inner--traces")).toBeTruthy();
@@ -82,7 +94,15 @@ describe("TracesTab row layout", () => {
     expect(container.querySelector(".data-table__td--duration .explorer-row__numeric")).toBeTruthy();
   });
 
-  it("filters traces by the dedicated status and trace id columns", () => {
+  it("filters traces by the dedicated status and trace id columns via the REST query endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { traceId: "trace-error-123", rootSpanName: "POST /payments", serviceName: "api-gateway", spanCount: 2, durationMs: 42, status: "error" },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
     const view = render(
       <TracesTab
         traces={[
@@ -95,15 +115,103 @@ describe("TracesTab row layout", () => {
       />,
     );
 
-    const input = view.getByPlaceholderText("Search operation, trace ID, service, or status");
+    fireEvent.change(view.getByLabelText("Filter field"), { target: { value: "status" } });
+    expect((view.getByRole("button", { name: "=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
+    fireEvent.change(view.getByLabelText("status value"), { target: { value: "error" } });
+    fireEvent.click(view.getByRole("button", { name: "Apply filter" }));
 
-    fireEvent.change(input, { target: { value: "error" } });
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/traces?filter%5Bstatus%5D%5Beq%5D=error", expect.any(Object));
     expect(view.getByText("POST /payments")).toBeTruthy();
     expect(view.queryByText("GET /health")).toBeNull();
+  });
 
-    fireEvent.change(input, { target: { value: "trace-ok-456" } });
-    expect(view.getByText("GET /health")).toBeTruthy();
-    expect(view.queryByText("POST /payments")).toBeNull();
+  it("uses descriptive value placeholders instead of example content", () => {
+    render(
+      <MetricsTab
+        metrics={[
+          {
+            name: "http.server.duration",
+            description: "Request duration",
+            unit: "ms",
+            type: "histogram",
+            serviceName: "checkout",
+            scopeName: "otel",
+            dataPointCount: 1,
+            dataPoints: [],
+          },
+        ]}
+        telemetryError={null}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), { target: { value: "Service" } });
+    expect(screen.getByLabelText("serviceName value").getAttribute("placeholder")).toBe("Enter Service");
+  });
+
+  it("uses semantic operator labels for min and max bound filters", () => {
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1234567890ab", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "error" },
+        ]}
+        telemetryError={null}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), { target: { value: "Min Duration" } });
+    expect(screen.getByRole("button", { name: ">=" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "<" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset filter draft" }));
+    fireEvent.change(screen.getByLabelText("Filter field"), { target: { value: "Max Span Count" } });
+    expect(screen.getByRole("button", { name: "<=" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: ">" })).toBeTruthy();
+  });
+
+  it("does not allow negative values in numeric filters", () => {
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1234567890ab", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "error" },
+        ]}
+        telemetryError={null}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), { target: { value: "Min Duration" } });
+    const input = screen.getByLabelText("minDurationMs value") as HTMLInputElement;
+
+    expect(input.getAttribute("min")).toBe("0");
+
+    fireEvent.change(input, { target: { value: "-5" } });
+    expect(input.value).toBe("");
+  });
+
+  it("uses whole-number inputs for count filters", () => {
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1234567890ab", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "error" },
+        ]}
+        telemetryError={null}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), { target: { value: "Min Span Count" } });
+    const input = screen.getByLabelText("minSpanCount value") as HTMLInputElement;
+
+    expect(input.getAttribute("step")).toBe("1");
+
+    fireEvent.change(input, { target: { value: "1.5" } });
+    expect(input.value).toBe("");
   });
 
   it("shows explicit labels for all trace statuses", () => {
@@ -178,6 +286,11 @@ describe("TracesTab row layout", () => {
     expect(css).toContain(".data-table__head--traces,\n.data-table__row--traces {\n  --table-columns: 220px 240px 140px 96px 88px 56px 1fr;\n}");
     expect(css).toContain(".data-table__row--traces {\n  align-items: center;\n  min-height: 34px;\n}");
     expect(css).toContain(".data-table__row--traces .data-table__td {\n  padding-top: 3px;\n  padding-bottom: 3px;\n}");
+    expect(css).toContain(".filter-builder {\n  position: relative;\n  display: flex;\n  flex: 0 1 auto;");
+    expect(css).toContain("width: min(100%, 860px);");
+    expect(css).toContain("max-width: min(100%, 860px);");
+    expect(css).toContain(".filter-builder__composer--selected {\n  flex: 0 1 auto;\n  width: min(100%, 640px);");
+    expect(css).toContain(".filter-builder__composer--selected .filter-builder__value {\n  flex: 0 1 320px;");
   });
 
   it("left-aligns stacked trace and metric values so content does not stretch across the cell", () => {

--- a/observer/client/src/traces/TracesTab.test.tsx
+++ b/observer/client/src/traces/TracesTab.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TracesTab } from "./TracesTab";
 
 vi.mock("@tanstack/react-virtual", () => ({
@@ -20,8 +20,22 @@ vi.mock("@tanstack/react-virtual", () => ({
   }),
 }));
 
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
 describe("TracesTab", () => {
-  it("filters traces from the compact explorer toolbar", () => {
+  it("filters traces from the compact explorer toolbar via the REST query endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { traceId: "trace-2", rootSpanName: "POST /charge", serviceName: "payments", spanCount: 5, durationMs: 88, status: "error" },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
     render(
       <TracesTab
         traces={[
@@ -34,11 +48,20 @@ describe("TracesTab", () => {
       />,
     );
 
-    fireEvent.change(screen.getByPlaceholderText("Search operation, trace ID, service, or status"), {
-      target: { value: "missing-service" },
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "rootSpanName" },
     });
+    expect((screen.getByRole("button", { name: "=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
+    fireEvent.change(screen.getByLabelText("rootSpanName value"), {
+      target: { value: "POST /charge" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
 
-    expect(screen.getByText("No traces match the current search.")).toBeTruthy();
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/traces?filter%5BrootSpanName%5D%5Beq%5D=POST+%2Fcharge", expect.any(Object));
+    expect(screen.getByText("POST /charge")).toBeTruthy();
+    expect(screen.queryByText("GET /orders")).toBeNull();
   });
 
   it("renders zero-duration traces as 0.0ms instead of dashes", () => {
@@ -56,6 +79,93 @@ describe("TracesTab", () => {
 
     expect(screen.getAllByText("0.0ms")).toHaveLength(2);
     expect(screen.queryByText("--")).toBeNull();
+  });
+
+  it("handles a null filtered trace response without crashing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => null,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "ok" },
+        ]}
+        telemetryError={null}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "serviceName" },
+    });
+    expect((screen.getByRole("button", { name: "=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
+    fireEvent.change(screen.getByLabelText("serviceName value"), {
+      target: { value: "missing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
+
+    await act(async () => {});
+
+    expect(screen.getByText("No traces match the current filters.")).toBeTruthy();
+  });
+
+  it("maps not-equal range filters to the complementary server-side range", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { traceId: "trace-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "ok" },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "ok" },
+        ]}
+        telemetryError={null}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "minDurationMs" },
+    });
+    expect((screen.getByRole("button", { name: ">=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "<" }));
+    fireEvent.change(screen.getByLabelText("minDurationMs value"), {
+      target: { value: "100" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
+
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/traces?range%5BdurationMs%5D%5Blt%5D=100", expect.any(Object));
+  });
+
+  it("shows bound-aware operators for max filters", () => {
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 3, durationMs: 42, status: "ok" },
+        ]}
+        telemetryError={null}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "maxDurationMs" },
+    });
+
+    expect((screen.getByRole("button", { name: "<=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
+    expect(screen.getByRole("button", { name: ">" })).toBeTruthy();
   });
 
   it("stacks the detail panel below the list on narrow widths", async () => {

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { TraceSummary, TraceDetail, ValidationFinding } from "../api/types";
-import { fetchTraceDetail } from "../api/client";
+import { fetchTraceDetail, fetchTraceFilterValues, fetchTraces, type TracesQuery } from "../api/client";
+import { FilterBar, type FilterClause, type FilterDefinition } from "../FilterBar";
 import { DetailPanel } from "../layout";
 import { TraceWaterfall } from "./TraceWaterfall";
 import { SpanDetailsPanel } from "./SpanDetailsPanel";
@@ -16,9 +17,92 @@ interface TracesTabProps {
   validationIndex: ValidationIndex;
 }
 
+const TRACE_FILTER_DEFINITIONS: FilterDefinition[] = [
+  { key: "maxDurationMs", label: "Max Duration", kind: "number", chipLabel: "Max Duration", operatorLabels: { eq: "<=", neq: ">" } },
+  { key: "maxSpanCount", label: "Max Span Count", kind: "number", chipLabel: "Max Span Count", operatorLabels: { eq: "<=", neq: ">" }, step: 1 },
+  { key: "minDurationMs", label: "Min Duration", kind: "number", chipLabel: "Min Duration", operatorLabels: { eq: ">=", neq: "<" } },
+  { key: "minSpanCount", label: "Min Span Count", kind: "number", chipLabel: "Min Span Count", operatorLabels: { eq: ">=", neq: "<" }, step: 1 },
+  { key: "rootSpanName", label: "Root Span", kind: "text" },
+  { key: "serviceName", label: "Service", kind: "text" },
+  {
+    key: "status",
+    label: "Status",
+    kind: "enum",
+    options: [
+      { label: "ok", value: "ok" },
+      { label: "error", value: "error" },
+      { label: "mixed", value: "mixed" },
+      { label: "unset", value: "unset" },
+    ],
+  },
+  { key: "traceId", label: "Trace ID", kind: "text" },
+];
+const TRACE_SUGGESTIBLE_FIELDS = new Set(["rootSpanName", "serviceName"]);
+
+function assignQueryFilter(query: TracesQuery, clause: FilterClause): void {
+  const targetKey = clause.op === "neq" ? "notFilters" : "filters";
+  query[targetKey] = { ...(query[targetKey] ?? {}), [clause.key]: clause.value };
+}
+
+function buildTracesQuery(clauses: FilterClause[]): TracesQuery {
+  const query: TracesQuery = {};
+  for (const clause of clauses) {
+    switch (clause.key) {
+      case "traceId":
+      case "rootSpanName":
+      case "serviceName":
+      case "status":
+        assignQueryFilter(query, clause);
+        break;
+      case "minSpanCount":
+        query.ranges = {
+          ...(query.ranges ?? {}),
+          spanCount: {
+            ...(query.ranges?.spanCount ?? {}),
+            [clause.op === "neq" ? "lt" : "gte"]: clause.value,
+          },
+        };
+        break;
+      case "maxSpanCount":
+        query.ranges = {
+          ...(query.ranges ?? {}),
+          spanCount: {
+            ...(query.ranges?.spanCount ?? {}),
+            [clause.op === "neq" ? "gt" : "lte"]: clause.value,
+          },
+        };
+        break;
+      case "minDurationMs":
+        query.ranges = {
+          ...(query.ranges ?? {}),
+          durationMs: {
+            ...(query.ranges?.durationMs ?? {}),
+            [clause.op === "neq" ? "lt" : "gte"]: clause.value,
+          },
+        };
+        break;
+      case "maxDurationMs":
+        query.ranges = {
+          ...(query.ranges ?? {}),
+          durationMs: {
+            ...(query.ranges?.durationMs ?? {}),
+            [clause.op === "neq" ? "gt" : "lte"]: clause.value,
+          },
+        };
+        break;
+      default:
+        break;
+    }
+  }
+  return query;
+}
+
 /** Traces tab with virtualized table and waterfall detail panel. */
 export function TracesTab({ traces, telemetryError, validationFindings, validationIndex }: TracesTabProps): React.ReactElement {
-  const [query, setQuery] = useState("");
+  const [clauses, setClauses] = useState<FilterClause[]>([]);
+  const [serverTraces, setServerTraces] = useState<TraceSummary[]>([]);
+  const [isFiltering, setIsFiltering] = useState(false);
+  const [filterError, setFilterError] = useState<string | null>(null);
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
   const [traceDetail, setTraceDetail] = useState<TraceDetail | null>(null);
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
@@ -29,6 +113,17 @@ export function TracesTab({ traces, telemetryError, validationFindings, validati
   const fetchIdRef = useRef(0);
   const traceDetailRef = useRef(traceDetail);
   traceDetailRef.current = traceDetail;
+  const activeQuery = useMemo(() => buildTracesQuery(clauses), [clauses]);
+  const suggestTraceValues = useCallback((fieldKey: string, prefix: string, signal: AbortSignal) => {
+    if (!TRACE_SUGGESTIBLE_FIELDS.has(fieldKey)) {
+      return Promise.resolve<string[]>([]);
+    }
+    return fetchTraceFilterValues(fieldKey, prefix, buildTracesQuery(clauses.filter((clause) => clause.key !== fieldKey)), signal);
+  }, [clauses]);
+  const hasActiveFilter = clauses.length > 0;
+  const liveTraces = Array.isArray(traces) ? traces : [];
+  const visibleTraces = hasActiveFilter ? serverTraces : liveTraces;
+
   const loadTraceDetail = useCallback(async (traceId: string, mode: "panel" | "background" = "panel") => {
     const fetchId = ++fetchIdRef.current;
     if (mode === "panel") {
@@ -76,21 +171,39 @@ export function TracesTab({ traces, telemetryError, validationFindings, validati
 
   useKeyboardShortcuts(shortcuts);
 
-  const filteredTraces = useMemo(() => {
-    const trimmedQuery = query.trim().toLowerCase();
-    if (!trimmedQuery) {
-      return traces;
+  useEffect(() => {
+    if (!hasActiveFilter) {
+      setServerTraces([]);
+      setIsFiltering(false);
+      setFilterError(null);
+      return;
     }
-    return traces.filter((trace) => {
-      const haystack = [trace.traceId, trace.serviceName ?? "", trace.rootSpanName, trace.status].join(" ").toLowerCase();
-      return haystack.includes(trimmedQuery);
-    });
-  }, [query, traces]);
+
+    const controller = new AbortController();
+    setIsFiltering(true);
+    fetchTraces(activeQuery, controller.signal)
+      .then((nextTraces) => {
+        if (controller.signal.aborted) return;
+        setServerTraces(nextTraces);
+        setFilterError(null);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setFilterError(error instanceof Error ? error.message : "Failed to filter traces");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsFiltering(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [activeQuery, hasActiveFilter, liveTraces]);
 
   // Invalidate detail when the selected trace is no longer in the list
   // (e.g., after live updates or store clear).
   // Re-fetch detail when the trace's span count changes (new spans arrived).
-  const selectedSummary = filteredTraces.find((t) => t.traceId === selectedTraceId) ?? traces.find((t) => t.traceId === selectedTraceId);
+  const selectedSummary = visibleTraces.find((t) => t.traceId === selectedTraceId) ?? liveTraces.find((t) => t.traceId === selectedTraceId);
   useEffect(() => {
     if (!selectedTraceId) return;
     if (!selectedSummary) {
@@ -107,17 +220,17 @@ export function TracesTab({ traces, telemetryError, validationFindings, validati
     if (traceDetailRef.current && selectedSummary.spanCount !== traceDetailRef.current.spanCount) {
       void loadTraceDetail(selectedTraceId, "background");
     }
-  }, [loadTraceDetail, selectedTraceId, selectedSummary, traces]);
+  }, [loadTraceDetail, selectedTraceId, selectedSummary, liveTraces]);
 
   useEffect(() => {
     if (!selectedTraceId) return;
-    if (!filteredTraces.some((trace) => trace.traceId === selectedTraceId)) {
+    if (!visibleTraces.some((trace) => trace.traceId === selectedTraceId)) {
       selectTrace(null);
     }
-  }, [filteredTraces, selectTrace, selectedTraceId]);
+  }, [selectTrace, selectedTraceId, visibleTraces]);
 
   const virtualizer = useVirtualizer({
-    count: filteredTraces.length,
+    count: visibleTraces.length,
     getScrollElement: () => tableRef.current,
     estimateSize: () => 36,
     overscan: 10,
@@ -138,26 +251,31 @@ export function TracesTab({ traces, telemetryError, validationFindings, validati
         className={`signal-view${hasDetail ? " signal-view--with-panel" : ""}`}
       >
         <div className="signal-view__content">
-          {traces.length > 0 ? (
+          {liveTraces.length > 0 || hasActiveFilter ? (
             <div className="explorer__toolbar explorer__toolbar--controls">
-              <input
-                className="explorer__input"
-                type="search"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search operation, trace ID, service, or status"
+              <FilterBar
+                definitions={TRACE_FILTER_DEFINITIONS}
+                clauses={clauses}
+                onChange={setClauses}
+                onSuggestValues={suggestTraceValues}
               />
             </div>
+          ) : null}
+
+          {filterError ? (
+            <p className="explorer__status explorer__status--error">{filterError}</p>
           ) : null}
 
           {telemetryError ? (
             <p className="explorer__status explorer__status--error">{telemetryError}</p>
           ) : null}
 
-          {traces.length === 0 ? (
+          {liveTraces.length === 0 && !hasActiveFilter ? (
             <p className="explorer__status explorer__status--empty">No traces received yet. Send OTLP telemetry to port 4318 to begin exploring.</p>
-          ) : filteredTraces.length === 0 ? (
-            <p className="explorer__status">No traces match the current search.</p>
+          ) : isFiltering && hasActiveFilter && visibleTraces.length === 0 ? (
+            <p className="explorer__status">Updating filtered traces...</p>
+          ) : visibleTraces.length === 0 ? (
+            <p className="explorer__status">No traces match the current filters.</p>
           ) : (
             <>
           <div className="data-table__head data-table__head--traces data-table__head--left-cluster">
@@ -172,7 +290,7 @@ export function TracesTab({ traces, telemetryError, validationFindings, validati
           <div className="data-table__body" ref={tableRef}>
             <div className="data-table__body-inner data-table__body-inner--traces" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
               {virtualizer.getVirtualItems().map((vi) => {
-                const t = filteredTraces[vi.index];
+                const t = visibleTraces[vi.index];
                 if (!t) return null;
                 const active = t.traceId === selectedTraceId;
                 return (

--- a/observer/internal/api/handler.go
+++ b/observer/internal/api/handler.go
@@ -58,9 +58,12 @@ func Register(mux *http.ServeMux, s *store.Store, params ...any) {
 	mux.HandleFunc("OPTIONS /api/", corsPreflightHandler())
 	mux.HandleFunc("GET /api/health", queryHealth(s, info))
 	mux.HandleFunc("GET /api/query/traces", queryTraces(s))
+	mux.HandleFunc("GET /api/query/traces/filter-values", queryTraceFilterValues(s))
 	mux.HandleFunc("GET /api/query/traces/{traceId}", queryTraceDetail(s))
 	mux.HandleFunc("GET /api/query/metrics", queryMetrics(s))
+	mux.HandleFunc("GET /api/query/metrics/filter-values", queryMetricFilterValues(s))
 	mux.HandleFunc("GET /api/query/logs", queryLogs(s))
+	mux.HandleFunc("GET /api/query/logs/filter-values", queryLogFilterValues(s))
 	mux.HandleFunc("GET /api/query/stats", queryStats(s))
 	mux.HandleFunc("GET /api/query/validation/summary", queryValidationStatus(validationService))
 	mux.HandleFunc("GET /api/query/validation/status", queryValidationStatus(validationService))
@@ -74,7 +77,7 @@ func Register(mux *http.ServeMux, s *store.Store, params ...any) {
 
 func queryTraces(s *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, s.QueryTraces(queryInt(r, "limit", 100)))
+		writeJSON(w, s.QueryTraceSummariesFiltered(traceSummaryFilterFromRequest(r)))
 	}
 }
 
@@ -92,13 +95,34 @@ func queryTraceDetail(s *store.Store) http.HandlerFunc {
 
 func queryMetrics(s *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, s.QueryMetrics(queryInt(r, "limit", 100)))
+		writeJSON(w, s.QueryMetricGroupsFiltered(metricGroupFilterFromRequest(r)))
+	}
+}
+
+func queryTraceFilterValues(s *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		field, prefix, limit := filterValueRequest(r)
+		writeJSON(w, s.QueryTraceSummaryFieldValues(field, prefix, traceSummaryFilterFromRequest(r), limit))
+	}
+}
+
+func queryMetricFilterValues(s *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		field, prefix, limit := filterValueRequest(r)
+		writeJSON(w, s.QueryMetricGroupFieldValues(field, prefix, metricGroupFilterFromRequest(r), limit))
+	}
+}
+
+func queryLogFilterValues(s *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		field, prefix, limit := filterValueRequest(r)
+		writeJSON(w, s.QueryLogRecordFieldValues(field, prefix, logRecordFilterFromRequest(r), limit))
 	}
 }
 
 func queryLogs(s *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, s.QueryLogs(queryInt(r, "limit", 100)))
+		writeJSON(w, s.QueryLogRecordsFiltered(logRecordFilterFromRequest(r)))
 	}
 }
 
@@ -247,6 +271,174 @@ func validationQueryFromRequest(r *http.Request) validator.Query {
 	}
 }
 
+func traceSummaryFilterFromRequest(r *http.Request) store.TraceSummaryFilter {
+	q := r.URL.Query()
+	filter := store.TraceSummaryFilter{
+		Query:               q.Get("query"),
+		TraceID:             queryEqString(q, "traceId", "traceId"),
+		ExcludeTraceID:      queryNeqString(q, "traceId"),
+		RootSpanName:        queryEqString(q, "rootSpanName", "rootSpanName"),
+		ExcludeRootSpanName: queryNeqString(q, "rootSpanName"),
+		ServiceName:         queryEqString(q, "serviceName", "serviceName"),
+		ExcludeServiceName:  queryNeqString(q, "serviceName"),
+		Status:              queryEqString(q, "status", "status"),
+		ExcludeStatus:       queryNeqString(q, "status"),
+		Limit:               queryInt(r, "limit", 100),
+		SpanPreviewCap:      8,
+	}
+	if n, ok := queryOptionalIntValues(q.Get("filter[spanCount][eq]"), q.Get("filter[spanCount]"), q.Get("spanCount")); ok {
+		filter.SpanCount = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[spanCount][gt]")); ok {
+		filter.SpanCountGT = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[spanCount][lt]")); ok {
+		filter.SpanCountLT = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[spanCount][gte]"), q.Get("minSpanCount")); ok {
+		filter.MinSpanCount = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[spanCount][lte]"), q.Get("maxSpanCount")); ok {
+		filter.MaxSpanCount = &n
+	}
+	if n, ok := queryOptionalFloatValues(q.Get("filter[durationMs][eq]"), q.Get("filter[durationMs]"), q.Get("durationMs")); ok {
+		filter.DurationMs = &n
+	}
+	if n, ok := queryOptionalFloatValues(q.Get("range[durationMs][gt]")); ok {
+		filter.DurationMsGT = &n
+	}
+	if n, ok := queryOptionalFloatValues(q.Get("range[durationMs][lt]")); ok {
+		filter.DurationMsLT = &n
+	}
+	if n, ok := queryOptionalFloatValues(q.Get("range[durationMs][gte]"), q.Get("minDurationMs")); ok {
+		filter.MinDurationMs = &n
+	}
+	if n, ok := queryOptionalFloatValues(q.Get("range[durationMs][lte]"), q.Get("maxDurationMs")); ok {
+		filter.MaxDurationMs = &n
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[from]")); ok {
+		filter.TimeFrom = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[to]")); ok {
+		filter.TimeTo = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[after]")); ok {
+		filter.TimeAfter = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[before]")); ok {
+		filter.TimeBefore = &ts
+	}
+	return filter
+}
+
+func metricGroupFilterFromRequest(r *http.Request) store.MetricGroupFilter {
+	q := r.URL.Query()
+	filter := store.MetricGroupFilter{
+		Query:             q.Get("query"),
+		MetricName:        queryEqString(q, "metricName", "metricName"),
+		ExcludeMetricName: queryNeqString(q, "metricName"),
+		DescriptionContains: firstNonEmpty(
+			q.Get("filter[descriptionContains][eq]"),
+			q.Get("filter[descriptionContains]"),
+			q.Get("description"),
+		),
+		ExcludeDescriptionContains: q.Get("filter[descriptionContains][neq]"),
+		Unit:                       queryEqString(q, "unit", "unit"),
+		ExcludeUnit:                queryNeqString(q, "unit"),
+		Type:                       queryEqString(q, "type", "type"),
+		ExcludeType:                queryNeqString(q, "type"),
+		ServiceName:                queryEqString(q, "serviceName", "serviceName"),
+		ExcludeServiceName:         queryNeqString(q, "serviceName"),
+		ScopeName:                  queryEqString(q, "scopeName", "scopeName"),
+		ExcludeScopeName:           queryNeqString(q, "scopeName"),
+		Limit:                      queryInt(r, "limit", 100),
+	}
+	if n, ok := queryOptionalIntValues(q.Get("filter[dataPointCount][eq]"), q.Get("filter[dataPointCount]"), q.Get("dataPointCount")); ok {
+		filter.DataPointCount = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[dataPointCount][gt]")); ok {
+		filter.DataPointCountGT = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[dataPointCount][lt]")); ok {
+		filter.DataPointCountLT = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[dataPointCount][gte]"), q.Get("minDataPointCount")); ok {
+		filter.MinDataPointCount = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[dataPointCount][lte]"), q.Get("maxDataPointCount")); ok {
+		filter.MaxDataPointCount = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("filter[seriesCount][eq]"), q.Get("filter[seriesCount]"), q.Get("seriesCount")); ok {
+		filter.SeriesCount = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[seriesCount][gt]")); ok {
+		filter.SeriesCountGT = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[seriesCount][lt]")); ok {
+		filter.SeriesCountLT = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[seriesCount][gte]"), q.Get("minSeriesCount")); ok {
+		filter.MinSeriesCount = &n
+	}
+	if n, ok := queryOptionalIntValues(q.Get("range[seriesCount][lte]"), q.Get("maxSeriesCount")); ok {
+		filter.MaxSeriesCount = &n
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[from]")); ok {
+		filter.TimeFrom = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[to]")); ok {
+		filter.TimeTo = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[after]")); ok {
+		filter.TimeAfter = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[before]")); ok {
+		filter.TimeBefore = &ts
+	}
+	return filter
+}
+
+func logRecordFilterFromRequest(r *http.Request) store.LogRecordFilter {
+	q := r.URL.Query()
+	filter := store.LogRecordFilter{
+		ServiceName:         queryEqString(q, "serviceName", "serviceName"),
+		ExcludeServiceName:  queryNeqString(q, "serviceName"),
+		SeverityText:        queryEqString(q, "severityText", "severityText"),
+		ExcludeSeverityText: queryNeqString(q, "severityText"),
+		BodyContains:        firstNonEmpty(q.Get("filter[bodyContains][eq]"), q.Get("filter[bodyContains]"), q.Get("body")),
+		ExcludeBodyContains: q.Get("filter[bodyContains][neq]"),
+		TraceID:             queryEqString(q, "traceId", "traceId"),
+		ExcludeTraceID:      queryNeqString(q, "traceId"),
+		SpanID:              queryEqString(q, "spanId", "spanId"),
+		ExcludeSpanID:       queryNeqString(q, "spanId"),
+		ScopeName:           queryEqString(q, "scopeName", "scopeName"),
+		ExcludeScopeName:    queryNeqString(q, "scopeName"),
+		Query:               q.Get("query"),
+		Limit:               queryInt(r, "limit", 100),
+	}
+	if n, ok := queryOptionalIntValues(q.Get("filter[severityNumber][eq]"), q.Get("filter[severityNumber]")); ok {
+		severity := int32(n)
+		filter.SeverityNumber = &severity
+	}
+	if n, ok := queryOptionalIntValues(q.Get("filter[severityNumber][neq]")); ok {
+		severity := int32(n)
+		filter.ExcludeSeverityNumber = &severity
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[from]")); ok {
+		filter.TimeFrom = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[to]")); ok {
+		filter.TimeTo = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[after]")); ok {
+		filter.TimeAfter = &ts
+	}
+	if ts, ok := queryOptionalTimeValues(q.Get("time[before]")); ok {
+		filter.TimeBefore = &ts
+	}
+	return filter
+}
+
 func validationQueryFromMap(args map[string]any) validator.Query {
 	return validator.Query{
 		ServiceName: stringArg(args, "serviceName"),
@@ -385,4 +577,112 @@ func queryInt(r *http.Request, key string, def int) int {
 		return maxLimit
 	}
 	return n
+}
+
+func queryOptionalInt(r *http.Request, key string) (int, bool) {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	if n > maxLimit {
+		return maxLimit, true
+	}
+	return n, true
+}
+
+func queryOptionalFloat(r *http.Request, key string) (float64, bool) {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseFloat(v, 64)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func queryOptionalIntValues(values ...string) (int, bool) {
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			return 0, false
+		}
+		if n > maxLimit {
+			return maxLimit, true
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+func queryOptionalFloatValues(values ...string) (float64, bool) {
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil || n < 0 {
+			return 0, false
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+func queryOptionalTimeValues(values ...string) (time.Time, bool) {
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return ts, true
+	}
+	return time.Time{}, false
+}
+
+func queryEqString(q map[string][]string, key string, legacyKeys ...string) string {
+	values := []string{
+		firstQueryValue(q, "filter["+key+"][eq]"),
+		firstQueryValue(q, "filter["+key+"]"),
+	}
+	for _, legacyKey := range legacyKeys {
+		values = append(values, firstQueryValue(q, legacyKey))
+	}
+	return firstNonEmpty(values...)
+}
+
+func queryNeqString(q map[string][]string, key string) string {
+	return firstQueryValue(q, "filter["+key+"][neq]")
+}
+
+func filterValueRequest(r *http.Request) (field, prefix string, limit int) {
+	q := r.URL.Query()
+	return q.Get("field"), q.Get("prefix"), queryInt(r, "limit", 20)
+}
+
+func firstQueryValue(q map[string][]string, key string) string {
+	if values, ok := q[key]; ok && len(values) > 0 {
+		return values[0]
+	}
+	return ""
 }

--- a/observer/internal/api/handler_test.go
+++ b/observer/internal/api/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -169,6 +170,376 @@ func TestQueryTracesWithLimit(t *testing.T) {
 
 	if len(traces) != 2 {
 		t.Errorf("expected 2 traces with limit=2, got %d", len(traces))
+	}
+}
+
+func TestQueryTracesWithSummaryFieldFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	trace1 := store.Span{
+		TraceID:    "trace-1",
+		SpanID:     "span-1",
+		Name:       "GET /orders",
+		Kind:       "internal",
+		StartTime:  now,
+		EndTime:    now.Add(10 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "OK"},
+		Resource:   store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace2Root := store.Span{
+		TraceID:    "trace-2",
+		SpanID:     "span-1",
+		Name:       "POST /checkout",
+		Kind:       "internal",
+		StartTime:  now.Add(100 * time.Millisecond),
+		EndTime:    now.Add(130 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "ERROR"},
+		Resource:   store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace2Child := store.Span{
+		TraceID:      "trace-2",
+		SpanID:       "span-2",
+		ParentSpanID: "span-1",
+		Name:         "db.write",
+		Kind:         "client",
+		StartTime:    now.Add(110 * time.Millisecond),
+		EndTime:      now.Add(115 * time.Millisecond),
+		Status:       store.SpanStatus{Code: "ERROR"},
+		Resource:     store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:        store.Scope{Name: "test-scope"},
+		Attributes:   map[string]any{},
+	}
+	s.AddSpansForConnection("", []store.Span{trace1})
+	s.AddSpansForConnection("", []store.Span{trace2Root, trace2Child})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"filter[traceId]":        {"trace-2"},
+		"filter[rootSpanName]":   {"post /checkout"},
+		"filter[serviceName]":    {"PAYMENTS"},
+		"filter[status]":         {"error"},
+		"range[spanCount][gte]":  {"2"},
+		"range[spanCount][lte]":  {"2"},
+		"range[durationMs][gte]": {"30"},
+		"range[durationMs][lte]": {"30"},
+		"time[from]":             {now.Add(90 * time.Millisecond).UTC().Format(time.RFC3339Nano)},
+		"time[to]":               {now.Add(140 * time.Millisecond).UTC().Format(time.RFC3339Nano)},
+	}
+	resp := mustGet(t, server.URL+"/api/query/traces?"+query.Encode())
+	defer resp.Body.Close()
+
+	var traces []store.TraceSummary
+	if err := json.NewDecoder(resp.Body).Decode(&traces); err != nil {
+		t.Fatalf("decode traces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 filtered trace, got %d", len(traces))
+	}
+	if traces[0].TraceID != "trace-2" {
+		t.Fatalf("expected trace-2, got %s", traces[0].TraceID)
+	}
+}
+
+func TestQueryTraceFilterValues(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+	s.AddSpansForConnection("", []store.Span{
+		{
+			TraceID:   "trace-1",
+			SpanID:    "span-1",
+			Name:      "GET /orders",
+			Kind:      "internal",
+			StartTime: now,
+			EndTime:   now.Add(10 * time.Millisecond),
+			Status:    store.SpanStatus{Code: "OK"},
+			Resource:  store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:     store.Scope{Name: "test-scope"},
+		},
+		{
+			TraceID:   "trace-2",
+			SpanID:    "span-2",
+			Name:      "POST /charge",
+			Kind:      "internal",
+			StartTime: now.Add(time.Second),
+			EndTime:   now.Add(time.Second + 10*time.Millisecond),
+			Status:    store.SpanStatus{Code: "ERROR"},
+			Resource:  store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:     store.Scope{Name: "test-scope"},
+		},
+	})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/traces/filter-values?field=serviceName&prefix=pa")
+	defer resp.Body.Close()
+
+	var values []string
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &values); err != nil {
+		t.Fatalf("unmarshal values: %v", err)
+	}
+	if len(values) != 1 || values[0] != "payments" {
+		t.Fatalf("expected [payments], got %v", values)
+	}
+}
+
+func TestQueryTracesWithServerSideQueryFilter(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	trace1 := store.Span{
+		TraceID:    "trace-1",
+		SpanID:     "span-1",
+		Name:       "GET /orders",
+		Kind:       "internal",
+		StartTime:  now,
+		EndTime:    now.Add(10 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "OK"},
+		Resource:   store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace2 := store.Span{
+		TraceID:    "trace-2",
+		SpanID:     "span-1",
+		Name:       "POST /charge",
+		Kind:       "internal",
+		StartTime:  now.Add(100 * time.Millisecond),
+		EndTime:    now.Add(120 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "ERROR"},
+		Resource:   store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	s.AddSpansForConnection("", []store.Span{trace1, trace2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/traces?query=charge")
+	defer resp.Body.Close()
+
+	var traces []store.TraceSummary
+	if err := json.NewDecoder(resp.Body).Decode(&traces); err != nil {
+		t.Fatalf("decode traces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 query-filtered trace, got %d", len(traces))
+	}
+	if traces[0].TraceID != "trace-2" {
+		t.Fatalf("expected trace-2, got %s", traces[0].TraceID)
+	}
+}
+
+func TestQueryTracesWithNegatedSummaryFieldFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	trace1 := store.Span{
+		TraceID:    "trace-1",
+		SpanID:     "span-1",
+		Name:       "GET /orders",
+		Kind:       "internal",
+		StartTime:  now,
+		EndTime:    now.Add(10 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "OK"},
+		Resource:   store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace2 := store.Span{
+		TraceID:    "trace-2",
+		SpanID:     "span-1",
+		Name:       "POST /checkout",
+		Kind:       "internal",
+		StartTime:  now.Add(100 * time.Millisecond),
+		EndTime:    now.Add(130 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "ERROR"},
+		Resource:   store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	s.AddSpansForConnection("", []store.Span{trace1, trace2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"filter[serviceName][neq]": {"checkout"},
+		"filter[status][neq]":      {"ok"},
+	}
+	resp := mustGet(t, server.URL+"/api/query/traces?"+query.Encode())
+	defer resp.Body.Close()
+
+	var traces []store.TraceSummary
+	if err := json.NewDecoder(resp.Body).Decode(&traces); err != nil {
+		t.Fatalf("decode traces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 negated trace, got %d", len(traces))
+	}
+	if traces[0].TraceID != "trace-2" {
+		t.Fatalf("expected trace-2, got %s", traces[0].TraceID)
+	}
+}
+
+func TestQueryTracesWithComplementaryRangeAndTimeFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	trace1 := store.Span{
+		TraceID:    "trace-1",
+		SpanID:     "span-1",
+		Name:       "GET /orders",
+		Kind:       "internal",
+		StartTime:  now,
+		EndTime:    now.Add(20 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "OK"},
+		Resource:   store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace2 := store.Span{
+		TraceID:    "trace-2",
+		SpanID:     "span-1",
+		Name:       "POST /checkout",
+		Kind:       "internal",
+		StartTime:  now.Add(100 * time.Millisecond),
+		EndTime:    now.Add(180 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "ERROR"},
+		Resource:   store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	s.AddSpansForConnection("", []store.Span{trace1, trace2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"range[durationMs][lt]": {"50"},
+		"time[before]":          {now.Add(50 * time.Millisecond).UTC().Format(time.RFC3339Nano)},
+	}
+	resp := mustGet(t, server.URL+"/api/query/traces?"+query.Encode())
+	defer resp.Body.Close()
+
+	var traces []store.TraceSummary
+	if err := json.NewDecoder(resp.Body).Decode(&traces); err != nil {
+		t.Fatalf("decode traces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 complementary trace, got %d", len(traces))
+	}
+	if traces[0].TraceID != "trace-1" {
+		t.Fatalf("expected trace-1, got %s", traces[0].TraceID)
+	}
+}
+
+func TestQueryTracesWithSummaryRangeFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	trace1 := store.Span{
+		TraceID:    "trace-1",
+		SpanID:     "span-1",
+		Name:       "trace-one",
+		Kind:       "internal",
+		StartTime:  now,
+		EndTime:    now.Add(10 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "OK"},
+		Resource:   store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace2Root := store.Span{
+		TraceID:    "trace-2",
+		SpanID:     "span-1",
+		Name:       "trace-two",
+		Kind:       "internal",
+		StartTime:  now.Add(100 * time.Millisecond),
+		EndTime:    now.Add(130 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "OK"},
+		Resource:   store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace2Child := store.Span{
+		TraceID:      "trace-2",
+		SpanID:       "span-2",
+		ParentSpanID: "span-1",
+		Name:         "child",
+		Kind:         "client",
+		StartTime:    now.Add(110 * time.Millisecond),
+		EndTime:      now.Add(115 * time.Millisecond),
+		Status:       store.SpanStatus{Code: "OK"},
+		Resource:     store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:        store.Scope{Name: "test-scope"},
+		Attributes:   map[string]any{},
+	}
+	trace3Root := store.Span{
+		TraceID:    "trace-3",
+		SpanID:     "span-1",
+		Name:       "trace-three",
+		Kind:       "internal",
+		StartTime:  now.Add(200 * time.Millisecond),
+		EndTime:    now.Add(260 * time.Millisecond),
+		Status:     store.SpanStatus{Code: "OK"},
+		Resource:   store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:      store.Scope{Name: "test-scope"},
+		Attributes: map[string]any{},
+	}
+	trace3Child := store.Span{
+		TraceID:      "trace-3",
+		SpanID:       "span-2",
+		ParentSpanID: "span-1",
+		Name:         "child",
+		Kind:         "client",
+		StartTime:    now.Add(210 * time.Millisecond),
+		EndTime:      now.Add(220 * time.Millisecond),
+		Status:       store.SpanStatus{Code: "OK"},
+		Resource:     store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:        store.Scope{Name: "test-scope"},
+		Attributes:   map[string]any{},
+	}
+	s.AddSpansForConnection("", []store.Span{trace1})
+	s.AddSpansForConnection("", []store.Span{trace2Root, trace2Child})
+	s.AddSpansForConnection("", []store.Span{trace3Root, trace3Child})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/traces?minSpanCount=2&maxSpanCount=2&minDurationMs=20&maxDurationMs=40")
+	defer resp.Body.Close()
+
+	var traces []store.TraceSummary
+	if err := json.NewDecoder(resp.Body).Decode(&traces); err != nil {
+		t.Fatalf("decode traces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 ranged trace, got %d", len(traces))
+	}
+	if traces[0].TraceID != "trace-2" {
+		t.Fatalf("expected trace-2, got %s", traces[0].TraceID)
 	}
 }
 
@@ -854,6 +1225,161 @@ func TestQueryMetricsSuccess(t *testing.T) {
 	}
 }
 
+func TestQueryMetricsWithServerSideFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	m1 := store.MetricDataPoint{
+		Name:        "http.server.duration",
+		Description: "Request duration",
+		Unit:        "ms",
+		Type:        "histogram",
+		Timestamp:   now,
+		Value:       42,
+		Resource:    store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:       store.Scope{Name: "otel.http"},
+		Attributes:  map[string]any{},
+	}
+	m2 := store.MetricDataPoint{
+		Name:        "db.client.connections.usage",
+		Description: "Open connections",
+		Unit:        "connections",
+		Type:        "gauge",
+		Timestamp:   now.Add(100 * time.Millisecond),
+		Value:       5,
+		Resource:    store.Resource{ServiceName: "db", Attributes: map[string]any{}},
+		Scope:       store.Scope{Name: "otel.db"},
+		Attributes:  map[string]any{},
+	}
+	s.AddMetricsForConnection("", []store.MetricDataPoint{m1, m2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"filter[descriptionContains]": {"duration"},
+		"filter[metricName]":          {"http.server.duration"},
+		"filter[serviceName]":         {"CHECKOUT"},
+		"filter[type]":                {"histogram"},
+		"filter[unit]":                {"ms"},
+		"range[dataPointCount][gte]":  {"1"},
+		"range[dataPointCount][lte]":  {"1"},
+		"time[from]":                  {now.Add(-time.Second).UTC().Format(time.RFC3339Nano)},
+		"time[to]":                    {now.Add(time.Second).UTC().Format(time.RFC3339Nano)},
+	}
+	resp := mustGet(t, server.URL+"/api/query/metrics?"+query.Encode())
+	defer resp.Body.Close()
+
+	var groups []store.MetricGroup
+	if err := json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+		t.Fatalf("decode metrics: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 filtered metric group, got %d", len(groups))
+	}
+	if groups[0].Name != "http.server.duration" {
+		t.Fatalf("expected http.server.duration, got %s", groups[0].Name)
+	}
+}
+
+func TestQueryMetricFilterValues(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+	s.AddMetricsForConnection("", []store.MetricDataPoint{
+		{
+			Name:        "http.server.duration",
+			Description: "Request duration",
+			Unit:        "ms",
+			Type:        "histogram",
+			Timestamp:   now,
+			Resource:    store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:       store.Scope{Name: "otel.http"},
+		},
+		{
+			Name:        "db.client.connections.usage",
+			Description: "Connections",
+			Unit:        "connections",
+			Type:        "gauge",
+			Timestamp:   now.Add(time.Second),
+			Resource:    store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:       store.Scope{Name: "otel.db"},
+		},
+	})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/metrics/filter-values?field=scopeName&filter%5BserviceName%5D%5Beq%5D=payments")
+	defer resp.Body.Close()
+
+	var values []string
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &values); err != nil {
+		t.Fatalf("unmarshal values: %v", err)
+	}
+	if len(values) != 1 || values[0] != "otel.db" {
+		t.Fatalf("expected [otel.db], got %v", values)
+	}
+}
+
+func TestQueryMetricsWithNegatedServerSideFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	s.AddMetricsForConnection("", []store.MetricDataPoint{
+		{
+			Name:        "http.server.duration",
+			Description: "Request duration",
+			Type:        "histogram",
+			Unit:        "ms",
+			Timestamp:   now,
+			Value:       12,
+			Resource:    store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:       store.Scope{Name: "otel.http"},
+			Attributes:  map[string]any{},
+		},
+		{
+			Name:        "db.client.connections.usage",
+			Description: "Open connections",
+			Type:        "gauge",
+			Unit:        "connections",
+			Timestamp:   now.Add(100 * time.Millisecond),
+			Value:       4,
+			Resource:    store.Resource{ServiceName: "database", Attributes: map[string]any{}},
+			Scope:       store.Scope{Name: "otel.sql"},
+			Attributes:  map[string]any{},
+		},
+	})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"filter[serviceName][neq]":         {"checkout"},
+		"filter[type][neq]":                {"histogram"},
+		"filter[descriptionContains][neq]": {"request"},
+	}
+	resp := mustGet(t, server.URL+"/api/query/metrics?"+query.Encode())
+	defer resp.Body.Close()
+
+	var metrics []store.MetricGroup
+	if err := json.NewDecoder(resp.Body).Decode(&metrics); err != nil {
+		t.Fatalf("decode metrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 negated metric, got %d", len(metrics))
+	}
+	if metrics[0].Name != "db.client.connections.usage" {
+		t.Fatalf("expected db.client.connections.usage, got %s", metrics[0].Name)
+	}
+}
+
 func TestQueryHealthReturnsServerMetadataAndEndpoints(t *testing.T) {
 	s := store.New()
 	s.SetEndpoints(store.Endpoints{
@@ -976,6 +1502,199 @@ func TestQueryLogsSuccess(t *testing.T) {
 
 	if logs[0].Body != "test log message" {
 		t.Errorf("expected 'test log message', got %s", logs[0].Body)
+	}
+}
+
+func TestQueryLogsWithServerSideFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	log1 := store.LogRecord{
+		Timestamp:    now,
+		Body:         "checkout started",
+		SeverityText: "INFO",
+		TraceID:      "trace-1",
+		Resource:     store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:        store.Scope{Name: "test-scope"},
+		Attributes:   map[string]any{},
+	}
+	log2 := store.LogRecord{
+		Timestamp:    now.Add(100 * time.Millisecond),
+		Body:         "payment failed",
+		SeverityText: "ERROR",
+		TraceID:      "trace-2",
+		SpanID:       "span-2",
+		Resource:     store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:        store.Scope{Name: "test-scope"},
+		Attributes:   map[string]any{},
+	}
+	s.AddLogsForConnection("", []store.LogRecord{log1, log2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"filter[severityText]": {"error"},
+		"filter[serviceName]":  {"PAYMENTS"},
+		"filter[traceId]":      {"trace-2"},
+		"filter[spanId]":       {"span-2"},
+		"filter[scopeName]":    {"test-scope"},
+		"filter[bodyContains]": {"failed"},
+		"time[from]":           {now.Add(50 * time.Millisecond).UTC().Format(time.RFC3339Nano)},
+		"time[to]":             {now.Add(150 * time.Millisecond).UTC().Format(time.RFC3339Nano)},
+	}
+	resp := mustGet(t, server.URL+"/api/query/logs?"+query.Encode())
+	defer resp.Body.Close()
+
+	var logs []store.LogRecord
+	if err := json.NewDecoder(resp.Body).Decode(&logs); err != nil {
+		t.Fatalf("decode logs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 filtered log, got %d", len(logs))
+	}
+	if logs[0].Body != "payment failed" {
+		t.Fatalf("expected payment failed, got %s", logs[0].Body)
+	}
+}
+
+func TestQueryLogFilterValues(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+	s.AddLogsForConnection("", []store.LogRecord{
+		{
+			ID:        "1",
+			Timestamp: now,
+			Body:      "checkout started",
+			Resource:  store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:     store.Scope{Name: "checkout.logger"},
+		},
+		{
+			ID:        "2",
+			Timestamp: now.Add(time.Second),
+			Body:      "payment failed",
+			Resource:  store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:     store.Scope{Name: "payments.logger"},
+		},
+	})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/logs/filter-values?field=scopeName&filter%5BserviceName%5D%5Beq%5D=payments")
+	defer resp.Body.Close()
+
+	var values []string
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &values); err != nil {
+		t.Fatalf("unmarshal values: %v", err)
+	}
+	if len(values) != 1 || values[0] != "payments.logger" {
+		t.Fatalf("expected [payments.logger], got %v", values)
+	}
+}
+
+func TestQueryLogsWithNegatedServerSideFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	log1 := store.LogRecord{
+		Timestamp:      now,
+		Body:           "checkout started",
+		SeverityNumber: 9,
+		SeverityText:   "INFO",
+		TraceID:        "trace-1",
+		Resource:       store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:          store.Scope{Name: "test-scope"},
+		Attributes:     map[string]any{},
+	}
+	log2 := store.LogRecord{
+		Timestamp:      now.Add(100 * time.Millisecond),
+		Body:           "payment failed",
+		SeverityNumber: 17,
+		SeverityText:   "ERROR",
+		TraceID:        "trace-2",
+		SpanID:         "span-2",
+		Resource:       store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:          store.Scope{Name: "test-scope"},
+		Attributes:     map[string]any{},
+	}
+	s.AddLogsForConnection("", []store.LogRecord{log1, log2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"filter[serviceName][neq]":    {"checkout"},
+		"filter[severityText][neq]":   {"info"},
+		"filter[severityNumber][neq]": {"9"},
+		"filter[bodyContains][neq]":   {"started"},
+	}
+	resp := mustGet(t, server.URL+"/api/query/logs?"+query.Encode())
+	defer resp.Body.Close()
+
+	var logs []store.LogRecord
+	if err := json.NewDecoder(resp.Body).Decode(&logs); err != nil {
+		t.Fatalf("decode logs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 negated log, got %d", len(logs))
+	}
+	if logs[0].Body != "payment failed" {
+		t.Fatalf("expected payment failed, got %s", logs[0].Body)
+	}
+}
+
+func TestQueryLogsWithComplementaryTimeFilters(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	log1 := store.LogRecord{
+		Timestamp:      now,
+		Body:           "checkout started",
+		SeverityNumber: 9,
+		SeverityText:   "INFO",
+		Resource:       store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:          store.Scope{Name: "test-scope"},
+		Attributes:     map[string]any{},
+	}
+	log2 := store.LogRecord{
+		Timestamp:      now.Add(100 * time.Millisecond),
+		Body:           "payment failed",
+		SeverityNumber: 17,
+		SeverityText:   "ERROR",
+		Resource:       store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:          store.Scope{Name: "test-scope"},
+		Attributes:     map[string]any{},
+	}
+	s.AddLogsForConnection("", []store.LogRecord{log1, log2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"time[before]": {now.Add(50 * time.Millisecond).UTC().Format(time.RFC3339Nano)},
+	}
+	resp := mustGet(t, server.URL+"/api/query/logs?"+query.Encode())
+	defer resp.Body.Close()
+
+	var logs []store.LogRecord
+	if err := json.NewDecoder(resp.Body).Decode(&logs); err != nil {
+		t.Fatalf("decode logs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 complementary log, got %d", len(logs))
+	}
+	if logs[0].Body != "checkout started" {
+		t.Fatalf("expected checkout started, got %s", logs[0].Body)
 	}
 }
 
@@ -1239,6 +1958,36 @@ func TestQueryIntDirect(t *testing.T) {
 				t.Errorf("queryInt(%q, %q, %d) = %d, want %d", tc.url, tc.key, tc.def, got, tc.expected)
 			}
 		})
+	}
+}
+
+func TestQueryOptionalNumericDirect(t *testing.T) {
+	intReq, err := http.NewRequest("GET", "/api?spanCount=7&minSpanCount=-1&bad=abc", nil)
+	if err != nil {
+		t.Fatalf("failed to create int request: %v", err)
+	}
+	if got, ok := queryOptionalInt(intReq, "spanCount"); !ok || got != 7 {
+		t.Fatalf("queryOptionalInt(spanCount) = (%d, %t), want (7, true)", got, ok)
+	}
+	if _, ok := queryOptionalInt(intReq, "minSpanCount"); ok {
+		t.Fatalf("expected negative optional int to be ignored")
+	}
+	if _, ok := queryOptionalInt(intReq, "missing"); ok {
+		t.Fatalf("expected missing optional int to be absent")
+	}
+
+	floatReq, err := http.NewRequest("GET", "/api?durationMs=30.5&minDurationMs=-1&bad=abc", nil)
+	if err != nil {
+		t.Fatalf("failed to create float request: %v", err)
+	}
+	if got, ok := queryOptionalFloat(floatReq, "durationMs"); !ok || got != 30.5 {
+		t.Fatalf("queryOptionalFloat(durationMs) = (%f, %t), want (30.5, true)", got, ok)
+	}
+	if _, ok := queryOptionalFloat(floatReq, "minDurationMs"); ok {
+		t.Fatalf("expected negative optional float to be ignored")
+	}
+	if _, ok := queryOptionalFloat(floatReq, "missing"); ok {
+		t.Fatalf("expected missing optional float to be absent")
 	}
 }
 

--- a/observer/internal/store/store.go
+++ b/observer/internal/store/store.go
@@ -135,6 +135,31 @@ type LogRecord struct {
 	ownerConnID string `json:"-"`
 }
 
+// LogRecordFilter narrows log queries using explicit fields, optional time
+// bounds, and a legacy free-text substring query over the summary columns.
+type LogRecordFilter struct {
+	ServiceName           string
+	ExcludeServiceName    string
+	SeverityNumber        *int32
+	ExcludeSeverityNumber *int32
+	SeverityText          string
+	ExcludeSeverityText   string
+	BodyContains          string
+	ExcludeBodyContains   string
+	TraceID               string
+	ExcludeTraceID        string
+	SpanID                string
+	ExcludeSpanID         string
+	ScopeName             string
+	ExcludeScopeName      string
+	TimeAfter             *time.Time
+	TimeBefore            *time.Time
+	TimeFrom              *time.Time
+	TimeTo                *time.Time
+	Query                 string
+	Limit                 int
+}
+
 // TraceSummary represents a summary of a single trace.
 type TraceSummary struct {
 	TraceID      string        `json:"traceId"`
@@ -144,6 +169,36 @@ type TraceSummary struct {
 	DurationMs   float64       `json:"durationMs"`
 	Status       string        `json:"status"`
 	Spans        []SpanPreview `json:"spans,omitempty"`
+}
+
+// TraceSummaryFilter narrows trace summary queries using fields already present
+// on TraceSummary plus optional numeric and time ranges.
+type TraceSummaryFilter struct {
+	Query               string
+	TraceID             string
+	ExcludeTraceID      string
+	RootSpanName        string
+	ExcludeRootSpanName string
+	ServiceName         string
+	ExcludeServiceName  string
+	Status              string
+	ExcludeStatus       string
+	SpanCount           *int
+	SpanCountGT         *int
+	SpanCountLT         *int
+	MinSpanCount        *int
+	MaxSpanCount        *int
+	DurationMs          *float64
+	DurationMsGT        *float64
+	DurationMsLT        *float64
+	TimeAfter           *time.Time
+	TimeBefore          *time.Time
+	MinDurationMs       *float64
+	MaxDurationMs       *float64
+	TimeFrom            *time.Time
+	TimeTo              *time.Time
+	Limit               int
+	SpanPreviewCap      int
 }
 
 // SpanPreview represents a preview of a span in a trace.
@@ -177,6 +232,40 @@ type MetricGroup struct {
 	SeriesCount    int               `json:"seriesCount,omitempty"`
 	DataPointCount int               `json:"dataPointCount"`
 	DataPoints     []MetricDataPoint `json:"dataPoints,omitempty"`
+}
+
+// MetricGroupFilter narrows metric group queries using exact summary fields,
+// optional count and time ranges, and a legacy free-text query over the visible
+// metric columns.
+type MetricGroupFilter struct {
+	Query                      string
+	MetricName                 string
+	ExcludeMetricName          string
+	DescriptionContains        string
+	ExcludeDescriptionContains string
+	Unit                       string
+	ExcludeUnit                string
+	Type                       string
+	ExcludeType                string
+	ServiceName                string
+	ExcludeServiceName         string
+	ScopeName                  string
+	ExcludeScopeName           string
+	DataPointCount             *int
+	DataPointCountGT           *int
+	DataPointCountLT           *int
+	MinDataPointCount          *int
+	MaxDataPointCount          *int
+	SeriesCount                *int
+	SeriesCountGT              *int
+	SeriesCountLT              *int
+	TimeAfter                  *time.Time
+	TimeBefore                 *time.Time
+	MinSeriesCount             *int
+	MaxSeriesCount             *int
+	TimeFrom                   *time.Time
+	TimeTo                     *time.Time
+	Limit                      int
 }
 
 // Stats represents aggregated statistics about stored telemetry.
@@ -554,8 +643,17 @@ func (s *Store) checkSessionReset() bool {
 
 // QueryTraces returns the latest traces, newest first, up to the specified limit.
 func (s *Store) QueryTraces(limit int) []TraceSummary {
-	if limit <= 0 {
-		limit = 100
+	return s.QueryTraceSummariesFiltered(TraceSummaryFilter{Limit: limit, SpanPreviewCap: 8})
+}
+
+// QueryTraceSummariesFiltered returns trace summaries filtered by fields already
+// surfaced on TraceSummary plus optional numeric ranges.
+func (s *Store) QueryTraceSummariesFiltered(filter TraceSummaryFilter) []TraceSummary {
+	if filter.Limit <= 0 {
+		filter.Limit = 100
+	}
+	if filter.SpanPreviewCap <= 0 {
+		filter.SpanPreviewCap = 8
 	}
 
 	s.mu.RLock()
@@ -563,36 +661,50 @@ func (s *Store) QueryTraces(limit int) []TraceSummary {
 	s.mu.RUnlock()
 
 	grouped := groupSpansByTrace(allSpans)
+	if len(grouped) == 0 {
+		return []TraceSummary{}
+	}
 
-	var results []TraceSummary
+	startTimes := make(map[string]time.Time, len(grouped))
+	results := make([]TraceSummary, 0, minInt(len(grouped), filter.Limit))
 	for traceID, spans := range grouped {
+		startTime := getTraceStartTime(spans)
+		if filter.TimeAfter != nil && !startTime.After(*filter.TimeAfter) {
+			continue
+		}
+		if filter.TimeBefore != nil && !startTime.Before(*filter.TimeBefore) {
+			continue
+		}
+		if filter.TimeFrom != nil && startTime.Before(*filter.TimeFrom) {
+			continue
+		}
+		if filter.TimeTo != nil && startTime.After(*filter.TimeTo) {
+			continue
+		}
 		root := findRootSpan(spans)
 		dur := computeTraceDuration(spans)
-		previews := makeSpanPreviews(spans, 8)
-
-		results = append(results, TraceSummary{
+		summary := TraceSummary{
 			TraceID:      traceID,
 			RootSpanName: root.Name,
 			ServiceName:  root.Resource.ServiceName,
 			SpanCount:    len(spans),
 			DurationMs:   dur,
 			Status:       computeTraceStatus(spans),
-			Spans:        previews,
-		})
-	}
-
-	// Precompute start times to avoid repeated map lookups during sort.
-	startTimes := make(map[string]time.Time, len(grouped))
-	for traceID, spans := range grouped {
-		startTimes[traceID] = getTraceStartTime(spans)
+			Spans:        makeSpanPreviews(spans, filter.SpanPreviewCap),
+		}
+		if !matchesTraceSummaryFilter(summary, filter) {
+			continue
+		}
+		startTimes[traceID] = startTime
+		results = append(results, summary)
 	}
 
 	sort.Slice(results, func(i, j int) bool {
 		return startTimes[results[i].TraceID].After(startTimes[results[j].TraceID])
 	})
 
-	if len(results) > limit {
-		results = results[:limit]
+	if len(results) > filter.Limit {
+		results = results[:filter.Limit]
 	}
 	return results
 }
@@ -638,8 +750,14 @@ func (s *Store) Trace(traceID string, eventLimit int) *TraceDetail {
 // The UI path returns a bounded rolling window per series plus explicit
 // series cardinality so live WebSocket payloads stay controlled.
 func (s *Store) QueryMetrics(limit int) []MetricGroup {
-	if limit <= 0 {
-		limit = 100
+	return s.QueryMetricGroupsFiltered(MetricGroupFilter{Limit: limit})
+}
+
+// QueryMetricGroupsFiltered returns metric groups using the same bounded
+// preview shape as QueryMetrics, but with server-side filtering applied.
+func (s *Store) QueryMetricGroupsFiltered(filter MetricGroupFilter) []MetricGroup {
+	if filter.Limit <= 0 {
+		filter.Limit = 100
 	}
 
 	s.mu.RLock()
@@ -656,8 +774,19 @@ func (s *Store) QueryMetrics(limit int) []MetricGroup {
 	groups := make(map[groupKey]*groupAccumulator)
 	latestByGroup := make(map[groupKey]time.Time)
 
-	// Keep a bounded rolling window for each series in chronological order.
 	for _, dp := range points {
+		if filter.TimeAfter != nil && !dp.Timestamp.After(*filter.TimeAfter) {
+			continue
+		}
+		if filter.TimeBefore != nil && !dp.Timestamp.Before(*filter.TimeBefore) {
+			continue
+		}
+		if filter.TimeFrom != nil && dp.Timestamp.Before(*filter.TimeFrom) {
+			continue
+		}
+		if filter.TimeTo != nil && dp.Timestamp.After(*filter.TimeTo) {
+			continue
+		}
 		key := groupKey{dp.Name, dp.Resource.ServiceName, dp.Scope.Name}
 		acc, exists := groups[key]
 		if !exists {
@@ -695,11 +824,7 @@ func (s *Store) QueryMetrics(limit int) []MetricGroup {
 		return latestByGroup[groupOrder[i]].After(latestByGroup[groupOrder[j]])
 	})
 
-	if len(groupOrder) > limit {
-		groupOrder = groupOrder[:limit]
-	}
-
-	results := make([]MetricGroup, 0, len(groupOrder))
+	results := make([]MetricGroup, 0, minInt(len(groupOrder), filter.Limit))
 	for _, key := range groupOrder {
 		acc := groups[key]
 		group := *acc.group
@@ -714,25 +839,114 @@ func (s *Store) QueryMetrics(limit int) []MetricGroup {
 			}
 			return group.DataPoints[i].Timestamp.Before(group.DataPoints[j].Timestamp)
 		})
+		if !matchesMetricGroupFilter(group, filter) {
+			continue
+		}
 		results = append(results, group)
+		if len(results) >= filter.Limit {
+			break
+		}
 	}
 	return results
 }
 
 // QueryLogs returns the latest log records, newest first, up to the specified limit.
 func (s *Store) QueryLogs(limit int) []LogRecord {
-	if limit <= 0 {
-		limit = 100
+	return s.QueryLogRecordsFiltered(LogRecordFilter{Limit: limit})
+}
+
+func (s *Store) QueryTraceSummaryFieldValues(field, prefix string, filter TraceSummaryFilter, limit int) []string {
+	s.mu.RLock()
+	count := s.spans.size()
+	s.mu.RUnlock()
+	if count == 0 {
+		return []string{}
+	}
+	filter = clearTraceSummaryFieldFilter(filter, field)
+	filter.Limit = count
+	filter.SpanPreviewCap = 1
+	summaries := s.QueryTraceSummariesFiltered(filter)
+	return collectSuggestionValues(limit, prefix, summaries, func(summary TraceSummary) string {
+		switch field {
+		case "rootSpanName":
+			return summary.RootSpanName
+		case "serviceName":
+			return summary.ServiceName
+		default:
+			return ""
+		}
+	})
+}
+
+func (s *Store) QueryMetricGroupFieldValues(field, prefix string, filter MetricGroupFilter, limit int) []string {
+	s.mu.RLock()
+	count := s.metrics.size()
+	s.mu.RUnlock()
+	if count == 0 {
+		return []string{}
+	}
+	filter = clearMetricGroupFieldFilter(filter, field)
+	filter.Limit = count
+	groups := s.QueryMetricGroupsFiltered(filter)
+	return collectSuggestionValues(limit, prefix, groups, func(group MetricGroup) string {
+		switch field {
+		case "metricName":
+			return group.Name
+		case "serviceName":
+			return group.ServiceName
+		case "scopeName":
+			return group.ScopeName
+		case "unit":
+			return group.Unit
+		default:
+			return ""
+		}
+	})
+}
+
+func (s *Store) QueryLogRecordFieldValues(field, prefix string, filter LogRecordFilter, limit int) []string {
+	s.mu.RLock()
+	count := s.logs.size()
+	s.mu.RUnlock()
+	if count == 0 {
+		return []string{}
+	}
+	filter = clearLogRecordFieldFilter(filter, field)
+	filter.Limit = count
+	records := s.QueryLogRecordsFiltered(filter)
+	return collectSuggestionValues(limit, prefix, records, func(record LogRecord) string {
+		switch field {
+		case "serviceName":
+			return record.Resource.ServiceName
+		case "scopeName":
+			return record.Scope.Name
+		default:
+			return ""
+		}
+	})
+}
+
+// QueryLogRecordsFiltered returns log records filtered by exact fields plus
+// an optional free-text query over the summary columns shown in the logs table.
+func (s *Store) QueryLogRecordsFiltered(filter LogRecordFilter) []LogRecord {
+	if filter.Limit <= 0 {
+		filter.Limit = 100
 	}
 
 	s.mu.RLock()
 	all := s.logs.snapshot()
 	s.mu.RUnlock()
+	if len(all) == 0 {
+		return []LogRecord{}
+	}
 
-	// Return newest first.
-	var results []LogRecord
-	for i := len(all) - 1; i >= 0 && len(results) < limit; i-- {
-		results = append(results, all[i])
+	results := make([]LogRecord, 0, minInt(len(all), filter.Limit))
+	for i := len(all) - 1; i >= 0 && len(results) < filter.Limit; i-- {
+		lr := all[i]
+		if !matchesLogRecordFilter(lr, filter) {
+			continue
+		}
+		results = append(results, lr)
 	}
 	return results
 }
@@ -993,32 +1207,13 @@ func (s *Store) QueryMetricsFiltered(metricName, serviceName, scopeName, metricT
 
 // QueryLogsFiltered is used by MCP tools that need filtering.
 func (s *Store) QueryLogsFiltered(serviceName, severityText, body, traceID string, limit int) []LogRecord {
-	if limit <= 0 {
-		limit = 50
-	}
-
-	s.mu.RLock()
-	all := s.logs.snapshot()
-	s.mu.RUnlock()
-
-	var results []LogRecord
-	for i := len(all) - 1; i >= 0 && len(results) < limit; i-- {
-		lr := all[i]
-		if serviceName != "" && !strings.EqualFold(lr.Resource.ServiceName, serviceName) {
-			continue
-		}
-		if severityText != "" && !strings.EqualFold(lr.SeverityText, severityText) {
-			continue
-		}
-		if body != "" && !strings.Contains(strings.ToLower(lr.Body), strings.ToLower(body)) {
-			continue
-		}
-		if traceID != "" && lr.TraceID != traceID {
-			continue
-		}
-		results = append(results, lr)
-	}
-	return results
+	return s.QueryLogRecordsFiltered(LogRecordFilter{
+		ServiceName:  serviceName,
+		SeverityText: severityText,
+		BodyContains: body,
+		TraceID:      traceID,
+		Limit:        limit,
+	})
 }
 
 func groupSpansByTrace(spans []Span) map[string][]Span {
@@ -1102,6 +1297,229 @@ func anySpanNameMatches(spans []Span, name string) bool {
 	return false
 }
 
+func matchesTraceSummaryFilter(summary TraceSummary, filter TraceSummaryFilter) bool {
+	if filter.Query != "" {
+		haystack := strings.ToLower(strings.Join([]string{
+			summary.TraceID,
+			summary.RootSpanName,
+			summary.ServiceName,
+			summary.Status,
+		}, " "))
+		if !strings.Contains(haystack, strings.ToLower(filter.Query)) {
+			return false
+		}
+	}
+	if filter.TraceID != "" && !strings.EqualFold(summary.TraceID, filter.TraceID) {
+		return false
+	}
+	if filter.ExcludeTraceID != "" && strings.EqualFold(summary.TraceID, filter.ExcludeTraceID) {
+		return false
+	}
+	if filter.RootSpanName != "" && !strings.EqualFold(summary.RootSpanName, filter.RootSpanName) {
+		return false
+	}
+	if filter.ExcludeRootSpanName != "" && strings.EqualFold(summary.RootSpanName, filter.ExcludeRootSpanName) {
+		return false
+	}
+	if filter.ServiceName != "" && !strings.EqualFold(summary.ServiceName, filter.ServiceName) {
+		return false
+	}
+	if filter.ExcludeServiceName != "" && strings.EqualFold(summary.ServiceName, filter.ExcludeServiceName) {
+		return false
+	}
+	if filter.Status != "" && !strings.EqualFold(summary.Status, filter.Status) {
+		return false
+	}
+	if filter.ExcludeStatus != "" && strings.EqualFold(summary.Status, filter.ExcludeStatus) {
+		return false
+	}
+	if filter.SpanCount != nil && summary.SpanCount != *filter.SpanCount {
+		return false
+	}
+	if filter.SpanCountGT != nil && summary.SpanCount <= *filter.SpanCountGT {
+		return false
+	}
+	if filter.SpanCountLT != nil && summary.SpanCount >= *filter.SpanCountLT {
+		return false
+	}
+	if filter.MinSpanCount != nil && summary.SpanCount < *filter.MinSpanCount {
+		return false
+	}
+	if filter.MaxSpanCount != nil && summary.SpanCount > *filter.MaxSpanCount {
+		return false
+	}
+	if filter.DurationMs != nil && summary.DurationMs != *filter.DurationMs {
+		return false
+	}
+	if filter.DurationMsGT != nil && summary.DurationMs <= *filter.DurationMsGT {
+		return false
+	}
+	if filter.DurationMsLT != nil && summary.DurationMs >= *filter.DurationMsLT {
+		return false
+	}
+	if filter.MinDurationMs != nil && summary.DurationMs < *filter.MinDurationMs {
+		return false
+	}
+	if filter.MaxDurationMs != nil && summary.DurationMs > *filter.MaxDurationMs {
+		return false
+	}
+	return true
+}
+
+func matchesMetricGroupFilter(group MetricGroup, filter MetricGroupFilter) bool {
+	if filter.MetricName != "" && !strings.EqualFold(group.Name, filter.MetricName) {
+		return false
+	}
+	if filter.ExcludeMetricName != "" && strings.EqualFold(group.Name, filter.ExcludeMetricName) {
+		return false
+	}
+	if filter.DescriptionContains != "" && !strings.Contains(strings.ToLower(group.Description), strings.ToLower(filter.DescriptionContains)) {
+		return false
+	}
+	if filter.ExcludeDescriptionContains != "" && strings.Contains(strings.ToLower(group.Description), strings.ToLower(filter.ExcludeDescriptionContains)) {
+		return false
+	}
+	if filter.Unit != "" && !strings.EqualFold(group.Unit, filter.Unit) {
+		return false
+	}
+	if filter.ExcludeUnit != "" && strings.EqualFold(group.Unit, filter.ExcludeUnit) {
+		return false
+	}
+	if filter.Type != "" && !strings.EqualFold(group.Type, filter.Type) {
+		return false
+	}
+	if filter.ExcludeType != "" && strings.EqualFold(group.Type, filter.ExcludeType) {
+		return false
+	}
+	if filter.ServiceName != "" && !strings.EqualFold(group.ServiceName, filter.ServiceName) {
+		return false
+	}
+	if filter.ExcludeServiceName != "" && strings.EqualFold(group.ServiceName, filter.ExcludeServiceName) {
+		return false
+	}
+	if filter.ScopeName != "" && !strings.EqualFold(group.ScopeName, filter.ScopeName) {
+		return false
+	}
+	if filter.ExcludeScopeName != "" && strings.EqualFold(group.ScopeName, filter.ExcludeScopeName) {
+		return false
+	}
+	if filter.DataPointCount != nil && group.DataPointCount != *filter.DataPointCount {
+		return false
+	}
+	if filter.DataPointCountGT != nil && group.DataPointCount <= *filter.DataPointCountGT {
+		return false
+	}
+	if filter.DataPointCountLT != nil && group.DataPointCount >= *filter.DataPointCountLT {
+		return false
+	}
+	if filter.MinDataPointCount != nil && group.DataPointCount < *filter.MinDataPointCount {
+		return false
+	}
+	if filter.MaxDataPointCount != nil && group.DataPointCount > *filter.MaxDataPointCount {
+		return false
+	}
+	if filter.SeriesCount != nil && group.SeriesCount != *filter.SeriesCount {
+		return false
+	}
+	if filter.SeriesCountGT != nil && group.SeriesCount <= *filter.SeriesCountGT {
+		return false
+	}
+	if filter.SeriesCountLT != nil && group.SeriesCount >= *filter.SeriesCountLT {
+		return false
+	}
+	if filter.MinSeriesCount != nil && group.SeriesCount < *filter.MinSeriesCount {
+		return false
+	}
+	if filter.MaxSeriesCount != nil && group.SeriesCount > *filter.MaxSeriesCount {
+		return false
+	}
+	if filter.Query != "" {
+		haystack := strings.ToLower(strings.Join([]string{
+			group.Name,
+			group.Description,
+			group.Unit,
+			group.Type,
+			group.ServiceName,
+			group.ScopeName,
+		}, " "))
+		if !strings.Contains(haystack, strings.ToLower(filter.Query)) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesLogRecordFilter(record LogRecord, filter LogRecordFilter) bool {
+	if filter.ServiceName != "" && !strings.EqualFold(record.Resource.ServiceName, filter.ServiceName) {
+		return false
+	}
+	if filter.ExcludeServiceName != "" && strings.EqualFold(record.Resource.ServiceName, filter.ExcludeServiceName) {
+		return false
+	}
+	if filter.SeverityNumber != nil && record.SeverityNumber != *filter.SeverityNumber {
+		return false
+	}
+	if filter.ExcludeSeverityNumber != nil && record.SeverityNumber == *filter.ExcludeSeverityNumber {
+		return false
+	}
+	if filter.SeverityText != "" && !strings.EqualFold(record.SeverityText, filter.SeverityText) {
+		return false
+	}
+	if filter.ExcludeSeverityText != "" && strings.EqualFold(record.SeverityText, filter.ExcludeSeverityText) {
+		return false
+	}
+	if filter.BodyContains != "" && !strings.Contains(strings.ToLower(record.Body), strings.ToLower(filter.BodyContains)) {
+		return false
+	}
+	if filter.ExcludeBodyContains != "" && strings.Contains(strings.ToLower(record.Body), strings.ToLower(filter.ExcludeBodyContains)) {
+		return false
+	}
+	if filter.TraceID != "" && record.TraceID != filter.TraceID {
+		return false
+	}
+	if filter.ExcludeTraceID != "" && record.TraceID == filter.ExcludeTraceID {
+		return false
+	}
+	if filter.SpanID != "" && record.SpanID != filter.SpanID {
+		return false
+	}
+	if filter.ExcludeSpanID != "" && record.SpanID == filter.ExcludeSpanID {
+		return false
+	}
+	if filter.ScopeName != "" && !strings.EqualFold(record.Scope.Name, filter.ScopeName) {
+		return false
+	}
+	if filter.ExcludeScopeName != "" && strings.EqualFold(record.Scope.Name, filter.ExcludeScopeName) {
+		return false
+	}
+	if filter.TimeFrom != nil && record.Timestamp.Before(*filter.TimeFrom) {
+		return false
+	}
+	if filter.TimeTo != nil && record.Timestamp.After(*filter.TimeTo) {
+		return false
+	}
+	if filter.TimeAfter != nil && !record.Timestamp.After(*filter.TimeAfter) {
+		return false
+	}
+	if filter.TimeBefore != nil && !record.Timestamp.Before(*filter.TimeBefore) {
+		return false
+	}
+	if filter.Query != "" {
+		haystack := strings.ToLower(strings.Join([]string{
+			record.SeverityText,
+			record.Body,
+			record.Resource.ServiceName,
+			record.TraceID,
+			record.SpanID,
+			record.Scope.Name,
+		}, " "))
+		if !strings.Contains(haystack, strings.ToLower(filter.Query)) {
+			return false
+		}
+	}
+	return true
+}
+
 func makeSpanPreviews(spans []Span, limit int) []SpanPreview {
 	n := len(spans)
 	if n > limit {
@@ -1118,6 +1536,106 @@ func makeSpanPreviews(spans []Span, limit int) []SpanPreview {
 		}
 	}
 	return previews
+}
+
+func clearTraceSummaryFieldFilter(filter TraceSummaryFilter, field string) TraceSummaryFilter {
+	switch field {
+	case "traceId":
+		filter.TraceID = ""
+		filter.ExcludeTraceID = ""
+	case "rootSpanName":
+		filter.RootSpanName = ""
+		filter.ExcludeRootSpanName = ""
+	case "serviceName":
+		filter.ServiceName = ""
+		filter.ExcludeServiceName = ""
+	case "status":
+		filter.Status = ""
+		filter.ExcludeStatus = ""
+	}
+	return filter
+}
+
+func clearMetricGroupFieldFilter(filter MetricGroupFilter, field string) MetricGroupFilter {
+	switch field {
+	case "metricName":
+		filter.MetricName = ""
+		filter.ExcludeMetricName = ""
+	case "descriptionContains":
+		filter.DescriptionContains = ""
+		filter.ExcludeDescriptionContains = ""
+	case "unit":
+		filter.Unit = ""
+		filter.ExcludeUnit = ""
+	case "type":
+		filter.Type = ""
+		filter.ExcludeType = ""
+	case "serviceName":
+		filter.ServiceName = ""
+		filter.ExcludeServiceName = ""
+	case "scopeName":
+		filter.ScopeName = ""
+		filter.ExcludeScopeName = ""
+	}
+	return filter
+}
+
+func clearLogRecordFieldFilter(filter LogRecordFilter, field string) LogRecordFilter {
+	switch field {
+	case "serviceName":
+		filter.ServiceName = ""
+		filter.ExcludeServiceName = ""
+	case "severityNumber":
+		filter.SeverityNumber = nil
+		filter.ExcludeSeverityNumber = nil
+	case "severityText":
+		filter.SeverityText = ""
+		filter.ExcludeSeverityText = ""
+	case "bodyContains":
+		filter.BodyContains = ""
+		filter.ExcludeBodyContains = ""
+	case "traceId":
+		filter.TraceID = ""
+		filter.ExcludeTraceID = ""
+	case "spanId":
+		filter.SpanID = ""
+		filter.ExcludeSpanID = ""
+	case "scopeName":
+		filter.ScopeName = ""
+		filter.ExcludeScopeName = ""
+	}
+	return filter
+}
+
+func collectSuggestionValues[T any](limit int, prefix string, values []T, project func(T) string) []string {
+	if limit <= 0 {
+		limit = 20
+	}
+	normalizedPrefix := strings.ToLower(strings.TrimSpace(prefix))
+	seen := make(map[string]struct{}, len(values))
+	results := make([]string, 0, minInt(len(values), limit))
+	for _, value := range values {
+		candidate := strings.TrimSpace(project(value))
+		if candidate == "" {
+			continue
+		}
+		if normalizedPrefix != "" && !strings.HasPrefix(strings.ToLower(candidate), normalizedPrefix) {
+			continue
+		}
+		key := strings.ToLower(candidate)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		results = append(results, candidate)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return strings.ToLower(results[i]) < strings.ToLower(results[j])
+	})
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results
 }
 
 func normalizeMetricType(t string) string {

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -70,6 +70,10 @@ func newTestLog(body string, timestamp time.Time) LogRecord {
 	}
 }
 
+func timePointer(ts time.Time) *time.Time {
+	return &ts
+}
+
 // ============================================================================
 // Ring Buffer Tests
 // ============================================================================
@@ -1185,6 +1189,159 @@ func TestQueryTracesFiltered_RespectsLimit(t *testing.T) {
 	}
 }
 
+func TestQueryTraceSummariesFiltered_FilterBySummaryFields(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	trace1Root := newTestSpan("trace-1", "span-1", "GET /orders", now, 10)
+	trace1Root.Resource.ServiceName = "checkout"
+	trace1Root.Status.Code = "OK"
+
+	trace2Root := newTestSpan("trace-2", "span-1", "POST /checkout", now.Add(100*time.Millisecond), 30)
+	trace2Root.Resource.ServiceName = "payments"
+	trace2Root.Status.Code = "ERROR"
+	trace2Child := newTestSpan("trace-2", "span-2", "db.write", now.Add(110*time.Millisecond), 5)
+	trace2Child.ParentSpanID = "span-1"
+	trace2Child.Resource.ServiceName = "payments"
+	trace2Child.Status.Code = "ERROR"
+
+	s.AddSpansForConnection("conn-1", []Span{trace1Root})
+	s.AddSpansForConnection("conn-1", []Span{trace2Root, trace2Child})
+
+	spanCount := 2
+	minDurationMs := 25.0
+	maxDurationMs := 35.0
+	results := s.QueryTraceSummariesFiltered(TraceSummaryFilter{
+		TraceID:        "trace-2",
+		RootSpanName:   "post /checkout",
+		ServiceName:    "PAYMENTS",
+		Status:         "error",
+		SpanCount:      &spanCount,
+		MinDurationMs:  &minDurationMs,
+		MaxDurationMs:  &maxDurationMs,
+		Limit:          10,
+		SpanPreviewCap: 5,
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 filtered result, got %d", len(results))
+	}
+	if results[0].TraceID != "trace-2" {
+		t.Fatalf("expected trace-2, got %s", results[0].TraceID)
+	}
+	if results[0].SpanCount != 2 {
+		t.Fatalf("expected span count 2, got %d", results[0].SpanCount)
+	}
+}
+
+func TestQueryTraceSummariesFiltered_FilterByQuery(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	trace1 := newTestSpan("trace-1", "span-1", "GET /orders", now, 10)
+	trace1.Resource.ServiceName = "checkout"
+
+	trace2 := newTestSpan("trace-2", "span-1", "POST /charge", now.Add(100*time.Millisecond), 20)
+	trace2.Resource.ServiceName = "payments"
+	trace2.Status.Code = "ERROR"
+
+	s.AddSpansForConnection("conn-1", []Span{trace1, trace2})
+
+	results := s.QueryTraceSummariesFiltered(TraceSummaryFilter{
+		Query: "charge",
+		Limit: 10,
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 query-matched result, got %d", len(results))
+	}
+	if results[0].TraceID != "trace-2" {
+		t.Fatalf("expected trace-2, got %s", results[0].TraceID)
+	}
+}
+
+func TestQueryTraceSummariesFiltered_EmptyReturnsEmptySlice(t *testing.T) {
+	s := New()
+	results := s.QueryTraceSummariesFiltered(TraceSummaryFilter{Limit: 10})
+	if results == nil {
+		t.Fatalf("expected empty slice, got nil")
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestQueryTraceSummariesFiltered_FilterBySummaryRanges(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	trace1 := newTestSpan("trace-1", "span-1", "root-a", now, 10)
+	trace2Root := newTestSpan("trace-2", "span-1", "root-b", now.Add(100*time.Millisecond), 30)
+	trace2Child := newTestSpan("trace-2", "span-2", "child-b", now.Add(110*time.Millisecond), 5)
+	trace2Child.ParentSpanID = "span-1"
+	trace3Root := newTestSpan("trace-3", "span-1", "root-c", now.Add(200*time.Millisecond), 60)
+	trace3Child := newTestSpan("trace-3", "span-2", "child-c", now.Add(210*time.Millisecond), 10)
+	trace3Child.ParentSpanID = "span-1"
+
+	s.AddSpansForConnection("conn-1", []Span{trace1})
+	s.AddSpansForConnection("conn-1", []Span{trace2Root, trace2Child})
+	s.AddSpansForConnection("conn-1", []Span{trace3Root, trace3Child})
+
+	minSpanCount := 2
+	maxSpanCount := 2
+	minDurationMs := 20.0
+	maxDurationMs := 40.0
+	timeFrom := now.Add(50 * time.Millisecond)
+	timeTo := now.Add(150 * time.Millisecond)
+	results := s.QueryTraceSummariesFiltered(TraceSummaryFilter{
+		MinSpanCount:  &minSpanCount,
+		MaxSpanCount:  &maxSpanCount,
+		MinDurationMs: &minDurationMs,
+		MaxDurationMs: &maxDurationMs,
+		TimeFrom:      &timeFrom,
+		TimeTo:        &timeTo,
+		Limit:         10,
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 ranged result, got %d", len(results))
+	}
+	if results[0].TraceID != "trace-2" {
+		t.Fatalf("expected trace-2, got %s", results[0].TraceID)
+	}
+}
+
+func TestQueryTraceSummaryFieldValues(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.AddSpansForConnection("", []Span{
+		{
+			TraceID:   "trace-1",
+			SpanID:    "span-1",
+			Name:      "GET /orders",
+			Kind:      "internal",
+			StartTime: now,
+			EndTime:   now.Add(10 * time.Millisecond),
+			Status:    SpanStatus{Code: "OK"},
+			Resource:  Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:     Scope{Name: "otel"},
+		},
+		{
+			TraceID:   "trace-2",
+			SpanID:    "span-2",
+			Name:      "POST /charge",
+			Kind:      "internal",
+			StartTime: now.Add(time.Second),
+			EndTime:   now.Add(time.Second + 5*time.Millisecond),
+			Status:    SpanStatus{Code: "ERROR"},
+			Resource:  Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:     Scope{Name: "otel"},
+		},
+	})
+
+	values := s.QueryTraceSummaryFieldValues("serviceName", "pa", TraceSummaryFilter{}, 10)
+	if len(values) != 1 || values[0] != "payments" {
+		t.Fatalf("expected [payments], got %v", values)
+	}
+}
+
 // ============================================================================
 // QueryMetricsFiltered Tests
 // ============================================================================
@@ -1289,6 +1446,123 @@ func TestQueryMetricsFiltered_RespectsLimit(t *testing.T) {
 	}
 }
 
+func TestQueryMetricGroupsFiltered_FilterByQueryAndSummaryFields(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	m1 := newTestMetric("http.server.duration", 12, now)
+	m1.Description = "Request duration"
+	m1.Unit = "ms"
+	m1.Type = "histogram"
+	m1.Resource.ServiceName = "checkout"
+	m1.Scope.Name = "otel.http"
+
+	m1b := newTestMetric("http.server.duration", 15, now.Add(10*time.Millisecond))
+	m1b.Description = "Request duration"
+	m1b.Unit = "ms"
+	m1b.Type = "histogram"
+	m1b.Resource.ServiceName = "checkout"
+	m1b.Scope.Name = "otel.http"
+	m1b.Attributes["http.method"] = "GET"
+
+	m2 := newTestMetric("db.client.connections.usage", 5, now.Add(100*time.Millisecond))
+	m2.Description = "Open connections"
+	m2.Unit = "connections"
+	m2.Type = "gauge"
+	m2.Resource.ServiceName = "db"
+	m2.Scope.Name = "otel.db"
+
+	s.AddMetricsForConnection("conn-1", []MetricDataPoint{m1, m1b, m2})
+
+	dataPointCount := 2
+	seriesCount := 2
+	results := s.QueryMetricGroupsFiltered(MetricGroupFilter{
+		Query:          "duration",
+		MetricName:     "http.server.duration",
+		ServiceName:    "CHECKOUT",
+		ScopeName:      "otel.http",
+		Type:           "histogram",
+		Unit:           "ms",
+		DataPointCount: &dataPointCount,
+		SeriesCount:    &seriesCount,
+		Limit:          10,
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 filtered metric group, got %d", len(results))
+	}
+	if results[0].Name != "http.server.duration" {
+		t.Fatalf("expected http.server.duration, got %s", results[0].Name)
+	}
+	if results[0].SeriesCount != 2 {
+		t.Fatalf("expected series count 2, got %d", results[0].SeriesCount)
+	}
+}
+
+func TestQueryMetricGroupsFiltered_FilterByCountRanges(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	oneSeries := newTestMetric("metric.one", 1, now)
+	oneSeries.Resource.ServiceName = "svc"
+	twoSeriesA := newTestMetric("metric.two", 2, now.Add(100*time.Millisecond))
+	twoSeriesA.Resource.ServiceName = "svc"
+	twoSeriesB := newTestMetric("metric.two", 3, now.Add(110*time.Millisecond))
+	twoSeriesB.Resource.ServiceName = "svc"
+	twoSeriesB.Attributes["dim"] = "b"
+
+	s.AddMetricsForConnection("conn-1", []MetricDataPoint{oneSeries, twoSeriesA, twoSeriesB})
+
+	minSeriesCount := 2
+	maxSeriesCount := 2
+	minDataPointCount := 2
+	maxDataPointCount := 2
+	timeFrom := now.Add(50 * time.Millisecond)
+	timeTo := now.Add(150 * time.Millisecond)
+	results := s.QueryMetricGroupsFiltered(MetricGroupFilter{
+		MinSeriesCount:    &minSeriesCount,
+		MaxSeriesCount:    &maxSeriesCount,
+		MinDataPointCount: &minDataPointCount,
+		MaxDataPointCount: &maxDataPointCount,
+		TimeFrom:          &timeFrom,
+		TimeTo:            &timeTo,
+		Limit:             10,
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 ranged metric group, got %d", len(results))
+	}
+	if results[0].Name != "metric.two" {
+		t.Fatalf("expected metric.two, got %s", results[0].Name)
+	}
+}
+
+func TestQueryMetricGroupFieldValues(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.AddMetricsForConnection("", []MetricDataPoint{
+		{
+			Name:      "http.server.duration",
+			Unit:      "ms",
+			Type:      "histogram",
+			Timestamp: now,
+			Resource:  Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:     Scope{Name: "otel.http"},
+		},
+		{
+			Name:      "db.client.connections.usage",
+			Unit:      "connections",
+			Type:      "gauge",
+			Timestamp: now.Add(time.Second),
+			Resource:  Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:     Scope{Name: "otel.db"},
+		},
+	})
+
+	values := s.QueryMetricGroupFieldValues("scopeName", "", MetricGroupFilter{ServiceName: "payments"}, 10)
+	if len(values) != 1 || values[0] != "otel.db" {
+		t.Fatalf("expected [otel.db], got %v", values)
+	}
+}
+
 // ============================================================================
 // QueryLogsFiltered Tests
 // ============================================================================
@@ -1390,6 +1664,79 @@ func TestQueryLogsFiltered_RespectsLimit(t *testing.T) {
 	results := s.QueryLogsFiltered("", "", "", "", 5)
 	if len(results) != 5 {
 		t.Errorf("expected 5 results, got %d", len(results))
+	}
+}
+
+func TestQueryLogRecordsFiltered_FilterByQueryAndSummaryFields(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	log1 := newTestLog("checkout started", now)
+	log1.SeverityText = "INFO"
+	log1.Resource.ServiceName = "checkout"
+	log1.TraceID = "trace-1"
+
+	log2 := newTestLog("payment failed", now.Add(100*time.Millisecond))
+	log2.SeverityText = "ERROR"
+	log2.Resource.ServiceName = "payments"
+	log2.TraceID = "trace-2"
+	log2.SpanID = "span-2"
+
+	s.AddLogsForConnection("conn-1", []LogRecord{log1, log2})
+
+	results := s.QueryLogRecordsFiltered(LogRecordFilter{
+		ServiceName:  "PAYMENTS",
+		SeverityText: "error",
+		TraceID:      "trace-2",
+		SpanID:       "span-2",
+		ScopeName:    "test-scope",
+		Query:        "failed",
+		TimeFrom:     timePointer(now.Add(50 * time.Millisecond)),
+		TimeTo:       timePointer(now.Add(150 * time.Millisecond)),
+		Limit:        10,
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 filtered log record, got %d", len(results))
+	}
+	if results[0].Body != "payment failed" {
+		t.Fatalf("expected payment failed, got %s", results[0].Body)
+	}
+}
+
+func TestQueryLogRecordsFiltered_EmptyReturnsEmptySlice(t *testing.T) {
+	s := New()
+	results := s.QueryLogRecordsFiltered(LogRecordFilter{Limit: 10})
+	if results == nil {
+		t.Fatalf("expected empty slice, got nil")
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestQueryLogRecordFieldValues(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.AddLogsForConnection("", []LogRecord{
+		{
+			ID:        "1",
+			Timestamp: now,
+			Body:      "checkout started",
+			Resource:  Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:     Scope{Name: "checkout.logger"},
+		},
+		{
+			ID:        "2",
+			Timestamp: now.Add(time.Second),
+			Body:      "payment failed",
+			Resource:  Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:     Scope{Name: "payments.logger"},
+		},
+	})
+
+	values := s.QueryLogRecordFieldValues("scopeName", "pay", LogRecordFilter{}, 10)
+	if len(values) != 1 || values[0] != "payments.logger" {
+		t.Fatalf("expected [payments.logger], got %v", values)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add explicit server-side filters for traces, metrics, and logs
- add a shared filter composer UI across the explorer tabs
- narrow the visible filter surface to the supported product fields
- add low-cardinality value suggestions for selected exact-match filters
- keep the change scoped to observer filter behavior only

## What Changed
- traces now support explicit filters for root span, service, status, trace ID, duration bounds, and span-count bounds
- metrics now support explicit filters for metric, service, and scope
- logs now support explicit filters for service, scope, severity, severity number, trace ID, span ID, and plain-text message search
- the old generic client-side search/filtering path was replaced with REST-backed filtering
- filter suggestions are derived from the retained in-memory snapshot for low-cardinality text fields only
- the shared filter composer uses exact-match operators for discrete fields and range operators for min/max numeric fields
- negative values are blocked for numeric filter inputs
- logs severity display now dedupes identical normalized/text values such as `ERROR (ERROR)` to `ERROR`

## Verification
- `go test ./internal/store ./internal/api`
- `npm test -- src/logs/LogsTab.test.tsx src/metrics/MetricsTab.test.tsx src/traces/TracesTab.test.tsx src/traces/TracesTab.style.test.tsx`
- `npm run typecheck`
- `npm run package`
- `npm run build:vsix`
- installed the generated VSIX with `code --install-extension ... --force`
