### PR TITLE
Bundle weaver with obstudio installs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,11 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: linux
+        goarch: arm64
+      - goos: windows
+        goarch: arm64
     ldflags:
       - -s -w -X main.version={{.Version}}
 
@@ -20,6 +25,8 @@ archives:
   - formats:
       - zip
     files:
+      - src: .release/weaver/{{ .Os }}-{{ .Arch }}/weaver*
+        strip_parent: true
       - docs/USER.md
       - docs/examples.md
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ EVALS_DIR  := evals
 PYTEST_PLUGIN_DIR := pytest-codex-evals
 
 ABS_BUILD  := $(CURDIR)/$(BUILD_DIR)
+RELEASE_WEAVER_DIR := $(CURDIR)/.release/weaver
 
-.PHONY: help build build-client build-vsix stage-skills bundle-weaver dev run load-severity-demo test test-extension test-client test-all tidy fmt vet eval-validation eval-validation-test eval-validation-report eval-sanity eval-sanity-test eval-sanity-report eval-sanity-ab eval-rubric eval-rubric-test eval-rubric-report eval-rubric-ab eval-runtime eval-runtime-test eval-runtime-report eval-runtime-ab eval-with-skill eval-with-baseline eval-ab eval-all eval-all-ab skill-eval skill-eval-all skill-eval-list skill-eval-ab skill-eval-ab-all test-eval-harness test-evals-all test-pytest-plugin build-pytest-plugin publish-pytest-plugin release-local release list-skills clean
+.PHONY: help build build-client build-vsix stage-skills bundle-weaver stage-release-weaver dev run load-severity-demo test test-extension test-client test-all tidy fmt vet eval-validation eval-validation-test eval-validation-report eval-sanity eval-sanity-test eval-sanity-report eval-sanity-ab eval-rubric eval-rubric-test eval-rubric-report eval-rubric-ab eval-runtime eval-runtime-test eval-runtime-report eval-runtime-ab eval-with-skill eval-with-baseline eval-ab eval-all eval-all-ab skill-eval skill-eval-all skill-eval-list skill-eval-ab skill-eval-ab-all test-eval-harness test-evals-all test-pytest-plugin build-pytest-plugin publish-pytest-plugin release-local release list-skills clean
 
 help: ## Show available targets
 	@grep -hE '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
@@ -36,6 +37,11 @@ dev: ## Watch client files and rebuild on changes (hot reload)
 bundle-weaver: ## Fetch the local Weaver validator runtime into build output
 	@mkdir -p $(BUILD_DIR)
 	cd $(GO_DIR) && $(GO) run ./cmd/fetch-weaver -output $(ABS_BUILD)
+
+stage-release-weaver: ## Fetch Weaver runtimes for all release targets
+	rm -rf "$(RELEASE_WEAVER_DIR)"
+	mkdir -p "$(RELEASE_WEAVER_DIR)"
+	cd $(GO_DIR) && $(GO) run ./cmd/fetch-weaver -all -output "$(RELEASE_WEAVER_DIR)"
 
 build: stage-skills build-client bundle-weaver ## Build obstudio binary (client + skills embedded)
 	@mkdir -p $(BUILD_DIR)
@@ -76,7 +82,7 @@ vet: stage-skills ## Vet Go source
 
 # --- Release ---
 
-release-prep: stage-skills build-client ## Prepare assets for GoReleaser (skills + client)
+release-prep: stage-skills build-client stage-release-weaver ## Prepare assets for GoReleaser (skills + client + validator runtimes)
 
 release-local: release-prep ## Build release archives locally via GoReleaser (snapshot, no publish)
 	goreleaser release --snapshot --clean
@@ -176,4 +182,4 @@ list-skills: ## List available skills in this repo
 # --- Clean ---
 
 clean: ## Remove build artifacts
-	rm -rf "$(BUILD_DIR)" dist $(GO_DIR)/cmd/obstudio/_skills $(GO_DIR)/internal/web/static/assets $(GO_DIR)/client/public/assets
+	rm -rf "$(BUILD_DIR)" .release dist $(GO_DIR)/cmd/obstudio/_skills $(GO_DIR)/internal/web/static/assets $(GO_DIR)/client/public/assets

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ unzip obstudio_*_darwin_arm64.zip
 ./obstudio install --target=codex
 ```
 
+After unzipping the release, run `obstudio install` from that extracted
+directory without moving the files. The installer expects `weaver` to be next
+to `obstudio`.
+
 ### Build From Source
 
 ```bash
