### PR TITLE
Make skill enable debugging in VS Code

### DIFF
--- a/examples/go/kvstore/.vscode/launch.json
+++ b/examples/go/kvstore/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/kvstore-server"
+        }
+    ]
+}

--- a/skills/splunk-instrument/SKILL.md
+++ b/skills/splunk-instrument/SKILL.md
@@ -108,6 +108,22 @@ For each signal with blank Status:
 3. Present a summary: N spans, N metrics, N logs instrumented,
    N remaining gaps (if any).
 
+### Step 5 -- Enable debugging in VS Code
+
+This step is REQUIRED whenever `.vscode/launch.json` exists.
+
+1. Check whether `.vscode/launch.json` exists.
+2. If it exists, you MUST update at least one debug configuration for this service to include:
+    - `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`
+    - `OTEL_METRIC_EXPORT_INTERVAL=1000`
+    - `OTEL_BSP_SCHEDULE_DELAY=100`
+3. After editing, you MUST report:
+    - which configuration was updated
+    - the file path
+    - whether the env vars were added or already present
+4. If `.vscode/launch.json` exists and you do not update it, stop and explain why.
+5. If `.vscode/launch.json` does not exist, explicitly report: `No .vscode/launch.json found; Step 5 skipped.`
+
 ## Examples
 
 ### Example 1: Python Flask with 3 gaps
@@ -181,3 +197,4 @@ For each signal with blank Status:
 - [ ] Custom spans follow semantic conventions
 - [ ] Error paths call `recordException` and set span status to ERROR
 - [ ] Derived metrics have corresponding OOB spans instrumented
+- [ ] If `.vscode/launch.json` exists, at least one service debug config includes the required OTEL env vars


### PR DESCRIPTION
Resolves https://github.com/signalfx/obstudio/issues/57

Since we target VS Code extension as one of the primary means of distribution we should play with it.

The skill previously automatically created/modified launch.json to make sure telemetry is visible in Telemetry Explorer view when running from VS code.

We [previously](https://github.com/signalfx/obstudio/commit/95b4d12f728e6726d33d58264ff8f7ee13eea733#diff-60cc6732010732a7f609cd236d167a09f1896b7382e3e4dde49ebb705dc0b3e0R42) had "Enable debugging in VS Code" section in the skill, but it got lost in the refactoring.

This PR brings it back.