### PR TITLE
Genericize eval plugin: pluggable agent backends and domain-agnostic runtime expectations

### DIFF
--- a/docs/USER.md
+++ b/docs/USER.md
@@ -39,7 +39,7 @@ The installer:
 2. Copies the binary alongside the skills (stable path for MCP)
 3. Configures the agent's MCP config to auto-start `obstudio`
 
-Restart your editor/agent to activate.
+Restart your agent to activate.
 
 ### What Gets Installed
 

--- a/eval-reports/otel-audit/rubric/benchmark.json
+++ b/eval-reports/otel-audit/rubric/benchmark.json
@@ -7,7 +7,7 @@
     "mode": "with_skill",
     "eval_kind": "rubric",
     "skill": "otel-audit",
-    "run_id": "20260429T171547534589Z",
+    "run_id": "20260430T171007325917Z",
     "agent_model": "gpt-5.5",
     "judge_model": "gpt-5.5",
     "rubric_enabled": true,
@@ -18,22 +18,22 @@
   "summary": {
     "eval_count": 7,
     "prompt_count": 14,
-    "failure_count": 0,
+    "failure_count": 1,
     "with_skill": {
       "prompt_count": 14,
-      "command_count": 356,
-      "duration_seconds": 1446.885,
-      "agent_duration_seconds": 890.841,
-      "tokens": 3281459,
-      "agent_tokens": 2140881,
+      "command_count": 370,
+      "duration_seconds": 1473.729,
+      "agent_duration_seconds": 897.2,
+      "tokens": 3370524,
+      "agent_tokens": 2186485,
       "error_count": 0,
       "rubric": {
-        "passed": 72,
-        "total": 72,
-        "average_score": 59.285714285714285
+        "passed": 70,
+        "total": 71,
+        "average_score": 63.785714285714285
       },
-      "rubric_tokens": 1140578,
-      "rubric_duration_seconds": 555.767
+      "rubric_tokens": 1184039,
+      "rubric_duration_seconds": 576.229
     },
     "with_baseline": null
   },
@@ -51,25 +51,25 @@
       "with_skill": {
         "prompt_count": 2,
         "command_count": 40,
-        "duration_seconds": 175.709,
-        "agent_duration_seconds": 106.43,
-        "tokens": 437813,
-        "agent_tokens": 282678,
+        "duration_seconds": 202.889,
+        "agent_duration_seconds": 104.149,
+        "tokens": 401161,
+        "agent_tokens": 247322,
         "error_count": 0,
         "rubric": {
-          "passed": 10,
-          "total": 10,
-          "average_score": 52.5
+          "passed": 11,
+          "total": 11,
+          "average_score": 100.0
         },
-        "rubric_tokens": 155135,
-        "rubric_duration_seconds": 69.247
+        "rubric_tokens": 153839,
+        "rubric_duration_seconds": 98.708
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/chi-basic/qual-audit/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/chi-basic/qual-audit/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/chi-basic/qual-audit/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/chi-basic/qual-audit/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/chi-basic/qual-audit/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/chi-basic/qual-audit/with_baseline.json"
       }
     },
     {
@@ -84,26 +84,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 34,
-        "duration_seconds": 239.268,
-        "agent_duration_seconds": 154.997,
-        "tokens": 442513,
-        "agent_tokens": 274702,
+        "command_count": 40,
+        "duration_seconds": 231.647,
+        "agent_duration_seconds": 152.326,
+        "tokens": 422327,
+        "agent_tokens": 258582,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
           "average_score": 100.0
         },
-        "rubric_tokens": 167811,
-        "rubric_duration_seconds": 84.239
+        "rubric_tokens": 163745,
+        "rubric_duration_seconds": 79.277
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/chi-partial/qual-audit/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/chi-partial/qual-audit/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/chi-partial/qual-audit/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/chi-partial/qual-audit/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/chi-partial/qual-audit/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/chi-partial/qual-audit/with_baseline.json"
       }
     },
     {
@@ -118,26 +118,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 74,
-        "duration_seconds": 266.348,
-        "agent_duration_seconds": 183.307,
-        "tokens": 834910,
-        "agent_tokens": 641335,
+        "command_count": 78,
+        "duration_seconds": 254.182,
+        "agent_duration_seconds": 165.879,
+        "tokens": 773436,
+        "agent_tokens": 526955,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
-          "average_score": 52.5
+          "average_score": 50.5
         },
-        "rubric_tokens": 193575,
-        "rubric_duration_seconds": 82.983
+        "rubric_tokens": 246481,
+        "rubric_duration_seconds": 88.25
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/kvstore/qual-audit/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/kvstore/qual-audit/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/go/kvstore/qual-audit/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/kvstore/qual-audit/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/kvstore/qual-audit/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/go/kvstore/qual-audit/with_baseline.json"
       }
     },
     {
@@ -152,26 +152,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 50,
-        "duration_seconds": 198.685,
-        "agent_duration_seconds": 123.268,
-        "tokens": 397285,
-        "agent_tokens": 244270,
+        "command_count": 66,
+        "duration_seconds": 221.722,
+        "agent_duration_seconds": 124.925,
+        "tokens": 428336,
+        "agent_tokens": 247007,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
-          "average_score": 5.0
+          "average_score": 52.5
         },
-        "rubric_tokens": 153015,
-        "rubric_duration_seconds": 75.356
+        "rubric_tokens": 181329,
+        "rubric_duration_seconds": 96.738
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/java/springboot-basic/qual-audit/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/java/springboot-basic/qual-audit/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/java/springboot-basic/qual-audit/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/java/springboot-basic/qual-audit/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/java/springboot-basic/qual-audit/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/java/springboot-basic/qual-audit/with_baseline.json"
       }
     },
     {
@@ -186,26 +186,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 44,
-        "duration_seconds": 161.623,
-        "agent_duration_seconds": 94.752,
-        "tokens": 398683,
-        "agent_tokens": 242626,
+        "command_count": 38,
+        "duration_seconds": 168.126,
+        "agent_duration_seconds": 105.529,
+        "tokens": 426802,
+        "agent_tokens": 271926,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
           "average_score": 52.5
         },
-        "rubric_tokens": 156057,
-        "rubric_duration_seconds": 66.842
+        "rubric_tokens": 154876,
+        "rubric_duration_seconds": 62.558
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/node/express-basic/qual-audit/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/node/express-basic/qual-audit/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/node/express-basic/qual-audit/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/node/express-basic/qual-audit/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/node/express-basic/qual-audit/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/node/express-basic/qual-audit/with_baseline.json"
       }
     },
     {
@@ -220,26 +220,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 76,
-        "duration_seconds": 211.617,
-        "agent_duration_seconds": 138.448,
-        "tokens": 405973,
-        "agent_tokens": 252213,
+        "command_count": 66,
+        "duration_seconds": 241.225,
+        "agent_duration_seconds": 143.368,
+        "tokens": 464394,
+        "agent_tokens": 281027,
         "error_count": 0,
         "rubric": {
-          "passed": 12,
-          "total": 12,
-          "average_score": 52.5
+          "passed": 9,
+          "total": 10,
+          "average_score": 86.0
         },
-        "rubric_tokens": 153760,
-        "rubric_duration_seconds": 73.133
+        "rubric_tokens": 183367,
+        "rubric_duration_seconds": 97.813
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/python/fastapi-celery/qual-audit/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/python/fastapi-celery/qual-audit/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/python/fastapi-celery/qual-audit/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/python/fastapi-celery/qual-audit/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/python/fastapi-celery/qual-audit/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/python/fastapi-celery/qual-audit/with_baseline.json"
       }
     },
     {
@@ -254,28 +254,38 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 38,
-        "duration_seconds": 193.635,
-        "agent_duration_seconds": 89.639,
-        "tokens": 364282,
-        "agent_tokens": 203057,
+        "command_count": 42,
+        "duration_seconds": 153.938,
+        "agent_duration_seconds": 101.024,
+        "tokens": 454068,
+        "agent_tokens": 353666,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
-          "average_score": 100.0
+          "average_score": 5.0
         },
-        "rubric_tokens": 161225,
-        "rubric_duration_seconds": 103.967
+        "rubric_tokens": 100402,
+        "rubric_duration_seconds": 52.885
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/python/flask-basic/qual-audit/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/python/flask-basic/qual-audit/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-audit/20260429T171547534589Z/results/python/flask-basic/qual-audit/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/python/flask-basic/qual-audit/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/python/flask-basic/qual-audit/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-audit/20260430T171007325917Z/results/python/flask-basic/qual-audit/with_baseline.json"
       }
     }
   ],
-  "failures": []
+  "failures": [
+    {
+      "service": "python/fastapi-celery",
+      "side": "with_skill",
+      "prompt": "direct",
+      "category": "rubric",
+      "result": "rubric:rubric-4 FAIL",
+      "evidence": "The response says there are no `OTEL_*` env vars/exporter/resource config, but it does not explicitly identify that the `api` and `worker` docker-compose start commands are not wrapped/configured for instrumentation.",
+      "mode": "with_skill"
+    }
+  ]
 }

--- a/eval-reports/otel-audit/rubric/report.md
+++ b/eval-reports/otel-audit/rubric/report.md
@@ -7,7 +7,7 @@
 | Mode | with_skill |
 | Eval kind | rubric |
 | Skill | otel-audit |
-| Run ID | 20260429T171547534589Z |
+| Run ID | 20260430T171007325917Z |
 | Agent model | gpt-5.5 |
 | Judge model | gpt-5.5 |
 | Rubric enabled | True |
@@ -18,17 +18,19 @@
 
 | Mode | Eval | Service | Prompts | With Skill | With Skill Tokens | With Skill Time | Baseline | Baseline Tokens | Baseline Time |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| with_skill | go/chi-basic/qual/audit | go/chi-basic | 2 | 100% (10/10), avg score 52 | 437.8K | 2.9m | - | - | - |
-| with_skill | go/chi-partial/qual/audit | go/chi-partial | 2 | 100% (10/10), avg score 100 | 442.5K | 4.0m | - | - | - |
-| with_skill | go/kvstore/qual/audit | go/kvstore | 2 | 100% (10/10), avg score 52 | 834.9K | 4.4m | - | - | - |
-| with_skill | java/springboot-basic/qual/audit | java/springboot-basic | 2 | 100% (10/10), avg score 5 | 397.3K | 3.3m | - | - | - |
-| with_skill | node/express-basic/qual/audit | node/express-basic | 2 | 100% (10/10), avg score 52 | 398.7K | 2.7m | - | - | - |
-| with_skill | python/fastapi-celery/qual/audit | python/fastapi-celery | 2 | 100% (12/12), avg score 52 | 406.0K | 3.5m | - | - | - |
-| with_skill | python/flask-basic/qual/audit | python/flask-basic | 2 | 100% (10/10), avg score 100 | 364.3K | 3.2m | - | - | - |
+| with_skill | go/chi-basic/qual/audit | go/chi-basic | 2 | 100% (11/11), avg score 100 | 401.2K | 3.4m | - | - | - |
+| with_skill | go/chi-partial/qual/audit | go/chi-partial | 2 | 100% (10/10), avg score 100 | 422.3K | 3.9m | - | - | - |
+| with_skill | go/kvstore/qual/audit | go/kvstore | 2 | 100% (10/10), avg score 50 | 773.4K | 4.2m | - | - | - |
+| with_skill | java/springboot-basic/qual/audit | java/springboot-basic | 2 | 100% (10/10), avg score 52 | 428.3K | 3.7m | - | - | - |
+| with_skill | node/express-basic/qual/audit | node/express-basic | 2 | 100% (10/10), avg score 52 | 426.8K | 2.8m | - | - | - |
+| with_skill | python/fastapi-celery/qual/audit | python/fastapi-celery | 2 | 90% (9/10), avg score 86 | 464.4K | 4.0m | - | - | - |
+| with_skill | python/flask-basic/qual/audit | python/flask-basic | 2 | 100% (10/10), avg score 5 | 454.1K | 2.6m | - | - | - |
 
 ## Rubric Failures
 
-No rubric failures.
+| Mode | Service | Side | Prompt | Result | Evidence |
+|---|---|---|---|---|---|
+| with_skill | python/fastapi-celery | with_skill | direct | rubric:rubric-4 FAIL | The response says there are no `OTEL_*` env vars/exporter/resource config, but it does not explicitly identify that the `api` and `worker` docker-compose start commands are not wrapped/configured for instrumentation. |
 
 ## Result JSON
 

--- a/eval-reports/otel-instrument/rubric/benchmark.json
+++ b/eval-reports/otel-instrument/rubric/benchmark.json
@@ -7,7 +7,7 @@
     "mode": "with_skill",
     "eval_kind": "rubric",
     "skill": "otel-instrument",
-    "run_id": "20260429T171547534589Z",
+    "run_id": "20260430T171007325917Z",
     "agent_model": "gpt-5.5",
     "judge_model": "gpt-5.5",
     "rubric_enabled": true,
@@ -21,19 +21,19 @@
     "failure_count": 5,
     "with_skill": {
       "prompt_count": 14,
-      "command_count": 1096,
-      "duration_seconds": 4439.559,
-      "agent_duration_seconds": 3438.741,
-      "tokens": 19685588,
-      "agent_tokens": 16879201,
+      "command_count": 1044,
+      "duration_seconds": 4335.757,
+      "agent_duration_seconds": 3374.632,
+      "tokens": 18641745,
+      "agent_tokens": 15875071,
       "error_count": 0,
       "rubric": {
         "passed": 65,
         "total": 70,
-        "average_score": 79.64285714285714
+        "average_score": 64.07142857142857
       },
-      "rubric_tokens": 2806387,
-      "rubric_duration_seconds": 1000.516
+      "rubric_tokens": 2766674,
+      "rubric_duration_seconds": 960.767
     },
     "with_baseline": null
   },