@@ -70,6 +74,10 @@ Validation is available through the Explorer UI, REST API, and MCP.
 |---|---|
 | REST | `/api/query/validation/summary`, `/api/query/validation/latest`, `/api/validation/run`, `/api/validation/refresh` |
 | MCP | `observer_validation_status`, `observer_validation_analyze`, `observer_validation_refresh` |
+
+If you move `obstudio` manually instead of using `obstudio install`, keep
+the bundled `weaver` runtime beside it or make `weaver` available on
+`PATH`.
 
 ## Repository Layout
 

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -24,7 +24,9 @@ Install skills and configure the MCP server:
 ./obstudio install --target=cursor
 ```
 
-Skills are embedded in the binary -- a single file is all you need.
+After unzipping the release, run `obstudio install` from that extracted
+directory without moving the files. The installer expects `weaver` to be next
+to `obstudio`.
 
 ### Supported Targets
 
@@ -36,7 +38,7 @@ Skills are embedded in the binary -- a single file is all you need.
 
 The installer:
 1. Extracts skills and references from the binary to the agent's skill directory
-2. Copies the binary alongside the skills (stable path for MCP)
+2. Copies `obstudio` and the bundled `weaver` runtime alongside the skills (stable path for MCP)
 3. Configures the agent's MCP config to auto-start `obstudio`
 
 Restart your agent to activate.
@@ -46,6 +48,7 @@ Restart your agent to activate.
 ```
 ~/.cursor/skills/obstudio/
   obstudio              # binary (MCP server, auto-started by Cursor)
+  weaver                # validator runtime used by the Validation tab and APIs
   audit/SKILL.md        # /otel-audit skill
   instrument/SKILL.md   # /otel-instrument skill
   references/           # language guides and reference material
@@ -116,6 +119,10 @@ Use `observer_validation_analyze` for most questions about missing
 telemetry or semantic convention issues. Use
 `observer_validation_refresh` only when you explicitly want to rerun
 validation against the current snapshot.
+
+If you move `obstudio` manually instead of using `obstudio install`, keep
+the bundled `weaver` runtime beside it or ensure `weaver` is available on
+`PATH`.
 
 ## Environment Variables
 

--- a/observer/README.md
+++ b/observer/README.md
@@ -27,6 +27,10 @@ Ports 4317 and 4318 must be free. If the VS Code extension or another
 collector is already running, either stop it first or override with
 environment variables (`PORT`, `OTLP_HTTP_PORT`, `OTLP_GRPC_PORT`).
 
