### PR TITLE
Prepare Splunk Observability Studio for Marketplace publishing

### DIFF
--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -5,6 +5,8 @@ node_modules/**
 src/**
 .gitignore
 .yarnrc
+.DS_Store
+**/.DS_Store
 build-observer.js
 esbuild.js
 vsc-extension-quickstart.md
@@ -13,3 +15,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+assets/observer-icon.svg

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-All notable changes to the "observability-studio" extension will be documented in this file.
+All notable changes to the "Splunk Observability Studio" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## 0.0.1
 
-## [Unreleased]
-
-- Initial release
+- Start and manage a bundled local Observer backend from VS Code
+- Open the Observer UI in a VS Code webview
+- Expose stable local OTLP endpoints for development
+- Configure MCP integration for Codex, Claude Code, and Cursor

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,6 +1,6 @@
-# Observability Studio
+# Splunk Observability Studio
 
-Observability Studio is a VS Code extension for viewing OpenTelemetry data locally while you work.
+Splunk Observability Studio is a VS Code extension for viewing OpenTelemetry data locally while you work.
 
 When the extension activates, it starts a bundled observer binary, exposes OTLP receivers on localhost, and opens an embedded Observer UI inside VS Code.
 
@@ -15,7 +15,7 @@ When the extension activates, it starts a bundled observer binary, exposes OTLP 
 
 ## Commands
 
-- `Observability Studio: Open Observer` — opens the Observer webview panel.
+- `Splunk Observability Studio: Open Observer` — opens the Observer webview panel.
 
 ## How It Works
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,8 @@
 {
   "name": "observability-studio",
-  "displayName": "Observability Studio",
-  "description": "Observability Studio for OpenTelemetry",
+  "publisher": "Splunk",
+  "displayName": "Splunk Observability Studio",
+  "description": "Splunk Observability Studio for OpenTelemetry",
   "version": "0.0.1",
   "license": "Apache-2.0",
   "repository": {
@@ -25,46 +26,46 @@
       {
         "command": "observability-studio.openObserver",
         "title": "Open Observer",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.statusMenu",
         "title": "Observer Status",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.startObserver",
         "title": "Start Observer",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.stopObserver",
         "title": "Stop Observer",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.restartObserver",
         "title": "Restart Observer",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.configureCodexMCP",
         "title": "Configure Codex MCP",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.configureClaudeCodeMCP",
         "title": "Configure Claude Code MCP",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.configureCursorMCP",
         "title": "Configure Cursor MCP",
-        "category": "Observability Studio"
+        "category": "Splunk Observability Studio"
       }
     ],
     "configuration": {
-      "title": "Observability Studio",
+      "title": "Splunk Observability Studio",
       "properties": {
         "observability-studio.sharedObserverUrl": {
           "type": "string",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -77,7 +77,7 @@ type ObserverProbeResult =
 	| { reason: string; status: 'mismatch' };
 
 export async function activate(context: vscode.ExtensionContext) {
-	observerOutputChannel = vscode.window.createOutputChannel('Observability Studio');
+	observerOutputChannel = vscode.window.createOutputChannel('Splunk Observability Studio');
 	context.subscriptions.push(observerOutputChannel);
 	logObserverLifecycle('Extension activated.');
 
@@ -119,7 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 		const message = getErrorMessage(error);
 		appendObserverOutputLine(`Observer startup failed: ${message}`);
-		void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
+		void vscode.window.showErrorMessage(`Splunk Observability Studio could not start: ${message}`);
 	});
 
 	const openObserverDisposable = vscode.commands.registerCommand('observability-studio.openObserver', () => {
@@ -204,7 +204,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 			const message = getErrorMessage(error);
-			void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
+			void vscode.window.showErrorMessage(`Splunk Observability Studio could not start: ${message}`);
 			refreshObserverPanel();
 		}
 	});
@@ -229,7 +229,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 			const message = getErrorMessage(error);
-			void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
+			void vscode.window.showErrorMessage(`Splunk Observability Studio could not start: ${message}`);
 			refreshObserverPanel();
 		}
 	});
@@ -442,7 +442,7 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 				observerBaseUrl = undefined;
 				observerUsesSharedServer = false;
 				syncObserverUi();