@@ -50,26 +50,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 242,
-        "duration_seconds": 972.615,
-        "agent_duration_seconds": 807.113,
-        "tokens": 5557926,
-        "agent_tokens": 5005332,
+        "command_count": 340,
+        "duration_seconds": 1018.18,
+        "agent_duration_seconds": 822.395,
+        "tokens": 7955539,
+        "agent_tokens": 7010112,
         "error_count": 0,
         "rubric": {
           "passed": 7,
           "total": 10,
           "average_score": 70.0
         },
-        "rubric_tokens": 552594,
-        "rubric_duration_seconds": 165.449
+        "rubric_tokens": 945427,
+        "rubric_duration_seconds": 195.719
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/chi-basic/qual-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/chi-basic/qual-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/chi-basic/qual-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/chi-basic/qual-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/chi-basic/qual-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/chi-basic/qual-instrument/with_baseline.json"
       }
     },
     {
@@ -84,26 +84,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 248,
-        "duration_seconds": 940.868,
-        "agent_duration_seconds": 725.915,
-        "tokens": 5733771,
-        "agent_tokens": 4910219,
+        "command_count": 124,
+        "duration_seconds": 690.088,
+        "agent_duration_seconds": 524.405,
+        "tokens": 2601488,
+        "agent_tokens": 2081097,
         "error_count": 0,
         "rubric": {
           "passed": 8,
           "total": 10,
-          "average_score": 42.0
+          "average_score": 80.0
         },
-        "rubric_tokens": 823552,
-        "rubric_duration_seconds": 214.912
+        "rubric_tokens": 520391,
+        "rubric_duration_seconds": 165.638
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/chi-partial/qual-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/chi-partial/qual-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/chi-partial/qual-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/chi-partial/qual-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/chi-partial/qual-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/chi-partial/qual-instrument/with_baseline.json"
       }
     },
     {
@@ -118,26 +118,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 256,
-        "duration_seconds": 812.93,
-        "agent_duration_seconds": 646.255,
-        "tokens": 4437352,
-        "agent_tokens": 4012263,
+        "command_count": 228,
+        "duration_seconds": 729.444,
+        "agent_duration_seconds": 549.784,
+        "tokens": 3439150,
+        "agent_tokens": 3028776,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
           "average_score": 100.0
         },
-        "rubric_tokens": 425089,
-        "rubric_duration_seconds": 166.615
+        "rubric_tokens": 410374,
+        "rubric_duration_seconds": 179.601
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/kvstore/qual-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/kvstore/qual-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/go/kvstore/qual-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/kvstore/qual-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/kvstore/qual-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/go/kvstore/qual-instrument/with_baseline.json"
       }
     },
     {
@@ -152,26 +152,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 88,
-        "duration_seconds": 380.963,
-        "agent_duration_seconds": 288.654,
-        "tokens": 991025,
-        "agent_tokens": 747639,
+        "command_count": 94,
+        "duration_seconds": 432.022,
+        "agent_duration_seconds": 350.588,
+        "tokens": 1048047,
+        "agent_tokens": 837833,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
-          "average_score": 100.0
+          "average_score": 52.5
         },
-        "rubric_tokens": 243386,
-        "rubric_duration_seconds": 92.26
+        "rubric_tokens": 210214,
+        "rubric_duration_seconds": 81.372
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/java/springboot-basic/qual-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/java/springboot-basic/qual-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/java/springboot-basic/qual-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/java/springboot-basic/qual-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/java/springboot-basic/qual-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/java/springboot-basic/qual-instrument/with_baseline.json"
       }
     },
     {
@@ -186,26 +186,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 96,
-        "duration_seconds": 447.507,
-        "agent_duration_seconds": 368.371,
-        "tokens": 1319159,
-        "agent_tokens": 1138521,
+        "command_count": 76,
+        "duration_seconds": 588.15,
+        "agent_duration_seconds": 488.968,
+        "tokens": 1742664,
+        "agent_tokens": 1504011,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
-          "average_score": 52.5
+          "average_score": 50.0
         },
-        "rubric_tokens": 180638,
-        "rubric_duration_seconds": 79.107
+        "rubric_tokens": 238653,
+        "rubric_duration_seconds": 99.144
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/node/express-basic/qual-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/node/express-basic/qual-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/node/express-basic/qual-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/node/express-basic/qual-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/node/express-basic/qual-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/node/express-basic/qual-instrument/with_baseline.json"
       }
     },
     {
@@ -220,26 +220,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 92,
-        "duration_seconds": 533.353,
-        "agent_duration_seconds": 353.523,
-        "tokens": 863287,
-        "agent_tokens": 492325,
+        "command_count": 96,
+        "duration_seconds": 544.236,
+        "agent_duration_seconds": 391.699,
+        "tokens": 1025531,
+        "agent_tokens": 737932,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
-          "average_score": 93.0
+          "average_score": 91.0
         },
-        "rubric_tokens": 370962,
-        "rubric_duration_seconds": 179.797
+        "rubric_tokens": 287599,
+        "rubric_duration_seconds": 152.488
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/python/fastapi-celery/qual-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/python/fastapi-celery/qual-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/python/fastapi-celery/qual-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/python/fastapi-celery/qual-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/python/fastapi-celery/qual-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/python/fastapi-celery/qual-instrument/with_baseline.json"
       }
     },
     {
@@ -254,26 +254,26 @@
       ],
       "with_skill": {
         "prompt_count": 2,
-        "command_count": 74,
-        "duration_seconds": 351.323,
-        "agent_duration_seconds": 248.91,
-        "tokens": 783068,
-        "agent_tokens": 572902,
+        "command_count": 86,
+        "duration_seconds": 333.637,
+        "agent_duration_seconds": 246.793,
+        "tokens": 829326,
+        "agent_tokens": 675310,
         "error_count": 0,
         "rubric": {
           "passed": 10,
           "total": 10,
-          "average_score": 100.0
+          "average_score": 5.0
         },
-        "rubric_tokens": 210166,
-        "rubric_duration_seconds": 102.376
+        "rubric_tokens": 154016,
+        "rubric_duration_seconds": 86.805
       },
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/python/flask-basic/qual-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/python/flask-basic/qual-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T171547534589Z/results/python/flask-basic/qual-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/python/flask-basic/qual-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/python/flask-basic/qual-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T171007325917Z/results/python/flask-basic/qual-instrument/with_baseline.json"
       }
     }
   ],
@@ -283,17 +283,17 @@
       "side": "with_skill",
       "prompt": "direct",
       "category": "rubric",
-      "result": "rubric:rubric-3 FAIL",
-      "evidence": "service/main.go:126 uses otelhttp.NewHandler(r, \"server\"); no otelchi import, middleware, or otelhttp route tag appears in service/main.go or service/otel.go.",
-      "mode": "with_skill"
-    },
-    {
-      "service": "go/chi-basic",
-      "side": "with_skill",
-      "prompt": "runtime-preserving",
-      "category": "rubric",
       "result": "rubric:rubric-1 FAIL",
-      "evidence": "trace.jsonl item_3 states a small Go service under service/ with no Docker/Makefile/alternate launcher and native go run startup. The first explicit service.name and environment source statement appears in last_message.md after edits.",
+      "evidence": "trace.jsonl agent preflight: existing native Go HTTP service in ./service using chi on :8000, no existing OTel; last_message.md later states OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES=deployment.environment=...",
+      "mode": "with_skill"
+    },
+    {
+      "service": "go/chi-basic",
+      "side": "with_skill",
+      "prompt": "direct",
+      "category": "rubric",
+      "result": "rubric:rubric-3 FAIL",
+      "evidence": "service/main.go uses otelhttp.NewHandler(r, \"server\") only.",
       "mode": "with_skill"
     },
     {
@@ -302,7 +302,7 @@
       "prompt": "runtime-preserving",
       "category": "rubric",
       "result": "rubric:rubric-3 FAIL",
-      "evidence": "service/main.go wraps the router with otelhttp.NewHandler(r, \"server\"). service/go.mod does not include otelchi, and the code contains no WithRouteTag or chi route-derived span naming.",
+      "evidence": "service/main.go:127 wraps the chi router with otelhttp.NewHandler(r, \"server\"), which keeps the router in place, but there is no otelchi middleware, otelhttp.WithRouteTag, or span name formatter using chi route patterns. Spans will use the constant operation name \"server\" rather than route-aware low-cardinality names or http.route attributes.",
       "mode": "with_skill"
     },
     {
@@ -311,7 +311,7 @@
       "prompt": "direct",
       "category": "rubric",
       "result": "rubric:rubric-5 FAIL",
-      "evidence": "service/main.go lines 65, 73, 91, 108, and 122 write 404/400 responses directly. rg found no RecordError, SetStatus, codes.Error, or trace.SpanFromContext in service.",
+      "evidence": "rg found no RecordError, SetStatus, or codes.* usage; service/main.go:65,73,91,108,122 write 404/400 responses without span error/status handling.",
       "mode": "with_skill"
     },
     {
@@ -320,7 +320,7 @@
       "prompt": "runtime-preserving",
       "category": "rubric",
       "result": "rubric:rubric-5 FAIL",
-      "evidence": "No fmt.Sprintf(\"GetTask-%d\") remains, but service/main.go failure paths only call writeJSON with 400/404 and there are no RecordError or SetStatus calls anywhere in ./service.",
+      "evidence": "service/main.go has no RecordError or SetStatus calls; 400/404 paths only call writeJSON. The local otelhttp v0.68.0 server status helper sets Error only for status >=500.",
       "mode": "with_skill"
     }
   ]

--- a/eval-reports/otel-instrument/rubric/report.md
+++ b/eval-reports/otel-instrument/rubric/report.md
@@ -7,7 +7,7 @@
 | Mode | with_skill |
 | Eval kind | rubric |
 | Skill | otel-instrument |
-| Run ID | 20260429T171547534589Z |
+| Run ID | 20260430T171007325917Z |
 | Agent model | gpt-5.5 |
 | Judge model | gpt-5.5 |
 | Rubric enabled | True |
@@ -18,23 +18,23 @@
 
 | Mode | Eval | Service | Prompts | With Skill | With Skill Tokens | With Skill Time | Baseline | Baseline Tokens | Baseline Time |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| with_skill | go/chi-basic/qual/instrument | go/chi-basic | 2 | 70% (7/10), avg score 70 | 5.6M | 16.2m | - | - | - |
-| with_skill | go/chi-partial/qual/instrument | go/chi-partial | 2 | 80% (8/10), avg score 42 | 5.7M | 15.7m | - | - | - |
-| with_skill | go/kvstore/qual/instrument | go/kvstore | 2 | 100% (10/10), avg score 100 | 4.4M | 13.5m | - | - | - |
-| with_skill | java/springboot-basic/qual/instrument | java/springboot-basic | 2 | 100% (10/10), avg score 100 | 991.0K | 6.3m | - | - | - |
-| with_skill | node/express-basic/qual/instrument | node/express-basic | 2 | 100% (10/10), avg score 52 | 1.3M | 7.5m | - | - | - |
-| with_skill | python/fastapi-celery/qual/instrument | python/fastapi-celery | 2 | 100% (10/10), avg score 93 | 863.3K | 8.9m | - | - | - |
-| with_skill | python/flask-basic/qual/instrument | python/flask-basic | 2 | 100% (10/10), avg score 100 | 783.1K | 5.9m | - | - | - |
+| with_skill | go/chi-basic/qual/instrument | go/chi-basic | 2 | 70% (7/10), avg score 70 | 8.0M | 17.0m | - | - | - |
+| with_skill | go/chi-partial/qual/instrument | go/chi-partial | 2 | 80% (8/10), avg score 80 | 2.6M | 11.5m | - | - | - |
+| with_skill | go/kvstore/qual/instrument | go/kvstore | 2 | 100% (10/10), avg score 100 | 3.4M | 12.2m | - | - | - |
+| with_skill | java/springboot-basic/qual/instrument | java/springboot-basic | 2 | 100% (10/10), avg score 52 | 1.0M | 7.2m | - | - | - |
+| with_skill | node/express-basic/qual/instrument | node/express-basic | 2 | 100% (10/10), avg score 50 | 1.7M | 9.8m | - | - | - |
+| with_skill | python/fastapi-celery/qual/instrument | python/fastapi-celery | 2 | 100% (10/10), avg score 91 | 1.0M | 9.1m | - | - | - |
+| with_skill | python/flask-basic/qual/instrument | python/flask-basic | 2 | 100% (10/10), avg score 5 | 829.3K | 5.6m | - | - | - |
 
 ## Rubric Failures
 
 | Mode | Service | Side | Prompt | Result | Evidence |
 |---|---|---|---|---|---|