+Validation uses the bundled `weaver` runtime that `make build` places
+next to `build/obstudio`. If you move the binary manually, keep `weaver`
+beside it or make `weaver` available on `PATH`.
+
 ## Architecture
 
 ```

--- a/observer/cmd/fetch-weaver/main_test.go
+++ b/observer/cmd/fetch-weaver/main_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
+
+	"go.yaml.in/yaml/v3"
 )
 
 func TestFindTarget(t *testing.T) {
@@ -108,5 +112,66 @@ func TestFetchTargetUsesCachedBinaryFromOverride(t *testing.T) {
 	}
 	if string(data) != "cached-weaver" {
 		t.Fatalf("unexpected output contents: %q", string(data))
+	}
+}
+
+func TestReleaseMatrixMatchesWeaverSupportedTargets(t *testing.T) {
+	t.Parallel()
+
+	type ignoreTarget struct {
+		Goos   string `yaml:"goos"`
+		Goarch string `yaml:"goarch"`
+	}
+	type buildConfig struct {
+		Goos   []string       `yaml:"goos"`
+		Goarch []string       `yaml:"goarch"`
+		Ignore []ignoreTarget `yaml:"ignore"`
+	}
+	type goreleaserConfig struct {
+		Builds []buildConfig `yaml:"builds"`
+	}
+
+	configPath := filepath.Join("..", "..", "..", ".goreleaser.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read goreleaser config: %v", err)
+	}
+
+	var config goreleaserConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("unmarshal goreleaser config: %v", err)
+	}
+
+	published := map[string]struct{}{}
+	for _, build := range config.Builds {
+		ignored := map[string]struct{}{}
+		for _, target := range build.Ignore {
+			ignored[target.Goos+"/"+target.Goarch] = struct{}{}
+		}
+		for _, goos := range build.Goos {
+			for _, goarch := range build.Goarch {
+				key := goos + "/" + goarch
+				if _, skip := ignored[key]; skip {
+					continue
+				}
+				published[key] = struct{}{}
+			}
+		}
+	}
+
+	supported := make([]string, 0, len(supportedTargets))
+	for _, target := range supportedTargets {
+		supported = append(supported, target.goos+"/"+target.goarch)
+	}
+	slices.Sort(supported)
+
+	publishedKeys := make([]string, 0, len(published))
+	for key := range published {
+		publishedKeys = append(publishedKeys, key)
+	}
+	slices.Sort(publishedKeys)
+
+	if !reflect.DeepEqual(publishedKeys, supported) {
+		t.Fatalf("release matrix %v does not match Weaver-supported targets %v", publishedKeys, supported)
 	}
 }

--- a/observer/cmd/obstudio/install.go
+++ b/observer/cmd/obstudio/install.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -165,6 +166,15 @@ func runInstall(target, sharedURL string) error {
 		return fmt.Errorf("failed to set binary permissions: %w", err)
 	}
 	fmt.Println("  Binary installed.")
+	weaverInstalled, externalWeaver, err := ensureInstallWeaverRuntime(exePath, destDir, resolvedSharedURL == "")
+	if err != nil {
+		return fmt.Errorf("failed to install Weaver runtime: %w", err)
+	}
+	if weaverInstalled {
+		fmt.Println("  Weaver runtime installed.")
+	} else if externalWeaver != "" && resolvedSharedURL == "" {
+		fmt.Printf("  Weaver runtime resolved via %s.\n", externalWeaver)
+	}
 
 	mcpFile := t.mcpConfig.path()
 	if err := configureMCP(t.mcpConfig, installedBinary, resolvedSharedURL); err != nil {
@@ -186,6 +196,73 @@ func runInstall(target, sharedURL string) error {
 	fmt.Printf("\nDone. Start the shared obstudio server before using %s:\n", target)
 	fmt.Println("  obstudio")
 	return nil
+}
+
+func ensureInstallWeaverRuntime(exePath, destDir string, requireLocalRuntime bool) (bool, string, error) {
+	installed, err := copySiblingWeaverRuntime(exePath, destDir)
+	if err != nil {
+		return false, "", err
+	}
+	if installed {
+		return true, filepath.Join(destDir, installedWeaverName(exePath)), nil
+	}
+	if external := externalWeaverRuntime(); external != "" {
+		return false, external, nil
+	}
+	if requireLocalRuntime {
+		return false, "", errors.New("Weaver runtime not found beside obstudio or on PATH; validation requires the bundled weaver binary from the release archive")
+	}
+	return false, "", nil
+}
+
+func installedWeaverName(exePath string) string {
+	if filepath.Ext(exePath) == ".exe" {
+		return "weaver.exe"
+	}
+	return "weaver"
+}
+
+func externalWeaverRuntime() string {
+	if custom := strings.TrimSpace(os.Getenv("WEAVER_PATH")); custom != "" {
+		if _, err := os.Stat(custom); err == nil {
+			return custom
+		}
+	}
+	if resolved, err := exec.LookPath("weaver"); err == nil {
+		return resolved
+	}
+	return ""
+}
+
+func copySiblingWeaverRuntime(exePath, destDir string) (bool, error) {
+	candidates := []string{filepath.Join(filepath.Dir(exePath), "weaver")}
+	if filepath.Ext(exePath) == ".exe" {
+		candidates = append(candidates, filepath.Join(filepath.Dir(exePath), "weaver.exe"))
+	}
+
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if info.IsDir() {
+			continue
+		}
+
+		destPath := filepath.Join(destDir, filepath.Base(candidate))
+		if err := copyFile(candidate, destPath); err != nil {
+			return false, err
+		}
+		if err := os.Chmod(destPath, 0o755); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func detectSharedObserverURL(healthURL string, client *http.Client) (string, bool) {

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -39,6 +39,134 @@ func TestCodexTargetUsesConfigTOML(t *testing.T) {
 	}
 }
 
+func TestCopySiblingWeaverRuntimeCopiesBundledRuntime(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	destDir := t.TempDir()
+	exePath := filepath.Join(sourceDir, "obstudio")
+	weaverPath := filepath.Join(sourceDir, "weaver")
+
+	if err := os.WriteFile(exePath, []byte("obstudio"), 0o755); err != nil {
+		t.Fatalf("write obstudio: %v", err)
+	}
+	if err := os.WriteFile(weaverPath, []byte("weaver-runtime"), 0o755); err != nil {
+		t.Fatalf("write weaver: %v", err)
+	}
+
+	copied, err := copySiblingWeaverRuntime(exePath, destDir)
+	if err != nil {
+		t.Fatalf("copySiblingWeaverRuntime returned error: %v", err)
+	}
+	if !copied {
+		t.Fatal("expected Weaver runtime to be copied")
+	}
+
+	data, err := os.ReadFile(filepath.Join(destDir, "weaver"))
+	if err != nil {
+		t.Fatalf("read copied weaver: %v", err)
+	}
+	if string(data) != "weaver-runtime" {
+		t.Fatalf("unexpected copied weaver contents: %q", string(data))
+	}
+}
+
+func TestCopySiblingWeaverRuntimeIsOptional(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	destDir := t.TempDir()
+	exePath := filepath.Join(sourceDir, "obstudio")
+	if err := os.WriteFile(exePath, []byte("obstudio"), 0o755); err != nil {
+		t.Fatalf("write obstudio: %v", err)
+	}
+
+	copied, err := copySiblingWeaverRuntime(exePath, destDir)
+	if err != nil {
+		t.Fatalf("copySiblingWeaverRuntime returned error: %v", err)
+	}
+	if copied {
+		t.Fatal("expected no Weaver runtime copy when none is bundled")
+	}
+}
+
+func TestEnsureInstallWeaverRuntimeUsesPATHFallback(t *testing.T) {
+	sourceDir := t.TempDir()
+	destDir := t.TempDir()
+	pathDir := t.TempDir()
+	exePath := filepath.Join(sourceDir, "obstudio")
+	weaverPath := filepath.Join(pathDir, "weaver")
+
+	if err := os.WriteFile(exePath, []byte("obstudio"), 0o755); err != nil {
+		t.Fatalf("write obstudio: %v", err)
+	}
+	if err := os.WriteFile(weaverPath, []byte("external-weaver"), 0o755); err != nil {
+		t.Fatalf("write weaver on PATH: %v", err)
+	}
+	t.Setenv("PATH", pathDir)
+	t.Setenv("WEAVER_PATH", "")
+
+	installed, external, err := ensureInstallWeaverRuntime(exePath, destDir, true)
+	if err != nil {
+		t.Fatalf("ensureInstallWeaverRuntime returned error: %v", err)
+	}
+	if installed {
+		t.Fatal("expected PATH fallback instead of local copy")
+	}
+	if external != weaverPath {
+		t.Fatalf("expected PATH weaver %q, got %q", weaverPath, external)
+	}
+}
+
+func TestEnsureInstallWeaverRuntimeFailsWhenLocalValidationWouldBeBroken(t *testing.T) {
+	sourceDir := t.TempDir()
+	destDir := t.TempDir()
+	exePath := filepath.Join(sourceDir, "obstudio")
+
+	if err := os.WriteFile(exePath, []byte("obstudio"), 0o755); err != nil {
+		t.Fatalf("write obstudio: %v", err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("WEAVER_PATH", "")
+
+	installed, external, err := ensureInstallWeaverRuntime(exePath, destDir, true)
+	if err == nil {
+		t.Fatal("expected ensureInstallWeaverRuntime to fail without a local or external runtime")
+	}
+	if installed {
+		t.Fatal("expected no local weaver installation")
+	}
+	if external != "" {
+		t.Fatalf("expected no external weaver runtime, got %q", external)
+	}
+	if !strings.Contains(err.Error(), "Weaver runtime not found beside obstudio or on PATH") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureInstallWeaverRuntimeAllowsSharedModeWithoutLocalRuntime(t *testing.T) {
+	sourceDir := t.TempDir()
+	destDir := t.TempDir()
+	exePath := filepath.Join(sourceDir, "obstudio")
+
+	if err := os.WriteFile(exePath, []byte("obstudio"), 0o755); err != nil {
+		t.Fatalf("write obstudio: %v", err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("WEAVER_PATH", "")
+
+	installed, external, err := ensureInstallWeaverRuntime(exePath, destDir, false)
+	if err != nil {
+		t.Fatalf("ensureInstallWeaverRuntime returned error: %v", err)
+	}
+	if installed {
+		t.Fatal("expected no local weaver installation")
+	}
+	if external != "" {
+		t.Fatalf("expected no external weaver runtime, got %q", external)
+	}
+}
+
 func TestUpsertJSONMCPServerPreservesExistingEntries(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- bundle the Weaver runtime into release artifacts and install it alongside `obstudio`
- restrict the release matrix to Weaver-supported targets and add a regression test that keeps the GoReleaser matrix in sync with `fetch-weaver`
- fail local installs when no bundled or external Weaver runtime is available, while still allowing shared-server installs without a local runtime

## Testing
- `go test ./cmd/obstudio ./cmd/fetch-weaver`
- `make release-prep`
- `go run github.com/goreleaser/goreleaser/v2@latest check`
fixes #79