-				void vscode.window.showErrorMessage(`Observability Studio failed to start observer: ${error.message}`);
+				void vscode.window.showErrorMessage(`Splunk Observability Studio failed to start observer: ${error.message}`);
 			}
 		});
 
@@ -842,7 +842,7 @@ async function restartObserver(context: vscode.ExtensionContext): Promise<void> 
 			return;
 		}
 		const message = getErrorMessage(error);
-		void vscode.window.showErrorMessage(`Observability Studio could not start: ${message}`);
+		void vscode.window.showErrorMessage(`Splunk Observability Studio could not start: ${message}`);
 		refreshObserverPanel();
 	}
 }

--- a/extension/src/test/extension-integration.test.ts
+++ b/extension/src/test/extension-integration.test.ts
@@ -245,7 +245,7 @@ it('integration: package.json registers all commands', () => {
 	}
 });
 
-it('integration: contributed commands are grouped under Observability Studio', async () => {
+it('integration: contributed commands are grouped under Splunk Observability Studio', async () => {
 	const packageJsonPath = path.join(extensionRoot, 'package.json');
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as ExtensionPackage;
 	const commands = packageJson.contributes?.commands ?? [];
@@ -261,8 +261,8 @@ it('integration: contributed commands are grouped under Observability Studio', a
 		assert.ok(command, `command ${commandId} should be contributed`);
 		assert.equal(
 			command?.category,
-			'Observability Studio',
-			`command ${commandId} should be grouped under Observability Studio`,
+			'Splunk Observability Studio',
+			`command ${commandId} should be grouped under Splunk Observability Studio`,
 		);
 	}
 });

--- a/extension/src/test/webview-html.test.ts
+++ b/extension/src/test/webview-html.test.ts
@@ -37,7 +37,7 @@ describe('getObserverWebviewHtml', () => {
 describe('getObserverLoadingWebviewHtml', () => {
 	it('shows a starting message', () => {
 		const html = getObserverLoadingWebviewHtml();
-		assert.ok(html.includes('Observability Studio is starting'));
+		assert.ok(html.includes('Splunk Observability Studio is starting'));
 	});
 
 	it('does not contain an iframe', () => {
@@ -136,4 +136,3 @@ describe('getStatusBarUpdate', () => {
 		}
 	});
 });
-

--- a/extension/src/webview-html.ts
+++ b/extension/src/webview-html.ts
@@ -72,7 +72,7 @@ export function getObserverLoadingWebviewHtml(): string {
 	</style>
 </head>
 <body>
-	<div>Observability Studio is starting…</div>
+	<div>Splunk Observability Studio is starting…</div>
 </body>
 </html>`;
 }
@@ -130,7 +130,7 @@ export function getObserverErrorWebviewHtml(errorMessage: string): string {
 		<div class="error-detail">${escaped}</div>
 		<p class="hint">
 			Use the Command Palette (Cmd+Shift+P) and run
-			<strong>Observability Studio: Restart Observer</strong> after
+			<strong>Splunk Observability Studio: Restart Observer</strong> after
 			freeing the port.
 		</p>
 	</div>
@@ -174,7 +174,7 @@ export function getObserverStoppedWebviewHtml(): string {
 		<div>Observer is stopped.</div>
 		<p class="hint">
 			Use the Command Palette (Cmd+Shift+P) and run
-			<strong>Observability Studio: Start Observer</strong> to start it again.
+			<strong>Splunk Observability Studio: Start Observer</strong> to start it again.
 		</p>
 	</div>
 </body>


### PR DESCRIPTION
## Summary
- brand the VS Code extension as `Splunk Observability Studio` and set the Marketplace publisher to `Splunk`
- update user-facing extension strings and docs to match the Marketplace branding
- tighten VSIX packaging by excluding `.DS_Store` files and the unused SVG asset

## Plan
- update extension metadata and user-facing branding for Splunk Marketplace publishing
- apply Marketplace packaging cleanup for the VSIX
- verify the extension metadata, tests, and package build before upload

## Testing
- `npm --prefix extension run test:unit`
- `npm --prefix extension run test:integration`
- `npm --prefix extension run build:vsix`