-| with_skill | go/chi-basic | with_skill | direct | rubric:rubric-3 FAIL | service/main.go:126 uses otelhttp.NewHandler(r, "server"); no otelchi import, middleware, or otelhttp route tag appears in service/main.go or service/otel.go. |
-| with_skill | go/chi-basic | with_skill | runtime-preserving | rubric:rubric-1 FAIL | trace.jsonl item_3 states a small Go service under service/ with no Docker/Makefile/alternate launcher and native go run startup. The first explicit service.name and environment source statement appears in last_message.md after edits. |
-| with_skill | go/chi-basic | with_skill | runtime-preserving | rubric:rubric-3 FAIL | service/main.go wraps the router with otelhttp.NewHandler(r, "server"). service/go.mod does not include otelchi, and the code contains no WithRouteTag or chi route-derived span naming. |
-| with_skill | go/chi-partial | with_skill | direct | rubric:rubric-5 FAIL | service/main.go lines 65, 73, 91, 108, and 122 write 404/400 responses directly. rg found no RecordError, SetStatus, codes.Error, or trace.SpanFromContext in service. |
-| with_skill | go/chi-partial | with_skill | runtime-preserving | rubric:rubric-5 FAIL | No fmt.Sprintf("GetTask-%d") remains, but service/main.go failure paths only call writeJSON with 400/404 and there are no RecordError or SetStatus calls anywhere in ./service. |
+| with_skill | go/chi-basic | with_skill | direct | rubric:rubric-1 FAIL | trace.jsonl agent preflight: existing native Go HTTP service in ./service using chi on :8000, no existing OTel; last_message.md later states OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES=deployment.environment=... |
+| with_skill | go/chi-basic | with_skill | direct | rubric:rubric-3 FAIL | service/main.go uses otelhttp.NewHandler(r, "server") only. |
+| with_skill | go/chi-basic | with_skill | runtime-preserving | rubric:rubric-3 FAIL | service/main.go:127 wraps the chi router with otelhttp.NewHandler(r, "server"), which keeps the router in place, but there is no otelchi middleware, otelhttp.WithRouteTag, or span name formatter using chi route patterns. Spans will use the constant operation name "server" rather than route-aware low-cardinality name... |
+| with_skill | go/chi-partial | with_skill | direct | rubric:rubric-5 FAIL | rg found no RecordError, SetStatus, or codes.* usage; service/main.go:65,73,91,108,122 write 404/400 responses without span error/status handling. |
+| with_skill | go/chi-partial | with_skill | runtime-preserving | rubric:rubric-5 FAIL | service/main.go has no RecordError or SetStatus calls; 400/404 paths only call writeJSON. The local otelhttp v0.68.0 server status helper sets Error only for status >=500. |
 
 ## Result JSON
 

--- a/eval-reports/otel-instrument/runtime/benchmark.json
+++ b/eval-reports/otel-instrument/runtime/benchmark.json
@@ -7,7 +7,7 @@
     "mode": "with_skill",
     "eval_kind": "runtime",
     "skill": "otel-instrument",
-    "run_id": "20260429T185105710232Z",
+    "run_id": "20260430T170207539067Z",
     "agent_model": "gpt-5.5",
     "judge_model": "gpt-5.5",
     "rubric_enabled": false,
@@ -18,17 +18,17 @@
   "summary": {
     "eval_count": 6,
     "prompt_count": 6,
-    "failure_count": 1,
+    "failure_count": 0,
     "with_skill": {
       "prompt_count": 6,
-      "command_count": 372,
-      "duration_seconds": 1342.533,
-      "agent_duration_seconds": 1269.821,
-      "tokens": 4903539,
-      "agent_tokens": 4903539,
+      "command_count": 500,
+      "duration_seconds": 1635.874,
+      "agent_duration_seconds": 1529.577,
+      "tokens": 7459751,
+      "agent_tokens": 7459751,
       "error_count": 0,
       "checks": {
-        "passed": 5,
+        "passed": 6,
         "total": 6,
         "skipped": 0
       }
@@ -47,11 +47,11 @@
       ],
       "with_skill": {
         "prompt_count": 1,
-        "command_count": 96,
-        "duration_seconds": 295.841,
-        "agent_duration_seconds": 279.752,
-        "tokens": 2054813,
-        "agent_tokens": 2054813,
+        "command_count": 142,
+        "duration_seconds": 367.622,
+        "agent_duration_seconds": 346.386,
+        "tokens": 3174728,
+        "agent_tokens": 3174728,
         "error_count": 0,
         "checks": {
           "passed": 1,
@@ -62,9 +62,9 @@
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/chi-basic/runtime-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/chi-basic/runtime-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/chi-basic/runtime-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/chi-basic/runtime-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/chi-basic/runtime-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/chi-basic/runtime-instrument/with_baseline.json"
       }
     },
     {
@@ -78,14 +78,14 @@
       ],
       "with_skill": {
         "prompt_count": 1,
-        "command_count": 52,
-        "duration_seconds": 230.993,
-        "agent_duration_seconds": 226.963,
-        "tokens": 759710,
-        "agent_tokens": 759710,
+        "command_count": 90,
+        "duration_seconds": 274.173,
+        "agent_duration_seconds": 256.11,
+        "tokens": 1108951,
+        "agent_tokens": 1108951,
         "error_count": 0,
         "checks": {
-          "passed": 0,
+          "passed": 1,
           "total": 1,
           "skipped": 0
         }
@@ -93,9 +93,9 @@
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/chi-partial/runtime-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/chi-partial/runtime-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/chi-partial/runtime-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/chi-partial/runtime-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/chi-partial/runtime-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/chi-partial/runtime-instrument/with_baseline.json"
       }
     },
     {
@@ -109,11 +109,11 @@
       ],
       "with_skill": {
         "prompt_count": 1,
-        "command_count": 108,
-        "duration_seconds": 278.283,
-        "agent_duration_seconds": 261.498,
-        "tokens": 963484,
-        "agent_tokens": 963484,
+        "command_count": 132,
+        "duration_seconds": 305.485,
+        "agent_duration_seconds": 288.313,
+        "tokens": 1653416,
+        "agent_tokens": 1653416,
         "error_count": 0,
         "checks": {
           "passed": 1,
@@ -124,9 +124,9 @@
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/kvstore/runtime-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/kvstore/runtime-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/go/kvstore/runtime-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/kvstore/runtime-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/kvstore/runtime-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/go/kvstore/runtime-instrument/with_baseline.json"
       }
     },
     {
@@ -140,11 +140,11 @@
       ],
       "with_skill": {
         "prompt_count": 1,
-        "command_count": 34,
-        "duration_seconds": 192.364,
-        "agent_duration_seconds": 183.464,
-        "tokens": 442457,
-        "agent_tokens": 442457,
+        "command_count": 32,
+        "duration_seconds": 276.599,
+        "agent_duration_seconds": 256.293,
+        "tokens": 415571,
+        "agent_tokens": 415571,
         "error_count": 0,
         "checks": {
           "passed": 1,
@@ -155,9 +155,9 @@
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/node/express-basic/runtime-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/node/express-basic/runtime-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/node/express-basic/runtime-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/node/express-basic/runtime-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/node/express-basic/runtime-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/node/express-basic/runtime-instrument/with_baseline.json"
       }
     },
     {
@@ -171,11 +171,11 @@
       ],
       "with_skill": {
         "prompt_count": 1,
-        "command_count": 52,
-        "duration_seconds": 206.043,
-        "agent_duration_seconds": 191.482,
-        "tokens": 479443,
-        "agent_tokens": 479443,
+        "command_count": 64,
+        "duration_seconds": 235.736,
+        "agent_duration_seconds": 224.663,
+        "tokens": 616708,
+        "agent_tokens": 616708,
         "error_count": 0,
         "checks": {
           "passed": 1,
@@ -186,9 +186,9 @@
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/python/fastapi-celery/runtime-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/python/fastapi-celery/runtime-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/python/fastapi-celery/runtime-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/python/fastapi-celery/runtime-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/python/fastapi-celery/runtime-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/python/fastapi-celery/runtime-instrument/with_baseline.json"
       }
     },
     {
@@ -202,11 +202,11 @@
       ],
       "with_skill": {
         "prompt_count": 1,
-        "command_count": 30,
-        "duration_seconds": 139.009,
-        "agent_duration_seconds": 126.662,
-        "tokens": 203632,
-        "agent_tokens": 203632,
+        "command_count": 40,
+        "duration_seconds": 176.259,
+        "agent_duration_seconds": 157.812,
+        "tokens": 490377,
+        "agent_tokens": 490377,
         "error_count": 0,
         "checks": {
           "passed": 1,
@@ -217,21 +217,11 @@
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/python/flask-basic/runtime-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/python/flask-basic/runtime-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T185105710232Z/results/python/flask-basic/runtime-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/python/flask-basic/runtime-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/python/flask-basic/runtime-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T170207539067Z/results/python/flask-basic/runtime-instrument/with_baseline.json"
       }
     }
   ],
-  "failures": [
-    {
-      "service": "go/chi-partial",
-      "side": "with_skill",
-      "prompt": "runtime-preserving",
-      "category": "runtime",
-      "result": "runtime:observer-runtime-telemetry FAIL",
-      "evidence": "Runtime check failed: docker compose -p codex-eval-4a2e0520ac72 -f /Users/pavankri/Cisco/obstudio/evals/go/chi-partial/eval/runtime/docker-compose.yml up -d --build exited 1: #1 [internal] load local bake definitions #1 reading from stdin 1.17kB done #1 DONE 0.0s #2 [app internal] load build definition from App.Dockerfile #2 DONE 0.0s #3 [observer internal] load build definition from observer.Dockerfile #3 transferring dockerfile: 810B done #3 DONE 0.0s #2 [app internal] load build definition from App.Dockerfile #2 transferring dockerfile: 299B done #2 DONE 0.0s #4 [observer internal] load metadata for docker.io/library/debian:bookworm-slim #4 DONE 0.5s #5 [app internal] load metadata for docker.io/library/golang:1.25-bookworm #5 DONE 0.5s #6 [app internal] load .dockerignore #6 transferring context: 2B done #6 DONE 0.0s #7 [observer internal] load .dockerignore #7 transferring context: 2B done #7 DONE 0.0s #8 [app build 1/5] FROM docker.io/library/golang:1.25-bookworm@sha256:298734aec230b5f3e8cee450ce6d7eccc39f1797ba548ee90d57e9803030c6c3 #8 resolve docker.io/library/golang:1.25-bookworm@sha256:298734aec230b5f3e8cee450ce6d7eccc39f1797ba548ee90d57e9803030c6c3 0.0s done #8 DONE 0.0s #9 [observer stage-1 1/2] FROM docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 #9 resolve docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 0.0s done #9 DONE 0.0s #10 [app internal] load build context #10 transferring context: 7.78kB done #10 DONE 0.0s #11 [app build 2/5] WORKDIR /app #11 CACHED #12 [observer internal] load build context #12 transferring context: 8.36kB 0.0s done #12 DONE 0.0s #13 [observer build 5/8] COPY docs/examples.md ./docs/examples.md #13 CACHED #14 [observer stage-1 2/4] RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates lsof && rm -rf /var/lib/apt/lists/* #14 CACHED #15 [observer build 8/8] RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/obstudio ./cmd/obstudio #15 CACHED #16 [observer build 3/8] COPY observer ./observer #16 CACHED #17 [observer build 4/8] COPY skills ./skill",
-      "mode": "with_skill"
-    }
-  ]
+  "failures": []
 }

--- a/eval-reports/otel-instrument/runtime/report.md
+++ b/eval-reports/otel-instrument/runtime/report.md
@@ -7,7 +7,7 @@
 | Mode | with_skill |
 | Eval kind | runtime |
 | Skill | otel-instrument |
-| Run ID | 20260429T185105710232Z |
+| Run ID | 20260430T170207539067Z |
 | Agent model | gpt-5.5 |
 | Runtime enabled | True |
 | Workers | 1 |
@@ -17,18 +17,16 @@
 
 | Mode | Eval | Service | Prompts | With Skill | With Skill Tokens | With Skill Time | Baseline | Baseline Tokens | Baseline Time |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| with_skill | go/chi-basic/runtime/instrument | go/chi-basic | 1 | 100% (1/1) | 2.1M | 4.9m | - | - | - |
-| with_skill | go/chi-partial/runtime/instrument | go/chi-partial | 1 | 0% (0/1) | 759.7K | 3.8m | - | - | - |
-| with_skill | go/kvstore/runtime/instrument | go/kvstore | 1 | 100% (1/1) | 963.5K | 4.6m | - | - | - |
-| with_skill | node/express-basic/runtime/instrument | node/express-basic | 1 | 100% (1/1) | 442.5K | 3.2m | - | - | - |
-| with_skill | python/fastapi-celery/runtime/instrument | python/fastapi-celery | 1 | 100% (1/1) | 479.4K | 3.4m | - | - | - |
-| with_skill | python/flask-basic/runtime/instrument | python/flask-basic | 1 | 100% (1/1) | 203.6K | 2.3m | - | - | - |
+| with_skill | go/chi-basic/runtime/instrument | go/chi-basic | 1 | 100% (1/1) | 3.2M | 6.1m | - | - | - |
+| with_skill | go/chi-partial/runtime/instrument | go/chi-partial | 1 | 100% (1/1) | 1.1M | 4.6m | - | - | - |
+| with_skill | go/kvstore/runtime/instrument | go/kvstore | 1 | 100% (1/1) | 1.7M | 5.1m | - | - | - |
+| with_skill | node/express-basic/runtime/instrument | node/express-basic | 1 | 100% (1/1) | 415.6K | 4.6m | - | - | - |
+| with_skill | python/fastapi-celery/runtime/instrument | python/fastapi-celery | 1 | 100% (1/1) | 616.7K | 3.9m | - | - | - |
+| with_skill | python/flask-basic/runtime/instrument | python/flask-basic | 1 | 100% (1/1) | 490.4K | 2.9m | - | - | - |
 
 ## Runtime Failures
 
-| Mode | Service | Side | Prompt | Result | Evidence |
-|---|---|---|---|---|---|
-| with_skill | go/chi-partial | with_skill | runtime-preserving | runtime:observer-runtime-telemetry FAIL | Runtime check failed: docker compose -p codex-eval-4a2e0520ac72 -f /Users/pavankri/Cisco/obstudio/evals/go/chi-partial/eval/runtime/docker-compose.yml up -d --build exited 1: #1 [internal] load local bake definitions #1 reading from stdin 1.17kB done #1 DONE 0.0s #2 [app internal] load build definition from App.Dock... |
+No runtime failures.
 
 ## Compose Evidence
 

--- a/eval-reports/otel-instrument/sanity/benchmark.json
+++ b/eval-reports/otel-instrument/sanity/benchmark.json
@@ -7,7 +7,7 @@
     "mode": "with_skill",
     "eval_kind": "sanity",
     "skill": "otel-instrument",
-    "run_id": "20260429T165922300205Z",
+    "run_id": "20260430T165653330754Z",
     "agent_model": "gpt-5.5",
     "judge_model": "gpt-5.5",
     "rubric_enabled": false,
@@ -22,10 +22,10 @@
     "with_skill": {
       "prompt_count": 2,
       "command_count": 0,
-      "duration_seconds": 13.299,
-      "agent_duration_seconds": 13.272,
-      "tokens": 52311,
-      "agent_tokens": 52311,
+      "duration_seconds": 16.361,
+      "agent_duration_seconds": 16.348,
+      "tokens": 53101,
+      "agent_tokens": 53101,
       "error_count": 0,
       "checks": {
         "passed": 4,
@@ -49,10 +49,10 @@
       "with_skill": {
         "prompt_count": 2,
         "command_count": 0,
-        "duration_seconds": 13.299,
-        "agent_duration_seconds": 13.272,
-        "tokens": 52311,
-        "agent_tokens": 52311,
+        "duration_seconds": 16.361,
+        "agent_duration_seconds": 16.348,
+        "tokens": 53101,
+        "agent_tokens": 53101,
         "error_count": 0,
         "checks": {
           "passed": 4,
@@ -63,9 +63,9 @@
       "with_baseline": null,
       "mode": "with_skill",
       "result_paths": {
-        "eval": ".workspace/codex-evals/otel-instrument/20260429T165922300205Z/results/sanity/skill-smoke/sanity-instrument/eval.json",
-        "with_skill": ".workspace/codex-evals/otel-instrument/20260429T165922300205Z/results/sanity/skill-smoke/sanity-instrument/with_skill.json",
-        "with_baseline": ".workspace/codex-evals/otel-instrument/20260429T165922300205Z/results/sanity/skill-smoke/sanity-instrument/with_baseline.json"
+        "eval": ".workspace/codex-evals/otel-instrument/20260430T165653330754Z/results/sanity/skill-smoke/sanity-instrument/eval.json",
+        "with_skill": ".workspace/codex-evals/otel-instrument/20260430T165653330754Z/results/sanity/skill-smoke/sanity-instrument/with_skill.json",
+        "with_baseline": ".workspace/codex-evals/otel-instrument/20260430T165653330754Z/results/sanity/skill-smoke/sanity-instrument/with_baseline.json"
       }
     }
   ],

--- a/eval-reports/otel-instrument/sanity/report.md
+++ b/eval-reports/otel-instrument/sanity/report.md
@@ -7,7 +7,7 @@
 | Mode | with_skill |
 | Eval kind | sanity |
 | Skill | otel-instrument |
-| Run ID | 20260429T165922300205Z |
+| Run ID | 20260430T165653330754Z |
 | Agent model | gpt-5.5 |
 | Workers | 1 |
 | Config | evals/codex-evals.toml |
@@ -16,7 +16,7 @@
 
 | Mode | Eval | Service | Prompts | With Skill | With Skill Tokens | With Skill Time | Baseline | Baseline Tokens | Baseline Time |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| with_skill | sanity/skill-smoke/sanity/instrument | sanity/skill-smoke | 2 | 100% (4/4) | 52.3K | 13.3s | - | - | - |
+| with_skill | sanity/skill-smoke/sanity/instrument | sanity/skill-smoke | 2 | 100% (4/4) | 53.1K | 16.4s | - | - | - |
 
 ## Sanity Failures
 

--- a/evals/go/chi-basic/eval/runtime/instrument.json
+++ b/evals/go/chi-basic/eval/runtime/instrument.json
@@ -13,17 +13,23 @@
       "compose_file": "docker-compose.yml",
       "timeout_seconds": 300,
       "expect": {
-        "traces": {
-          "span_names": [
-            "server"
-          ]
-        },
-        "metrics": {
-          "contains_any": [
-            "http.server.request.duration",
-            "http.server.duration"
-          ]
-        }
+        "endpoints": [
+          {
+            "id": "traces",
+            "url": "/api/query/traces",
+            "field_checks": {
+              "span_names": ["server"]
+            }
+          },
+          {
+            "id": "metrics",
+            "url": "/api/query/metrics",
+            "contains_any": [
+              "http.server.request.duration",
+              "http.server.duration"
+            ]
+          }
+        ]
       }
     }
   ]

--- a/evals/go/chi-partial/eval/runtime/instrument.json
+++ b/evals/go/chi-partial/eval/runtime/instrument.json
@@ -13,17 +13,23 @@
       "compose_file": "docker-compose.yml",
       "timeout_seconds": 300,
       "expect": {
-        "traces": {
-          "span_names": [
-            "server"
-          ]
-        },
-        "metrics": {
-          "contains_any": [
-            "http.server.request.duration",
-            "http.server.duration"
-          ]
-        }
+        "endpoints": [
+          {
+            "id": "traces",
+            "url": "/api/query/traces",
+            "field_checks": {
+              "span_names": ["server"]
+            }
+          },
+          {
+            "id": "metrics",
+            "url": "/api/query/metrics",
+            "contains_any": [
+              "http.server.request.duration",
+              "http.server.duration"
+            ]
+          }
+        ]
       }
     }
   ]

--- a/evals/go/kvstore/eval/runtime/instrument.json
+++ b/evals/go/kvstore/eval/runtime/instrument.json
@@ -13,17 +13,23 @@
       "compose_file": "docker-compose.yml",
       "timeout_seconds": 300,
       "expect": {
-        "traces": {
-          "span_names": [
-            "server"
-          ]
-        },
-        "metrics": {
-          "contains_any": [
-            "http.server.request.duration",
-            "http.server.duration"
-          ]
-        }
+        "endpoints": [
+          {
+            "id": "traces",
+            "url": "/api/query/traces",
+            "field_checks": {
+              "span_names": ["server"]
+            }
+          },
+          {
+            "id": "metrics",
+            "url": "/api/query/metrics",
+            "contains_any": [
+              "http.server.request.duration",
+              "http.server.duration"
+            ]
+          }
+        ]
       }
     }
   ]

--- a/evals/node/express-basic/eval/runtime/instrument.json
+++ b/evals/node/express-basic/eval/runtime/instrument.json
@@ -13,24 +13,32 @@
       "compose_file": "docker-compose.yml",
       "timeout_seconds": 300,
       "expect": {
-        "traces": {
-          "service_names": [
-            "node-express-basic"
-          ],
-          "trace_detail_contains_all": [
-            "http.request.method",
-            "GET",
-            "POST",
-            "/health",
-            "/tasks"
-          ]
-        },
-        "metrics": {
-          "contains_any": [
-            "http.server.request.duration",
-            "http.server.duration"
-          ]
-        }
+        "endpoints": [
+          {
+            "id": "traces",
+            "url": "/api/query/traces",
+            "field_checks": {
+              "service_names": ["node-express-basic"]
+            },
+            "detail_path_template": "/api/query/traces/{id}",
+            "detail_id_field": "traceId",
+            "detail_contains_all": [
+              "http.request.method",
+              "GET",
+              "POST",
+              "/health",
+              "/tasks"
+            ]
+          },
+          {
+            "id": "metrics",
+            "url": "/api/query/metrics",
+            "contains_any": [
+              "http.server.request.duration",
+              "http.server.duration"
+            ]
+          }
+        ]
       }
     }
   ]

--- a/evals/python/fastapi-celery/eval/runtime/instrument.json
+++ b/evals/python/fastapi-celery/eval/runtime/instrument.json
@@ -13,19 +13,23 @@
       "compose_file": "docker-compose.yml",
       "timeout_seconds": 300,
       "expect": {
-        "traces": {
-          "span_names": [
-            "GET /health",
-            "GET /orders",
-            "POST /orders"
-          ]
-        },
-        "metrics": {
-          "contains_any": [
-            "http.server.request.duration",
-            "http.server.duration"
-          ]
-        }
+        "endpoints": [
+          {
+            "id": "traces",
+            "url": "/api/query/traces",
+            "field_checks": {
+              "span_names": ["GET /health", "GET /orders", "POST /orders"]
+            }
+          },
+          {
+            "id": "metrics",
+            "url": "/api/query/metrics",
+            "contains_any": [
+              "http.server.request.duration",
+              "http.server.duration"
+            ]
+          }
+        ]
       }
     }
   ]

--- a/evals/python/flask-basic/eval/runtime/instrument.json
+++ b/evals/python/flask-basic/eval/runtime/instrument.json
@@ -13,19 +13,23 @@
       "compose_file": "docker-compose.yml",
       "timeout_seconds": 300,
       "expect": {
-        "traces": {
-          "span_names": [
-            "GET /health",
-            "GET /tasks",
-            "POST /tasks"
-          ]
-        },
-        "metrics": {
-          "contains_any": [
-            "http.server.request.duration",
-            "http.server.duration"
-          ]
-        }
+        "endpoints": [
+          {
+            "id": "traces",
+            "url": "/api/query/traces",
+            "field_checks": {
+              "span_names": ["GET /health", "GET /tasks", "POST /tasks"]
+            }
+          },
+          {
+            "id": "metrics",
+            "url": "/api/query/metrics",
+            "contains_any": [
+              "http.server.request.duration",
+              "http.server.duration"
+            ]
+          }
+        ]
       }
     }
   ]

--- a/observer/cmd/obstudio/install.go
+++ b/observer/cmd/obstudio/install.go
@@ -179,11 +179,11 @@ func runInstall(target, sharedURL string) error {
 	}
 
 	if resolvedSharedURL == "" {
-		fmt.Println("\nDone. Restart your editor to activate the MCP server.")
+		fmt.Printf("\nDone. Restart %s to activate the MCP server.\n", target)
 		return nil
 	}
 
-	fmt.Println("\nDone. Start the shared obstudio server before opening your agent:")
+	fmt.Printf("\nDone. Start the shared obstudio server before using %s:\n", target)
 	fmt.Println("  obstudio")
 	return nil
 }

--- a/pytest-codex-evals/src/pytest_codex_evals/backends.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/backends.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from .trace import TraceSummary, parse_trace
+
+
+@dataclass
+class AgentResult:
+    returncode: int
+    trace_path: Path
+    final_message_path: Path
+    stderr_path: Path
+
+
+class AgentBackend(Protocol):
+    """Protocol for pluggable agent execution backends."""
+
+    @property
+    def name(self) -> str: ...
+
+    def run_agent(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        timeout: int = 1200,
+    ) -> AgentResult: ...
+
+    def run_judge(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        schema_path: Path | None = None,
+        timeout: int = 900,
+    ) -> AgentResult: ...
+
+    def parse_trace(self, trace_path: Path) -> TraceSummary: ...
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StreamedCommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_streamed_command(
+    cmd: list[str],
+    *,
+    stdout_path: Path,
+    stderr_path: Path,
+    timeout: int,
+    env: dict[str, str] | None = None,
+) -> StreamedCommandResult:
+    stdout_chunks: list[str] = []
+    stderr_chunks: list[str] = []
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+
+    stdout_thread = threading.Thread(
+        target=_pump_stream,
+        args=(process.stdout, stdout_path, stdout_chunks),
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_pump_stream,
+        args=(process.stderr, stderr_path, stderr_chunks),
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    try:
+        returncode = process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+        stdout_thread.join(timeout=5)
+        stderr_thread.join(timeout=5)
+        raise
+    stdout_thread.join()
+    stderr_thread.join()
+    return StreamedCommandResult(
+        returncode=returncode,
+        stdout="".join(stdout_chunks),
+        stderr="".join(stderr_chunks),
+    )
+
+
+def _pump_stream(pipe: Any, output_path: Path, chunks: list[str]) -> None:
+    if pipe is None:
+        output_path.write_text("", encoding="utf-8")
+        return
+    with output_path.open("w", encoding="utf-8") as output:
+        for line in pipe:
+            chunks.append(line)
+            output.write(line)
+            output.flush()
+
+
+# ---------------------------------------------------------------------------
+# Codex backend
+# ---------------------------------------------------------------------------
+
+
+def _codex_subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    clean_package_config = env.get("CODEX_EVAL_CLEAN_PACKAGE_CONFIG", "1").strip().lower()
+    if clean_package_config in {"1", "true", "yes", "on"}:
+        default_index = env.get("UV_DEFAULT_INDEX") or env.get("PIP_INDEX_URL") or "https://pypi.org/simple"
+        env["UV_NO_CONFIG"] = "1"
+        env["UV_DEFAULT_INDEX"] = default_index
+        env["PIP_CONFIG_FILE"] = os.devnull
+        env["PIP_INDEX_URL"] = default_index
+        env.pop("PIP_EXTRA_INDEX_URL", None)
+    return env
+
+
+@dataclass
+class CodexBackend:
+    command: str = "codex"
+    extra_args: list[str] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def run_agent(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        timeout: int = 1200,
+    ) -> AgentResult:
+        trace_path = exec_dir / "trace.jsonl"
+        final_path = exec_dir / "last_message.md"
+        stderr_path = exec_dir / "stderr.txt"
+
+        cmd = [
+            self.command,
+            "exec",
+            "--json",
+            "--full-auto",
+            "--skip-git-repo-check",
+            "--cd",
+            str(exec_dir),
+            "--output-last-message",
+            str(final_path),
+            *self.extra_args,
+        ]
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append(prompt)
+
+        completed = run_streamed_command(
+            cmd,
+            stdout_path=trace_path,
+            stderr_path=stderr_path,
+            timeout=timeout,
+            env=_codex_subprocess_env(),
+        )
+        if not final_path.exists():
+            final_path.write_text("", encoding="utf-8")
+
+        return AgentResult(
+            returncode=completed.returncode,
+            trace_path=trace_path,
+            final_message_path=final_path,
+            stderr_path=stderr_path,
+        )
+
+    def run_judge(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        schema_path: Path | None = None,
+        timeout: int = 900,
+    ) -> AgentResult:
+        output_path = exec_dir / "rubric_grade.json"
+        trace_path = exec_dir / "rubric_trace.jsonl"
+        stderr_path = exec_dir / "rubric_stderr.txt"
+
+        cmd = [
+            self.command,
+            "exec",
+            "--json",
+            "--sandbox",
+            "read-only",
+            "--skip-git-repo-check",
+            "--cd",
+            str(exec_dir),
+        ]
+        if schema_path:
+            cmd.extend(["--output-schema", str(schema_path)])
+        cmd.extend(["--output-last-message", str(output_path), *self.extra_args])
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append(prompt)
+
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        trace_path.write_text(completed.stdout, encoding="utf-8")
+        stderr_path.write_text(completed.stderr, encoding="utf-8")
+
+        if completed.returncode != 0 and not output_path.exists():
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "overall_pass": False,
+                        "score": 0,
+                        "checks": [
+                            {
+                                "id": "rubric-run",
+                                "pass": False,
+                                "notes": f"Agent rubric grader exited with {completed.returncode}",
+                                "evidence": completed.stderr[-1000:],
+                            }
+                        ],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+        return AgentResult(
+            returncode=completed.returncode,
+            trace_path=trace_path,
+            final_message_path=output_path,
+            stderr_path=stderr_path,
+        )
+
+    def parse_trace(self, trace_path: Path) -> TraceSummary:
+        return parse_trace(trace_path)
+
+
+# ---------------------------------------------------------------------------
+# Cursor backend
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CursorBackend:
+    command: str = "cursor"
+    extra_args: list[str] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return "cursor"
+
+    def run_agent(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        timeout: int = 1200,
+    ) -> AgentResult:
+        trace_path = exec_dir / "trace.jsonl"
+        final_path = exec_dir / "last_message.md"
+        stderr_path = exec_dir / "stderr.txt"
+
+        cmd = [
+            self.command,
+            "--cli",
+            "agent",
+            "--full-auto",
+            "--skip-git-repo-check",
+            "--cd",
+            str(exec_dir),
+            "--output-last-message",
+            str(final_path),
+            *self.extra_args,
+        ]
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append(prompt)
+
+        completed = run_streamed_command(
+            cmd,
+            stdout_path=trace_path,
+            stderr_path=stderr_path,
+            timeout=timeout,
+        )
+        if not final_path.exists():
+            final_path.write_text("", encoding="utf-8")
+
+        return AgentResult(
+            returncode=completed.returncode,
+            trace_path=trace_path,
+            final_message_path=final_path,
+            stderr_path=stderr_path,
+        )
+
+    def run_judge(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        schema_path: Path | None = None,
+        timeout: int = 900,
+    ) -> AgentResult:
+        output_path = exec_dir / "rubric_grade.json"
+        trace_path = exec_dir / "rubric_trace.jsonl"
+        stderr_path = exec_dir / "rubric_stderr.txt"
+
+        cmd = [
+            self.command,
+            "--cli",
+            "agent",
+            "--full-auto",
+            "--skip-git-repo-check",
+            "--cd",
+            str(exec_dir),
+        ]
+        if schema_path:
+            cmd.extend(["--output-schema", str(schema_path)])
+        cmd.extend(["--output-last-message", str(output_path), *self.extra_args])
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append(prompt)
+
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        trace_path.write_text(completed.stdout, encoding="utf-8")
+        stderr_path.write_text(completed.stderr, encoding="utf-8")
+
+        if completed.returncode != 0 and not output_path.exists():
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "overall_pass": False,
+                        "score": 0,
+                        "checks": [
+                            {
+                                "id": "rubric-run",
+                                "pass": False,
+                                "notes": f"Agent rubric grader exited with {completed.returncode}",
+                                "evidence": completed.stderr[-1000:],
+                            }
+                        ],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+        return AgentResult(
+            returncode=completed.returncode,
+            trace_path=trace_path,
+            final_message_path=output_path,
+            stderr_path=stderr_path,
+        )
+
+    def parse_trace(self, trace_path: Path) -> TraceSummary:
+        return parse_trace(trace_path)
+
+
+# ---------------------------------------------------------------------------
+# Claude Code backend
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClaudeBackend:
+    command: str = "claude"
+    extra_args: list[str] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return "claude"
+
+    def run_agent(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        timeout: int = 1200,
+    ) -> AgentResult:
+        trace_path = exec_dir / "trace.jsonl"
+        final_path = exec_dir / "last_message.md"
+        stderr_path = exec_dir / "stderr.txt"
+
+        cmd = [
+            self.command,
+            "-p",
+            prompt,
+            "--output-format",
+            "json",
+            "--max-turns",
+            "50",
+            *self.extra_args,
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        completed = run_streamed_command(
+            cmd,
+            stdout_path=trace_path,
+            stderr_path=stderr_path,
+            timeout=timeout,
+            env=_claude_subprocess_env(exec_dir),
+        )
+        if not final_path.exists():
+            _extract_claude_final_message(trace_path, final_path)
+
+        return AgentResult(
+            returncode=completed.returncode,
+            trace_path=trace_path,
+            final_message_path=final_path,
+            stderr_path=stderr_path,
+        )
+
+    def run_judge(
+        self,
+        *,
+        prompt: str,
+        exec_dir: Path,
+        model: str | None = None,
+        schema_path: Path | None = None,
+        timeout: int = 900,
+    ) -> AgentResult:
+        output_path = exec_dir / "rubric_grade.json"
+        trace_path = exec_dir / "rubric_trace.jsonl"
+        stderr_path = exec_dir / "rubric_stderr.txt"
+
+        judge_prompt = prompt
+        if schema_path:
+            schema_text = schema_path.read_text(encoding="utf-8")
+            judge_prompt = f"{prompt}\n\nOutput must conform to this JSON schema:\n{schema_text}"
+
+        cmd = [
+            self.command,
+            "-p",
+            judge_prompt,
+            "--output-format",
+            "json",
+            "--max-turns",
+            "5",
+            *self.extra_args,
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=exec_dir,
+        )
+        trace_path.write_text(completed.stdout, encoding="utf-8")
+        stderr_path.write_text(completed.stderr, encoding="utf-8")
+
+        _extract_claude_final_message(trace_path, output_path)
+
+        if completed.returncode != 0 and not output_path.exists():
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "overall_pass": False,
+                        "score": 0,
+                        "checks": [
+                            {
+                                "id": "rubric-run",
+                                "pass": False,
+                                "notes": f"Agent rubric grader exited with {completed.returncode}",
+                                "evidence": completed.stderr[-1000:],
+                            }
+                        ],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+        return AgentResult(
+            returncode=completed.returncode,
+            trace_path=trace_path,
+            final_message_path=output_path,
+            stderr_path=stderr_path,
+        )
+
+    def parse_trace(self, trace_path: Path) -> TraceSummary:
+        return _parse_claude_trace(trace_path)
+
+
+def _claude_subprocess_env(exec_dir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["CLAUDE_CWD"] = str(exec_dir)
+    return env
+
+
+def _extract_claude_final_message(trace_path: Path, output_path: Path) -> None:
+    """Extract the last assistant text from Claude JSON output."""
+    try:
+        raw = trace_path.read_text(encoding="utf-8", errors="replace")
+        data = json.loads(raw) if raw.strip() else {}
+        result_text = ""
+        if isinstance(data, dict):
+            result_text = data.get("result", "") or ""
+        elif isinstance(data, list) and data:
+            last = data[-1]
+            if isinstance(last, dict):
+                result_text = last.get("content", "") or last.get("result", "") or ""
+        output_path.write_text(result_text, encoding="utf-8")
+    except (json.JSONDecodeError, OSError):
+        output_path.write_text("", encoding="utf-8")
+
+
+def _parse_claude_trace(trace_path: Path) -> TraceSummary:
+    """Parse Claude Code JSON output into TraceSummary (best-effort)."""
+    from .trace import CommandEvent, TraceSummary, TraceUsage
+
+    raw = trace_path.read_text(encoding="utf-8", errors="replace")
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return TraceSummary([], raw)
+
+    events: list[dict[str, Any]] = []
+    if isinstance(data, dict):
+        events = [data]
+    elif isinstance(data, list):
+        events = data
+
+    commands: list[CommandEvent] = []
+    usage = TraceUsage()
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "tool_use" and event.get("name") in {"bash", "execute_command"}:
+            cmd_text = ""
+            inp = event.get("input", {})
+            if isinstance(inp, dict):
+                cmd_text = inp.get("command", "")
+            if cmd_text:
+                commands.append(CommandEvent(command=cmd_text))
+        u = event.get("usage")
+        if isinstance(u, dict):
+            usage.input_tokens += int(u.get("input_tokens") or 0)
+            usage.output_tokens += int(u.get("output_tokens") or 0)
+
+    if usage.total_tokens == 0:
+        usage.total_tokens = usage.input_tokens + usage.output_tokens
+    summary = TraceSummary(events, raw)
+    summary.commands = commands
+    summary.usage = usage
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Backend registry
+# ---------------------------------------------------------------------------
+
+BACKEND_REGISTRY: dict[str, type] = {
+    "codex": CodexBackend,
+    "cursor": CursorBackend,
+    "claude": ClaudeBackend,
+}
+
+
+def create_backend(
+    name: str = "codex",
+    command: str | None = None,
+    extra_args: list[str] | None = None,
+) -> AgentBackend:
+    cls = BACKEND_REGISTRY.get(name)
+    if cls is None:
+        raise ValueError(f"unknown agent backend: {name!r}; available: {', '.join(BACKEND_REGISTRY)}")
+    kwargs: dict[str, Any] = {}
+    if command is not None:
+        kwargs["command"] = command
+    if extra_args is not None:
+        kwargs["extra_args"] = extra_args
+    return cls(**kwargs)

--- a/pytest-codex-evals/src/pytest_codex_evals/config.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +14,11 @@ class CodexEvalSettings:
     runtime_enabled: bool = False
     agent_model: str | None = None
     judge_model: str | None = None
+    agent_backend: str = "codex"
+    agent_command: str | None = None
+    agent_extra_args: tuple[str, ...] = ()
+    agent_timeout: int = 1200
+    judge_timeout: int = 900
 
 
 def load_settings(path: Path | None) -> CodexEvalSettings:
@@ -24,6 +29,7 @@ def load_settings(path: Path | None) -> CodexEvalSettings:
     rubric = table(data, "rubric")
     runtime = table(data, "runtime")
     models = table(data, "models")
+    agent = table(data, "agent")
     return CodexEvalSettings(
         run_mode=run_mode(run),
         eval_kind=eval_kind(run),
@@ -31,6 +37,11 @@ def load_settings(path: Path | None) -> CodexEvalSettings:
         runtime_enabled=bool(runtime.get("enabled", False)),
         agent_model=optional_string(models.get("agent")),
         judge_model=optional_string(models.get("judge")),
+        agent_backend=agent_backend(agent),
+        agent_command=optional_string(agent.get("command")),
+        agent_extra_args=agent_extra_args(agent),
+        agent_timeout=int(agent.get("timeout", 1200)),
+        judge_timeout=int(agent.get("judge_timeout", 900)),
     )
 
 
@@ -82,3 +93,20 @@ def eval_kind(run: dict[str, Any]) -> str:
     if normalized not in {"validation", "standard", "sanity", "rubric", "runtime"}:
         raise ValueError("[run].eval_kind must be one of: validation, standard, sanity, rubric, runtime")
     return normalized
+
+
+def agent_backend(agent: dict[str, Any]) -> str:
+    value = agent.get("backend", "codex")
+    if not isinstance(value, str):
+        raise ValueError("[agent].backend must be a string")
+    normalized = value.strip().lower()
+    if normalized not in {"codex", "cursor", "claude"}:
+        raise ValueError("[agent].backend must be one of: codex, cursor, claude")
+    return normalized
+
+
+def agent_extra_args(agent: dict[str, Any]) -> tuple[str, ...]:
+    value = agent.get("extra_args", [])
+    if not isinstance(value, list):
+        raise ValueError("[agent].extra_args must be a list of strings")
+    return tuple(str(arg) for arg in value)

--- a/pytest-codex-evals/src/pytest_codex_evals/definitions/__init__.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/definitions/__init__.py
@@ -11,7 +11,7 @@ from .base import (
     ValidationResult,
 )
 from .rubric import RubricEvalCase, RubricEvalDefinition
-from .runtime import ObserverExpectation, RuntimeCheck, RuntimeEvalCase, RuntimeEvalDefinition, RuntimeExpectations
+from .runtime import EndpointExpectation, RuntimeCheck, RuntimeEvalCase, RuntimeEvalDefinition, RuntimeExpectations
 from .sanity import SanityCheck, SanityEvalCase, SanityEvalDefinition
 
 EvalDefinition = SanityEvalDefinition | RubricEvalDefinition | RuntimeEvalDefinition
@@ -24,10 +24,11 @@ __all__ = [
     "CheckCategory",
     "EvalCase",
     "EvalDefinition",
+    "EndpointExpectation",
     "EvalRole",
     "GradeCheckResult",
     "GradeResult",
-    "ObserverExpectation",
+
     "PromptVariant",
     "RubricEvalCase",
     "RubricEvalDefinition",

--- a/pytest-codex-evals/src/pytest_codex_evals/definitions/runtime.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/definitions/runtime.py
@@ -7,19 +7,38 @@ from pydantic import BaseModel, Field
 from .base import BaseEvalCase, BaseEvalDefinition
 
 
-class ObserverExpectation(BaseModel):
-    path: str | None = None
+# ---------------------------------------------------------------------------
+# Generic endpoint expectation (domain-agnostic)
+# ---------------------------------------------------------------------------
+
+
+class EndpointExpectation(BaseModel):
+    id: str
+    url: str = ""
+    method: str = "GET"
     contains_all: list[str] = Field(default_factory=list)
     contains_any: list[str] = Field(default_factory=list)
-    service_names: list[str] = Field(default_factory=list)
-    span_names: list[str] = Field(default_factory=list)
-    metric_names: list[str] = Field(default_factory=list)
-    trace_detail_contains_all: list[str] = Field(default_factory=list)
+    field_checks: dict[str, list[str]] = Field(default_factory=dict)
+    detail_path_template: str | None = None
+    detail_id_field: str | None = None
+    detail_contains_all: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Runtime expectations
+# ---------------------------------------------------------------------------
 
 
 class RuntimeExpectations(BaseModel):
-    traces: ObserverExpectation | None = None
-    metrics: ObserverExpectation | None = None
+    service_name: str = "observer"
+    service_port: int = 3000
+    health_path: str = "/api/health"
+    clear_path: str | None = "/api/data"
+    clear_method: str = "DELETE"
+    endpoints: list[EndpointExpectation] = Field(default_factory=list)
+
+    def has_expectations(self) -> bool:
+        return bool(self.endpoints)
 
 
 class RuntimeCheck(BaseModel):

--- a/pytest-codex-evals/src/pytest_codex_evals/graders/rubric.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/graders/rubric.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 
 from jsonschema import Draft202012Validator
 
+from pytest_codex_evals.backends import AgentBackend, CodexBackend
 from pytest_codex_evals.definitions import RubricEvalCase
 from pytest_codex_evals.schema_resources import schema_path as packaged_schema_path
 
@@ -16,11 +16,14 @@ def run_rubric_grade(
     side_dir: Path,
     schema_path: Path | None = None,
     model: str | None,
+    backend: AgentBackend | None = None,
 ) -> Path:
+    if backend is None:
+        backend = CodexBackend()
     if schema_path is None:
         with packaged_schema_path("rubric_grade.schema.json") as path:
-            return _run_rubric_grade(case=case, side_dir=side_dir, schema_path=path, model=model)
-    return _run_rubric_grade(case=case, side_dir=side_dir, schema_path=schema_path, model=model)
+            return _run_rubric_grade(case=case, side_dir=side_dir, schema_path=path, model=model, backend=backend)
+    return _run_rubric_grade(case=case, side_dir=side_dir, schema_path=schema_path, model=model, backend=backend)
 
 
 def _run_rubric_grade(
@@ -29,48 +32,15 @@ def _run_rubric_grade(
     side_dir: Path,
     schema_path: Path,
     model: str | None,
+    backend: AgentBackend,
 ) -> Path:
-    output_path = side_dir / "rubric_grade.json"
-    trace_path = side_dir / "rubric_trace.jsonl"
-    cmd = [
-        "codex",
-        "exec",
-        "--json",
-        "--sandbox",
-        "read-only",
-        "--skip-git-repo-check",
-        "--cd",
-        str(side_dir),
-        "--output-schema",
-        str(schema_path),
-        "--output-last-message",
-        str(output_path),
-    ]
-    if model:
-        cmd.extend(["--model", model])
-    cmd.append(rubric_prompt(case))
-    completed = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
-    trace_path.write_text(completed.stdout, encoding="utf-8")
-    (side_dir / "rubric_stderr.txt").write_text(completed.stderr, encoding="utf-8")
-    if completed.returncode != 0 and not output_path.exists():
-        output_path.write_text(
-            json.dumps(
-                {
-                    "overall_pass": False,
-                    "score": 0,
-                    "checks": [
-                        {
-                            "id": "rubric-run",
-                            "pass": False,
-                            "notes": f"Codex rubric grader exited with {completed.returncode}",
-                            "evidence": completed.stderr[-1000:],
-                        }
-                    ],
-                },
-                indent=2,
-            ),
-            encoding="utf-8",
-        )
+    result = backend.run_judge(
+        prompt=rubric_prompt(case),
+        exec_dir=side_dir,
+        model=model,
+        schema_path=schema_path,
+    )
+    output_path = result.final_message_path
     validate_rubric_output(output_path, schema_path)
     return output_path
 

--- a/pytest-codex-evals/src/pytest_codex_evals/graders/runtime.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/graders/runtime.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from pytest_codex_evals.definitions import GradeCheckResult, GradeResult, RuntimeCheck, RuntimeEvalCase
+from pytest_codex_evals.definitions.runtime import EndpointExpectation, RuntimeExpectations
 from pytest_codex_evals.trace import TraceSummary
 
 from .shared import guard_checks
@@ -42,11 +43,11 @@ def grade_runtime(
                 )
             )
             continue
-        results.append(run_observer_runtime(check, service_dir, repo_root, eval_dir))
+        results.append(run_runtime_check(check, service_dir, repo_root, eval_dir))
     return GradeResult(checks=results)
 
 
-def run_observer_runtime(
+def run_runtime_check(
     check: RuntimeCheck,
     service_dir: Path,
     repo_root: Path | None = None,
@@ -55,19 +56,21 @@ def run_observer_runtime(
     compose_file: Path | None = None
     project = safe_name(f"codex-eval-{uuid.uuid4().hex[:12]}")
     env = runtime_env(repo_root, service_dir, project)
+    expect = check.expect
     try:
         compose_file = resolve_compose_file(check, service_dir, eval_dir)
         cwd = compose_file.parent
         run_process(compose_command(compose_file, project) + ["up", "-d", "--build"], cwd, env, check.timeout_seconds)
-        observer_base_url = discover_observer_base_url(compose_file, project, env)
-        wait_for_observer(observer_base_url, check.timeout_seconds)
-        clear_observer(observer_base_url)
+        base_url = discover_service_base_url(compose_file, project, env, expect.service_name, expect.service_port)
+        wait_for_service(base_url, expect.health_path, check.timeout_seconds)
+        if expect.clear_path:
+            clear_service(base_url, expect.clear_path, expect.clear_method)
         run_process(compose_command(compose_file, project, profile="traffic") + ["run", "--rm", "traffic"], cwd, env, check.timeout_seconds)
 
         if check.settle_seconds > 0:
             time.sleep(check.settle_seconds)
 
-        passed, evidence = validate_observer_expectations(check.expect.model_dump(exclude_none=True), observer_base_url)
+        passed, evidence = validate_endpoint_expectations(expect.endpoints, base_url)
         if not passed:
             evidence = evidence_with_compose_logs(evidence, compose_file, project, env)
         return runtime_result(check, passed, evidence)
@@ -88,6 +91,118 @@ def run_observer_runtime(
                 )
             except Exception:
                 pass
+
+
+# ---------------------------------------------------------------------------
+# Generic endpoint validation
+# ---------------------------------------------------------------------------
+
+
+def validate_endpoint_expectations(
+    endpoints: list[EndpointExpectation],
+    base_url: str,
+) -> tuple[bool, str]:
+    if not endpoints:
+        return False, "runtime expect must include at least one endpoint expectation"
+
+    evidence: list[str] = []
+    failures: list[str] = []
+
+    for ep in endpoints:
+        url = service_url(base_url, ep.url)
+        text = request_json_text(url)
+
+        check_text_expectations(ep.id, text, ep.contains_all, ep.contains_any, ep.field_checks, evidence, failures)
+
+        if ep.detail_contains_all:
+            check_detail_expectations(
+                base_url,
+                text,
+                ep.id,
+                ep.detail_path_template or "",
+                ep.detail_id_field or "id",
+                ep.detail_contains_all,
+                evidence,
+                failures,
+            )
+
+    if failures:
+        return False, "; ".join(failures)
+    return True, "; ".join(evidence) if evidence else "Endpoint expectations passed"
+
+
+def check_text_expectations(
+    scope: str,
+    text: str,
+    contains_all: list[str],
+    contains_any: list[str],
+    field_checks: dict[str, list[str]],
+    evidence: list[str],
+    failures: list[str],
+) -> None:
+    if contains_all:
+        missing = [v for v in contains_all if v.lower() not in text.lower()]
+        if missing:
+            failures.append(f"{scope} missing contains_all: {', '.join(missing)}")
+        else:
+            evidence.append(f"{scope} matched contains_all: {', '.join(contains_all)}")
+
+    if contains_any:
+        if not any(v.lower() in text.lower() for v in contains_any):
+            failures.append(f"{scope} missing any contains_any: {', '.join(contains_any)}")
+        else:
+            evidence.append(f"{scope} matched one of contains_any: {', '.join(contains_any)}")
+
+    for key, values in field_checks.items():
+        missing = [v for v in values if v.lower() not in text.lower()]
+        if missing:
+            failures.append(f"{scope} missing {key}: {', '.join(missing)}")
+        elif values:
+            evidence.append(f"{scope} matched {key}: {', '.join(values)}")
+
+
+def check_detail_expectations(
+    base_url: str,
+    list_text: str,
+    scope: str,
+    detail_path_template: str,
+    detail_id_field: str,
+    detail_contains_all: list[str],
+    evidence: list[str],
+    failures: list[str],
+) -> None:
+    if not detail_contains_all or not detail_path_template:
+        return
+    try:
+        summaries = json.loads(list_text)
+    except json.JSONDecodeError:
+        failures.append(f"{scope} detail unavailable: list response was not JSON")
+        return
+    if not isinstance(summaries, list) or not summaries:
+        failures.append(f"{scope} detail unavailable: no summaries returned")
+        return
+
+    detail_texts: list[str] = []
+    for summary in summaries[:20]:
+        if not isinstance(summary, dict):
+            continue
+        item_id = str(summary.get(detail_id_field) or "")
+        if not item_id:
+            continue
+        detail_url = detail_path_template.replace("{id}", item_id)
+        detail_texts.append(request_json_text(service_url(base_url, detail_url)))
+
+    combined = "\n".join(detail_texts)
+    missing = [v for v in detail_contains_all if v.lower() not in combined.lower()]
+    if missing:
+        failures.append(f"{scope} missing detail_contains_all: {', '.join(missing)}")
+    else:
+        evidence.append(f"{scope} matched detail_contains_all: {', '.join(detail_contains_all)}")
+
+
+# ---------------------------------------------------------------------------
+# Compose / service discovery helpers
+# ---------------------------------------------------------------------------
 
 
 def resolve_compose_file(check: RuntimeCheck, service_dir: Path, eval_dir: Path | None = None) -> Path:
@@ -158,35 +273,41 @@ def compose_logs(compose_file: Path, project: str, env: dict[str, str]) -> str:
     return f"compose logs: {output}" if output else ""
 
 
-def discover_observer_base_url(compose_file: Path, project: str, env: dict[str, str]) -> str:
+def discover_service_base_url(
+    compose_file: Path,
+    project: str,
+    env: dict[str, str],
+    service_name: str = "observer",
+    service_port: int = 3000,
+) -> str:
     completed = run_process(
-        compose_command(compose_file, project) + ["port", "observer", "3000"],
+        compose_command(compose_file, project) + ["port", service_name, str(service_port)],
         compose_file.parent,
         env,
         timeout=30,
     )
-    return observer_base_url_from_port_output(completed.stdout)
+    return base_url_from_port_output(completed.stdout, service_name)
 
 
-def observer_base_url_from_port_output(output: str) -> str:
+def base_url_from_port_output(output: str, service_name: str = "observer") -> str:
     line = next((item.strip() for item in output.splitlines() if item.strip()), "")
     if not line:
-        raise RuntimeError("docker compose port observer 3000 returned no output")
+        raise RuntimeError(f"docker compose port {service_name} returned no output")
     host, separator, port = line.rpartition(":")
     if not separator or not port:
-        raise RuntimeError(f"could not parse observer port output: {line}")
+        raise RuntimeError(f"could not parse port output for {service_name}: {line}")
     host = host.strip("[]")
     if host in {"", "0.0.0.0", "::"}:
         host = "127.0.0.1"
     return f"http://{host}:{port}"
 
 
-def clear_observer(base_url: str) -> None:
-    request_text(observer_url(base_url, "/api/data"), method="DELETE", timeout=10, allow_404=True)
+def clear_service(base_url: str, path: str, method: str = "DELETE") -> None:
+    request_text(service_url(base_url, path), method=method, timeout=10, allow_404=True)
 
 
-def wait_for_observer(base_url: str, timeout: int) -> None:
-    url = observer_url(base_url, "/api/health")
+def wait_for_service(base_url: str, health_path: str, timeout: int) -> None:
+    url = service_url(base_url, health_path)
     deadline = time.monotonic() + timeout
     last_error = ""
     while time.monotonic() < deadline:
@@ -198,81 +319,15 @@ def wait_for_observer(base_url: str, timeout: int) -> None:
         except Exception as exc:
             last_error = str(exc)
         time.sleep(1)
-    raise TimeoutError(f"observer did not reach 200: {url}; last error: {last_error}")
+    raise TimeoutError(f"service did not reach 200: {url}; last error: {last_error}")
 
 
-def validate_observer_expectations(expect: dict[str, Any], base_url: str) -> tuple[bool, str]:
-    if not expect:
-        return False, "runtime expect is required"
-
-    evidence = []
-    failures = []
-    traces = expect.get("traces") or {}
-    if traces:
-        text = request_json_text(observer_url(base_url, traces.get("path", "/api/query/traces")))
-        check_expected_text("traces", text, traces, evidence, failures)
-        check_trace_detail_expectations(base_url, text, traces, evidence, failures)
-
-    metrics = expect.get("metrics") or {}
-    if metrics:
-        text = request_json_text(observer_url(base_url, metrics.get("path", "/api/query/metrics")))
-        check_expected_text("metrics", text, metrics, evidence, failures)
-
-    if not traces and not metrics:
-        return False, "runtime expect must include traces or metrics expectations"
-    if failures:
-        return False, "; ".join(failures)
-    return True, "; ".join(evidence) if evidence else "Observer expectations passed"
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
 
 
-def check_expected_text(scope: str, text: str, expect: dict[str, Any], evidence: list[str], failures: list[str]) -> None:
-    for key in ("contains_all", "service_names", "span_names", "metric_names"):
-        values = [str(value) for value in expect.get(key, [])]
-        missing = [value for value in values if value.lower() not in text.lower()]
-        if missing:
-            failures.append(f"{scope} missing {key}: {', '.join(missing)}")
-        elif values:
-            evidence.append(f"{scope} matched {key}: {', '.join(values)}")
-
-    for key in ("contains_any", "span_name_contains_any", "metric_name_contains_any"):
-        values = [str(value) for value in expect.get(key, [])]
-        if values and not any(value.lower() in text.lower() for value in values):
-            failures.append(f"{scope} missing any {key}: {', '.join(values)}")
-        elif values:
-            evidence.append(f"{scope} matched one of {key}: {', '.join(values)}")
-
-
-def check_trace_detail_expectations(base_url: str, traces_text: str, expect: dict[str, Any], evidence: list[str], failures: list[str]) -> None:
-    values = [str(value) for value in expect.get("trace_detail_contains_all", [])]
-    if not values:
-        return
-    try:
-        summaries = json.loads(traces_text)
-    except json.JSONDecodeError:
-        failures.append("traces detail unavailable: trace summary response was not JSON")
-        return
-    if not isinstance(summaries, list) or not summaries:
-        failures.append("traces detail unavailable: no trace summaries returned")
-        return
-
-    detail_texts: list[str] = []
-    for summary in summaries[:20]:
-        if not isinstance(summary, dict):
-            continue
-        trace_id = str(summary.get("traceId") or "")
-        if not trace_id:
-            continue
-        detail_texts.append(request_json_text(observer_url(base_url, f"/api/query/traces/{trace_id}")))
-
-    combined = "\n".join(detail_texts)
-    missing = [value for value in values if value.lower() not in combined.lower()]
-    if missing:
-        failures.append(f"traces missing trace_detail_contains_all: {', '.join(missing)}")
-    else:
-        evidence.append(f"traces matched trace_detail_contains_all: {', '.join(values)}")
-
-
-def observer_url(base_url: str, path: str) -> str:
+def service_url(base_url: str, path: str) -> str:
     if path.startswith("http://") or path.startswith("https://"):
         return path
     return base_url.rstrip("/") + "/" + path.lstrip("/")

--- a/pytest-codex-evals/src/pytest_codex_evals/plugin.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/plugin.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from .backends import AgentBackend, create_backend
 from .config import CodexEvalSettings, load_settings
 from .eval_files import eval_file_layout, is_eval_file
 from .definitions import (
@@ -28,6 +29,7 @@ from .schema_resources import schema_validator
 RUNS_ATTR = "_codex_eval_runs"
 SETTINGS_ATTR = "_codex_eval_settings"
 RUN_ID_ATTR = "_codex_eval_run_id"
+BACKEND_ATTR = "_codex_eval_backend"
 PROGRESS_ENABLED = False
 PROGRESS_MODE = "validation"
 PROGRESS_IS_WORKER = False
@@ -48,6 +50,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group.addoption("--no-rubric", action="store_true", default=False, help="Skip schema-constrained rubric grading")
     group.addoption("--codex-runtime", action="store_true", default=False, help="Run Docker-backed runtime checks")
     group.addoption("--codex-eval-progress", action="store_true", default=False, help="Print per-item eval progress")
+    group.addoption("--agent-backend", default="", help="Agent backend: codex, cursor, or claude (default: from config or codex)")
+    group.addoption("--agent-command", default="", help="Override the agent CLI binary path")
+    group.addoption("--agent-timeout", type=int, default=0, help="Agent execution timeout in seconds (0 = use config default)")
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -55,6 +60,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "codex_live: runs Codex subprocess evals")
     setattr(config, RUNS_ATTR, {})
     setattr(config, SETTINGS_ATTR, load_settings(config_path(config)))
+    setattr(config, BACKEND_ATTR, _create_backend(config))
     PROGRESS_ENABLED = bool(config.getoption("--codex-eval-progress"))
     PROGRESS_MODE = progress_label(config)
     PROGRESS_IS_WORKER = is_xdist_worker(config)
@@ -239,6 +245,7 @@ class CodexEvalItem(pytest.Item):
             runtime=runtime_enabled(self.config),
             eval_kind=kind,
             sides=sides,
+            backend=get_backend(self.config),
         )
         run["results"].append(result)
         validate_live_result(result)
@@ -413,6 +420,10 @@ def judge_model(config: pytest.Config) -> str | None:
     return settings(config).judge_model
 
 
+def get_backend(config: pytest.Config) -> AgentBackend:
+    return getattr(config, BACKEND_ATTR)
+
+
 def settings(config: pytest.Config) -> CodexEvalSettings:
     return getattr(config, SETTINGS_ATTR)
 
@@ -455,6 +466,7 @@ def session_run(config: pytest.Config, repo_root: Path, skill: str, mode: str, k
 def run_metadata(config: pytest.Config, repo_root: Path, skill: str, mode: str) -> dict[str, Any]:
     path = config_path(config)
     workers = getattr(config.option, "numprocesses", None) or 1
+    backend = get_backend(config)
     return {
         "mode": mode,
         "eval_kind": eval_kind(config) if mode != "validation" else "validation",
@@ -465,6 +477,7 @@ def run_metadata(config: pytest.Config, repo_root: Path, skill: str, mode: str) 
         "config_path": display_path(path, repo_root) if path else "",
         "agent_model": agent_model(config) or "",
         "judge_model": judge_model(config) or "",
+        "agent_backend": backend.name,
         "rubric_enabled": rubric_enabled(config),
         "runtime_enabled": runtime_enabled(config),
         "workers": str(workers),
@@ -504,6 +517,16 @@ def validation_result(case: EvalCase, repo_root: Path, skill_dir: Path | None) -
         rubric_check_count=rubric_count,
         runtime_check_count=runtime_count,
     )
+
+
+def _create_backend(config: pytest.Config) -> AgentBackend:
+    s = settings(config)
+    cli_backend = config.getoption("--agent-backend") or ""
+    cli_command = config.getoption("--agent-command") or ""
+    backend_name = cli_backend or s.agent_backend
+    command = cli_command or s.agent_command or None
+    extra_args = list(s.agent_extra_args) if s.agent_extra_args else None
+    return create_backend(name=backend_name, command=command, extra_args=extra_args)
 
 
 def validate_live_result(result: CaseResult) -> None:

--- a/pytest-codex-evals/src/pytest_codex_evals/runner.py
+++ b/pytest-codex-evals/src/pytest_codex_evals/runner.py
@@ -2,19 +2,16 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import tempfile
-import threading
 import time
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 from .ab import side_prompt
+from .backends import AgentBackend, CodexBackend
 from .definitions import CaseResult, EvalCase, RubricEvalCase, SideResult
 from .graders import grade_side
 from .graders.rubric import run_rubric_grade
-from .trace import parse_trace
 
 
 def new_run_id() -> str:
@@ -38,7 +35,10 @@ def run_case(
     runtime: bool = False,
     eval_kind: str = "standard",
     sides: tuple[str, ...] = ("with_skill", "baseline"),
+    backend: AgentBackend | None = None,
 ) -> CaseResult:
+    if backend is None:
+        backend = CodexBackend()
     case_root = run_root / "cases" / case.language / case.service / case.prompt_id
     exec_case_root = Path(tempfile.mkdtemp(prefix=f"codex-eval-{case.skill}-{case.language}-{case.service}-{case.prompt_id}-"))
     try:
@@ -58,6 +58,7 @@ def run_case(
                 rubric=rubric,
                 runtime=runtime,
                 eval_kind=eval_kind,
+                backend=backend,
             )
         if "baseline" in sides:
             baseline = run_side(
@@ -73,6 +74,7 @@ def run_case(
                 rubric=rubric,
                 runtime=runtime,
                 eval_kind=eval_kind,
+                backend=backend,
             )
         return CaseResult(
             id=case.id,
@@ -102,42 +104,22 @@ def run_side(
     rubric: bool,
     runtime: bool,
     eval_kind: str,
+    backend: AgentBackend,
 ) -> SideResult:
     side_start = time.monotonic()
     prepare_side_workspace(repo_root, case, side, exec_dir, skill_dir)
-    trace_path = exec_dir / "trace.jsonl"
-    final_path = exec_dir / "last_message.md"
-    stderr_path = exec_dir / "stderr.txt"
-
-    cmd = [
-        "codex",
-        "exec",
-        "--json",
-        "--full-auto",
-        "--skip-git-repo-check",
-        "--cd",
-        str(exec_dir),
-        "--output-last-message",
-        str(final_path),
-    ]
-    if model:
-        cmd.extend(["--model", model])
-    cmd.append(prompt)
 
     agent_start = time.monotonic()
-    completed = run_streamed_command(
-        cmd,
-        stdout_path=trace_path,
-        stderr_path=stderr_path,
-        timeout=1200,
+    agent_result = backend.run_agent(
+        prompt=prompt,
+        exec_dir=exec_dir,
+        model=model,
     )
     agent_duration_seconds = time.monotonic() - agent_start
-    if not final_path.exists():
-        final_path.write_text("", encoding="utf-8")
 
-    trace = parse_trace(trace_path)
+    trace = backend.parse_trace(agent_result.trace_path)
     agent_tokens = trace.usage.total_tokens
-    final_message = final_path.read_text(encoding="utf-8", errors="replace")
+    final_message = agent_result.final_message_path.read_text(encoding="utf-8", errors="replace")
     grade = grade_side(
         case=case,
         run_dir=exec_dir,
@@ -154,8 +136,8 @@ def run_side(
     rubric_duration_seconds = 0.0
     rubric_tokens = 0
     errors: list[str] = []
-    if completed.returncode != 0:
-        errors.append(f"codex exec exited with {completed.returncode}")
+    if agent_result.returncode != 0:
+        errors.append(f"{backend.name} exited with {agent_result.returncode}")
     if rubric and isinstance(case, RubricEvalCase) and case.rubric:
         rubric_start = time.monotonic()
         try:
@@ -163,6 +145,7 @@ def run_side(
                 case=case,
                 side_dir=exec_dir,
                 model=judge_model or model,
+                backend=backend,
             )
         except Exception as exc:  # pragma: no cover - preserved in run artifacts
             errors.append(f"rubric grading failed: {exc}")
@@ -171,7 +154,7 @@ def run_side(
             rubric_trace_path = exec_dir / "rubric_trace.jsonl"
             if rubric_trace_path.exists():
                 try:
-                    rubric_tokens = parse_trace(rubric_trace_path).usage.total_tokens
+                    rubric_tokens = backend.parse_trace(rubric_trace_path).usage.total_tokens
                 except Exception as exc:  # pragma: no cover - preserved in run artifacts
                     errors.append(f"rubric trace parsing failed: {exc}")
 
@@ -186,7 +169,7 @@ def run_side(
 
     result = SideResult(
         side=side,
-        exit_code=completed.returncode,
+        exit_code=agent_result.returncode,
         trace_path=str(artifact_trace_path),
         final_message_path=str(artifact_final_path),
         grade=grade,
@@ -234,81 +217,3 @@ def create_skill_link(target: Path, link: Path) -> None:
         os.symlink(target, link, target_is_directory=True)
     except OSError:
         shutil.copytree(target, link)
-
-
-@dataclass
-class StreamedCommandResult:
-    returncode: int
-    stdout: str
-    stderr: str
-
-
-def run_streamed_command(
-    cmd: list[str],
-    *,
-    stdout_path: Path,
-    stderr_path: Path,
-    timeout: int,
-) -> StreamedCommandResult:
-    stdout_chunks: list[str] = []
-    stderr_chunks: list[str] = []
-    process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=codex_subprocess_env(),
-        text=True,
-        bufsize=1,
-    )
-
-    stdout_thread = threading.Thread(
-        target=pump_stream,
-        args=(process.stdout, stdout_path, stdout_chunks),
-        daemon=True,
-    )
-    stderr_thread = threading.Thread(
-        target=pump_stream,
-        args=(process.stderr, stderr_path, stderr_chunks),
-        daemon=True,
-    )
-    stdout_thread.start()
-    stderr_thread.start()
-    try:
-        returncode = process.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.wait()
-        stdout_thread.join(timeout=5)
-        stderr_thread.join(timeout=5)
-        raise
-    stdout_thread.join()
-    stderr_thread.join()
-    return StreamedCommandResult(
-        returncode=returncode,
-        stdout="".join(stdout_chunks),
-        stderr="".join(stderr_chunks),
-    )
-
-
-def pump_stream(pipe, output_path: Path, chunks: list[str]) -> None:
-    if pipe is None:
-        output_path.write_text("", encoding="utf-8")
-        return
-    with output_path.open("w", encoding="utf-8") as output:
-        for line in pipe:
-            chunks.append(line)
-            output.write(line)
-            output.flush()
-
-
-def codex_subprocess_env() -> dict[str, str]:
-    env = os.environ.copy()
-    clean_package_config = env.get("CODEX_EVAL_CLEAN_PACKAGE_CONFIG", "1").strip().lower()
-    if clean_package_config in {"1", "true", "yes", "on"}:
-        default_index = env.get("UV_DEFAULT_INDEX") or env.get("PIP_INDEX_URL") or "https://pypi.org/simple"
-        env["UV_NO_CONFIG"] = "1"
-        env["UV_DEFAULT_INDEX"] = default_index
-        env["PIP_CONFIG_FILE"] = os.devnull
-        env["PIP_INDEX_URL"] = default_index
-        env.pop("PIP_EXTRA_INDEX_URL", None)
-    return env

--- a/pytest-codex-evals/src/pytest_codex_evals/schemas/common.schema.json
+++ b/pytest-codex-evals/src/pytest_codex_evals/schemas/common.schema.json
@@ -59,30 +59,43 @@
         "settle_seconds": { "type": "number", "minimum": 0, "default": 5 },
         "expect": {
           "type": "object",
-          "additionalProperties": false,
+          "required": ["endpoints"],
           "properties": {
-            "traces": { "$ref": "#/$defs/observerExpectation" },
-            "metrics": { "$ref": "#/$defs/observerExpectation" }
-          },
-          "anyOf": [
-            { "required": ["traces"] },
-            { "required": ["metrics"] }
-          ]
+            "service_name": { "type": "string", "default": "observer" },
+            "service_port": { "type": "integer", "default": 3000 },
+            "health_path": { "type": "string", "default": "/api/health" },
+            "clear_path": { "type": ["string", "null"], "default": "/api/data" },
+            "clear_method": { "type": "string", "default": "DELETE" },
+            "endpoints": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/endpointExpectation" }
+            }
+          }
         },
         "applies_to": { "type": "string", "enum": ["both", "with_skill", "baseline"], "default": "with_skill" }
       }
     },
-    "observerExpectation": {
+    "endpointExpectation": {
       "type": "object",
+      "required": ["id"],
       "additionalProperties": false,
       "properties": {
-        "path": { "type": "string" },
+        "id": { "type": "string" },
+        "url": { "type": "string" },
+        "method": { "type": "string", "default": "GET" },
         "contains_all": { "type": "array", "items": { "type": "string" } },
         "contains_any": { "type": "array", "items": { "type": "string" } },
-        "service_names": { "type": "array", "items": { "type": "string" } },
-        "span_names": { "type": "array", "items": { "type": "string" } },
-        "metric_names": { "type": "array", "items": { "type": "string" } },
-        "trace_detail_contains_all": { "type": "array", "items": { "type": "string" } }
+        "field_checks": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "detail_path_template": { "type": "string" },
+        "detail_id_field": { "type": "string" },
+        "detail_contains_all": { "type": "array", "items": { "type": "string" } }
       }
     }
   }

--- a/pytest-codex-evals/tests/test_collection.py
+++ b/pytest-codex-evals/tests/test_collection.py
@@ -179,7 +179,7 @@ def test_eval_kind_filters_collection_by_file_role(pytester: pytest.Pytester):
                         "id": "runtime",
                         "description": "Runtime check.",
                         "compose_file": "docker-compose.yml",
-                        "expect": {"traces": {"contains_any": ["sample-service"]}},
+                        "expect": {"endpoints": [{"id": "traces", "url": "/api/query/traces", "contains_any": ["sample-service"]}]},
                     }
                 ],
             },
@@ -217,7 +217,7 @@ def test_role_schemas_reject_cross_role_fields():
     runtime_payload = {
         "skill": "sample-skill",
         "prompts": [{"id": "direct", "task": "Run."}],
-        "checks": [{"id": "runtime", "description": "Run", "compose_file": "docker-compose.yml", "expect": {"traces": {"contains_any": ["svc"]}}}],
+        "checks": [{"id": "runtime", "description": "Run", "compose_file": "docker-compose.yml", "expect": {"endpoints": [{"id": "traces", "url": "/api/query/traces", "contains_any": ["svc"]}]}}],
         "rubric": ["Not allowed."],
     }
     runtime_with_kind = {

--- a/pytest-codex-evals/tests/test_core.py
+++ b/pytest-codex-evals/tests/test_core.py
@@ -8,9 +8,9 @@ from pytest_codex_evals.ab import side_prompt
 from pytest_codex_evals.config import load_settings
 from pytest_codex_evals.definitions import (
     CaseResult,
+    EndpointExpectation,
     GradeCheckResult,
     GradeResult,
-    ObserverExpectation,
     RubricEvalCase,
     RuntimeCheck,
     RuntimeEvalCase,
@@ -21,17 +21,17 @@ from pytest_codex_evals.definitions import (
     ValidationResult,
 )
 from pytest_codex_evals.graders.rubric import rubric_prompt
+from pytest_codex_evals.backends import run_streamed_command
 from pytest_codex_evals.graders.runtime import (
+    base_url_from_port_output,
     grade_runtime,
-    observer_base_url_from_port_output,
-    observer_url,
     resolve_compose_file,
     runtime_env,
+    service_url,
 )
 from pytest_codex_evals.graders.sanity import grade_sanity
 from pytest_codex_evals.cli import main as cli_main
 from pytest_codex_evals.report import render_reports_for_run_root, write_session_results
-from pytest_codex_evals.runner import run_streamed_command
 from pytest_codex_evals.trace import parse_trace
 
 
@@ -133,6 +133,45 @@ def test_config_loads_eval_kind(tmp_path: Path):
     assert settings.eval_kind == "sanity"
 
 
+def test_config_loads_agent_backend_settings(tmp_path: Path):
+    config_path = tmp_path / "codex-evals.toml"
+    config_path.write_text(
+        """
+        [run]
+        mode = "with_skill"
+
+        [agent]
+        backend = "cursor"
+        command = "/usr/local/bin/cursor"
+        extra_args = ["--verbose"]
+        timeout = 600
+        judge_timeout = 300
+        """,
+        encoding="utf-8",
+    )
+
+    settings = load_settings(config_path)
+
+    assert settings.agent_backend == "cursor"
+    assert settings.agent_command == "/usr/local/bin/cursor"
+    assert settings.agent_extra_args == ("--verbose",)
+    assert settings.agent_timeout == 600
+    assert settings.judge_timeout == 300
+
+
+def test_config_defaults_agent_backend_to_codex(tmp_path: Path):
+    config_path = tmp_path / "codex-evals.toml"
+    config_path.write_text("[run]\nmode = \"with_skill\"\n", encoding="utf-8")
+
+    settings = load_settings(config_path)
+
+    assert settings.agent_backend == "codex"
+    assert settings.agent_command is None
+    assert settings.agent_extra_args == ()
+    assert settings.agent_timeout == 1200
+    assert settings.judge_timeout == 900
+
+
 def test_command_backed_sanity_check(tmp_path: Path):
     service_dir = tmp_path / "service"
     service_dir.mkdir()
@@ -204,9 +243,9 @@ def test_runtime_env_points_to_instrumented_service_copy(tmp_path: Path):
 
 
 def test_runtime_observer_url_uses_discovered_compose_port():
-    assert observer_base_url_from_port_output("0.0.0.0:49153\n") == "http://127.0.0.1:49153"
-    assert observer_base_url_from_port_output("[::]:49154\n") == "http://127.0.0.1:49154"
-    assert observer_url("http://127.0.0.1:49153", "/api/health") == "http://127.0.0.1:49153/api/health"
+    assert base_url_from_port_output("0.0.0.0:49153\n") == "http://127.0.0.1:49153"
+    assert base_url_from_port_output("[::]:49154\n") == "http://127.0.0.1:49154"
+    assert service_url("http://127.0.0.1:49153", "/api/health") == "http://127.0.0.1:49153/api/health"
 
 
 def test_sanity_file_and_final_checks(tmp_path: Path):
@@ -488,7 +527,15 @@ def runtime_check() -> RuntimeCheck:
         id="observer-runtime",
         description="Runtime telemetry reaches Observer.",
         compose_file="docker-compose.yml",
-        expect=RuntimeExpectations(traces=ObserverExpectation(contains_any=["sample-service"])),
+        expect=RuntimeExpectations(
+            endpoints=[
+                EndpointExpectation(
+                    id="traces",
+                    url="/api/query/traces",
+                    contains_any=["sample-service"],
+                )
+            ]
+        ),
     )
 
 
@@ -515,6 +562,55 @@ def case_result(with_skill: SideResult | None, baseline: SideResult | None) -> C
         with_skill=with_skill,
         baseline=baseline,
     )
+
+
+def test_backend_registry_creates_backends():
+    from pytest_codex_evals.backends import create_backend, CodexBackend, CursorBackend, ClaudeBackend
+
+    codex = create_backend("codex")
+    assert isinstance(codex, CodexBackend)
+    assert codex.name == "codex"
+
+    cursor = create_backend("cursor", command="/usr/bin/cursor")
+    assert isinstance(cursor, CursorBackend)
+    assert cursor.name == "cursor"
+    assert cursor.command == "/usr/bin/cursor"
+
+    claude = create_backend("claude", extra_args=["--verbose"])
+    assert isinstance(claude, ClaudeBackend)
+    assert claude.name == "claude"
+    assert claude.extra_args == ["--verbose"]
+
+    import pytest as _pytest
+    with _pytest.raises(ValueError, match="unknown agent backend"):
+        create_backend("unsupported")
+
+
+def test_runtime_expectations_generic_endpoints():
+    from pytest_codex_evals.definitions.runtime import EndpointExpectation
+
+    expectations = RuntimeExpectations(
+        service_name="my-api",
+        service_port=8080,
+        health_path="/health",
+        clear_path=None,
+        endpoints=[
+            EndpointExpectation(
+                id="users",
+                url="/api/users",
+                contains_all=["admin"],
+                field_checks={"roles": ["admin", "editor"]},
+            )
+        ],
+    )
+
+    assert expectations.service_name == "my-api"
+    assert expectations.service_port == 8080
+    assert expectations.health_path == "/health"
+    assert expectations.clear_path is None
+    assert len(expectations.endpoints) == 1
+    assert expectations.endpoints[0].id == "users"
+    assert expectations.endpoints[0].url == "/api/users"
 
 
 def write_loaded_skill(root: Path, skill: str) -> None:


### PR DESCRIPTION
## Summary

- **Agent backend abstraction**: Introduce `AgentBackend` protocol with pluggable implementations for Codex, Cursor, and Claude Code, replacing the hardcoded `codex exec --json` invocation in the runner and rubric grader. Backend selection is configurable via TOML `[agent]` section or `--agent-backend` CLI flag.
- **Generic runtime expectations**: Replace the Observer-specific `traces`/`metrics` schema (`observerExpectation`) with a domain-agnostic `endpoints` array (`endpointExpectation`), allowing runtime checks against any HTTP service endpoint. All existing eval JSON files migrated to the new format.
- **Fix confusing install message** (fixes #78): The install completion message now names the specific target (e.g. "Restart cursor to activate the MCP server.") instead of the generic "Restart your editor".

## Test plan

- [x] All 31 plugin unit tests pass (`uv run pytest tests/ -v`)
- [x] All 22 otel-instrument validation tests pass (schema + Pydantic loading)
- [x] All 16 otel-audit validation tests pass
- [x] Sanity eval checks pass (`make eval-sanity SKILL=skills/otel-instrument`)
- [x] Go build succeeds for install.go fix
- [x] Rubric eval checks
- [x] Runtime eval checks (requires Docker)


Made with [Cursor](https://cursor.com)