### PR TITLE
Add consented agent integration and explicit Observer port overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ the skills and MCP config for your agent:
 
 ```bash
 unzip obstudio_*_darwin_arm64.zip
-./obstudio install --target=codex
+./obstudio install --target=<agent>
 ```
 
 After unzipping the release, run `obstudio install` from that extracted
 directory without moving the files. The installer expects `weaver` to be next
-to `obstudio`.
+to `obstudio`. It stores the managed bundle under `~/.<agent>/skills/obstudio/`
+and creates top-level discoverable skill entries such as `otel-audit` and
+`otel-instrument` in the agent skills root.
 
 ### Build From Source
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The collector starts on:
 | OTLP/gRPC | localhost:4317 |
 | MCP endpoint | http://localhost:3000/mcp |
 
+Use `obstudio --observer-http-port <port>` to move the Observer UI, REST API,
+and MCP endpoint to a different port. The OTLP receivers stay fixed at `4318`
+and `4317`, matching the VS Code extension.
+
 ## Using The Skills
 
 From a service directory, invoke the relevant skill in Codex:

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -50,8 +50,8 @@ Restart your agent to activate.
 ~/.cursor/skills/obstudio/
   obstudio              # binary (MCP server, auto-started by Cursor)
   weaver                # validator runtime used by the Validation tab and APIs
-  otel-audit/SKILL.md   # /otel-audit skill source
-  otel-instrument/SKILL.md # /otel-instrument skill source
+  otel-audit/SKILL.md   # bundled /otel-audit skill file
+  otel-instrument/SKILL.md # bundled /otel-instrument skill file
   references/           # language guides and reference material
 
 ~/.cursor/skills/

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -99,6 +99,9 @@ To override the Observer UI, REST API, and MCP HTTP port explicitly:
 obstudio --observer-http-port 41234
 ```
 
+The OTLP receiver ports stay fixed at `4318` and `4317`, matching the VS Code
+extension.
+
 When a standalone Observer is already running, `obstudio install --target=<agent>`
 auto-detects its current HTTP MCP endpoint from local runtime state, including
 nondefault `--observer-http-port` values. Use `--shared-url` only when you want
@@ -147,8 +150,6 @@ the bundled `weaver` runtime beside it or ensure `weaver` is available on
 |----------|---------|-------------|
 | `HOST` | `127.0.0.1` | Bind address for all servers |
 | `PORT` | `3000` | Observer UI, REST API, and MCP HTTP port |
-| `OTLP_HTTP_PORT` | `4318` | OTLP/HTTP receiver port |
-| `OTLP_GRPC_PORT` | `4317` | OTLP/gRPC receiver port |
 
 ## Example Prompts
 

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -21,7 +21,7 @@ unzip obstudio_linux_amd64.zip
 Install skills and configure the MCP server:
 
 ```bash
-./obstudio install --target=cursor
+./obstudio install --target=<agent>
 ```
 
 After unzipping the release, run `obstudio install` from that extracted
@@ -33,13 +33,14 @@ to `obstudio`.
 | Target | Skills directory | MCP config |
 |--------|-----------------|------------|
 | `cursor` | `~/.cursor/skills/obstudio/` | `~/.cursor/mcp.json` |
-| `claude-code` | `~/.claude/skills/obstudio/` | `~/.claude/settings.json` |
+| `claude-code` | `~/.claude/skills/obstudio/` | `~/.claude.json` |
 | `codex` | `~/.codex/skills/obstudio/` | `~/.codex/config.toml` |
 
 The installer:
 1. Extracts skills and references from the binary to the agent's skill directory
 2. Copies `obstudio` and the bundled `weaver` runtime alongside the skills (stable path for MCP)
-3. Configures the agent's MCP config to auto-start `obstudio`
+3. Creates top-level discoverable skill entries in the agent skills root
+4. Configures the agent's MCP config to auto-start `obstudio` or reuse a shared Observer
 
 Restart your agent to activate.
 
@@ -49,9 +50,13 @@ Restart your agent to activate.
 ~/.cursor/skills/obstudio/
   obstudio              # binary (MCP server, auto-started by Cursor)
   weaver                # validator runtime used by the Validation tab and APIs
-  audit/SKILL.md        # /otel-audit skill
-  instrument/SKILL.md   # /otel-instrument skill
+  otel-audit/SKILL.md   # /otel-audit skill source
+  otel-instrument/SKILL.md # /otel-instrument skill source
   references/           # language guides and reference material
+
+~/.cursor/skills/
+  otel-audit -> obstudio/otel-audit
+  otel-instrument -> obstudio/otel-instrument
 ```
 
 ## CLI Reference
@@ -60,6 +65,7 @@ Restart your agent to activate.
 |---------|-------------|
 | `obstudio` | Start the collector + stdio MCP server (OTLP receiver, Web UI, REST API, MCP) |
 | `obstudio install --target=<agent>` | Install skills and configure MCP (`cursor`, `claude-code`, `codex`) |
+| `obstudio --observer-http-port <port>` | Override the Observer UI, REST API, and MCP HTTP port |
 | `obstudio --version` | Print version |
 | `obstudio --help` | Show all available commands |
 
@@ -86,6 +92,17 @@ For the complete experience (Web UI, OTLP receiver, HTTP MCP endpoint):
 ```bash
 obstudio
 ```
+
+To override the Observer UI, REST API, and MCP HTTP port explicitly:
+
+```bash
+obstudio --observer-http-port 41234
+```
+
+When a standalone Observer is already running, `obstudio install --target=<agent>`
+auto-detects its current HTTP MCP endpoint from local runtime state, including
+nondefault `--observer-http-port` values. Use `--shared-url` only when you want
+to point an agent at a different already-running Observer explicitly.
 
 | Service | URL |
 |---------|-----|
@@ -129,7 +146,7 @@ the bundled `weaver` runtime beside it or ensure `weaver` is available on
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `HOST` | `127.0.0.1` | Bind address for all servers |
-| `PORT` | `3000` | Web UI and MCP HTTP port |
+| `PORT` | `3000` | Observer UI, REST API, and MCP HTTP port |
 | `OTLP_HTTP_PORT` | `4318` | OTLP/HTTP receiver port |
 | `OTLP_GRPC_PORT` | `4317` | OTLP/gRPC receiver port |
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -52,13 +52,14 @@ The severity levels are meant to be easy to read:
 ## Features
 
 - Reuses a healthy shared observer at `http://127.0.0.1:3000` or starts a bundled local observer automatically on activation.
+- Detects local Codex, Claude Code, and Cursor installs and offers a one-time prompt to enable integration.
 - Exposes stable OTLP endpoints for local applications:
   - OTLP/HTTP on `127.0.0.1:4318`
   - OTLP/gRPC on `127.0.0.1:4317`
 - Opens the Telemetry Explorer in a VS Code webview panel.
 - Keeps a status bar entry available so you can reopen the explorer quickly.
 - Includes commands for starting, stopping, restarting, and reusing the shared observer runtime.
-- Includes helper commands to configure MCP clients against the shared observer endpoint.
+- Includes helper commands to enable agent integrations against the shared observer endpoint.
 
 ## Commands
 
@@ -67,9 +68,9 @@ The severity levels are meant to be easy to read:
 - `Splunk Observability Studio: Start Observer` — starts the shared observer runtime.
 - `Splunk Observability Studio: Stop Observer` — stops the shared observer runtime.
 - `Splunk Observability Studio: Restart Observer` — restarts the shared observer runtime.
-- `Splunk Observability Studio: Configure Codex MCP` — writes Codex MCP settings for the shared observer.
-- `Splunk Observability Studio: Configure Claude Code MCP` — writes Claude Code MCP settings for the shared observer.
-- `Splunk Observability Studio: Configure Cursor MCP` — writes Cursor MCP settings for the shared observer.
+- `Splunk Observability Studio: Enable Codex Integration` — installs bundled skills and writes Codex MCP settings for the shared observer.
+- `Splunk Observability Studio: Enable Claude Code Integration` — installs bundled skills and writes Claude Code MCP settings for the shared observer.
+- `Splunk Observability Studio: Enable Cursor Integration` — installs bundled skills and writes Cursor MCP settings for the shared observer.
 
 ## How It Works
 
@@ -79,9 +80,10 @@ At startup, the extension:
 
 1. Uses `observability-studio.sharedObserverUrl` when it is configured.
 2. Otherwise reuses a healthy observer already serving `http://127.0.0.1:3000` when one is available.
-3. If no shared observer is already running, verifies that `3000`, `4317`, and `4318` are available.
-4. Launches the bundled observer binary on the fixed local endpoint `http://127.0.0.1:3000`.
-5. Connects the VS Code webview to the Observer UI via an iframe.
+3. If no shared observer is already running, verifies that `managedObserverPort`, `4317`, and `4318` are available.
+4. Launches the bundled observer binary on the managed local endpoint `http://127.0.0.1:<managedObserverPort>`.
+5. When a supported agent home is detected, offers a one-time prompt to install bundled skills and point that agent at the shared Observer MCP endpoint.
+6. Connects the VS Code webview to the Observer UI via an iframe.
 
 If the managed endpoint or either OTLP port is already in use by an incompatible service, the extension reports a startup error.
 
@@ -105,4 +107,4 @@ From the `extension` directory:
 
 ## Known Limitations
 
-- The managed local observer expects `127.0.0.1:3000`, `127.0.0.1:4318`, and `127.0.0.1:4317` to be free unless you point the extension at an existing shared observer with `observability-studio.sharedObserverUrl`.
+- The managed local observer expects `127.0.0.1:<managedObserverPort>`, `127.0.0.1:4318`, and `127.0.0.1:4317` to be free unless you point the extension at an existing shared observer with `observability-studio.sharedObserverUrl`.

--- a/extension/README.md
+++ b/extension/README.md
@@ -72,6 +72,19 @@ The severity levels are meant to be easy to read:
 - `Splunk Observability Studio: Enable Claude Code Integration` — installs bundled skills and writes Claude Code MCP settings for the shared observer.
 - `Splunk Observability Studio: Enable Cursor Integration` — installs bundled skills and writes Cursor MCP settings for the shared observer.
 
+## Configuration
+
+To run the extension-managed Observer on a different local UI/MCP port, set:
+
+```json
+{
+  "observability-studio.managedObserverPort": 41234
+}
+```
+
+This is the extension equivalent of `obstudio --observer-http-port 41234`.
+The extension-managed OTLP receiver ports stay fixed at `4318` and `4317`.
+
 ## How It Works
 
 The extension packages a pre-built observer binary (Go) into the extension bundle under `dist/observer/obstudio`. The binary embeds its own web UI via Go's `//go:embed` directive.

--- a/extension/package.json
+++ b/extension/package.json
@@ -50,17 +50,17 @@
       },
       {
         "command": "observability-studio.configureCodexMCP",
-        "title": "Configure Codex MCP",
+        "title": "Enable Codex Integration",
         "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.configureClaudeCodeMCP",
-        "title": "Configure Claude Code MCP",
+        "title": "Enable Claude Code Integration",
         "category": "Splunk Observability Studio"
       },
       {
         "command": "observability-studio.configureCursorMCP",
-        "title": "Configure Cursor MCP",
+        "title": "Enable Cursor Integration",
         "category": "Splunk Observability Studio"
       }
     ],
@@ -70,7 +70,14 @@
         "observability-studio.sharedObserverUrl": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Optional shared `obstudio` base URL or `/mcp` URL override. When unset, the extension reuses or starts `obstudio` on the fixed shared endpoint `http://127.0.0.1:3000`."
+          "markdownDescription": "Optional shared `obstudio` base URL or `/mcp` URL override. When unset, the extension reuses or starts a managed local `obstudio` on `http://127.0.0.1:<managedObserverPort>`."
+        },
+        "observability-studio.managedObserverPort": {
+          "type": "number",
+          "default": 3000,
+          "minimum": 1,
+          "maximum": 65535,
+          "markdownDescription": "Local port used by the extension-managed Observer UI and MCP HTTP endpoint when `sharedObserverUrl` is unset."
         }
       }
     }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,7 +1,10 @@
 import * as cp from 'node:child_process';
+import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import {
 	buildObserverHealthUrl,
@@ -40,16 +43,19 @@ let observerStartupPromise: Promise<void> | undefined;
 let observerStopPromise: Promise<void> | undefined;
 let observerStatusBarItem: vscode.StatusBarItem | undefined;
 let observerUsesSharedServer = false;
+let agentIntegrationPromptPromise: Promise<void> | undefined;
+let recentAgentIntegrationPrompts: Array<{ detail?: string; message: string }> = [];
 const observerLifecycleState = createObserverLifecycleState();
 let lastObserverPanelRenderKey: string | undefined;
 
 const observerPanelViewType = 'observabilityStudioObserver';
 const sharedObserverUrlSetting = 'sharedObserverUrl';
+const managedObserverPortSetting = 'managedObserverPort';
 const managedObserverHost = '127.0.0.1';
-const managedObserverPort = 3000;
-const managedObserverBaseUrl = `http://${managedObserverHost}:${managedObserverPort}`;
+const defaultManagedObserverPort = 3000;
 const observerKind = 'obstudio';
 const observerAPIVersion = 'v1';
+const agentIntegrationPromptDismissedPrefix = 'agentIntegrationPromptDismissed.';
 
 // The extension exposes a stable OTLP endpoint so instrumented apps can target a
 // predictable localhost port.
@@ -67,6 +73,21 @@ type InternalRuntimeState = {
 	validatorSummaryUrl?: string;
 };
 
+type AgentIntegrationTarget = 'claude-code' | 'codex' | 'cursor';
+
+type AgentIntegrationConfigFormat = 'json' | 'toml';
+
+type AgentIntegrationSpec = {
+	configFormat: AgentIntegrationConfigFormat;
+	configPath: (home: string) => string;
+	detectPaths: (home: string) => string[];
+	label: string;
+	skillsSentinelPath: (home: string) => string;
+	target: AgentIntegrationTarget;
+};
+
+type AgentIntegrationConfigState = 'different' | 'matching' | 'missing';
+
 type ObserverProbeOptions = {
 	requireStableOtlp: boolean;
 };
@@ -75,6 +96,33 @@ type ObserverProbeResult =
 	| { health: ObserverHealth; status: 'ready' }
 	| { error: Error; status: 'unavailable' }
 	| { reason: string; status: 'mismatch' };
+
+const agentIntegrationSpecs: AgentIntegrationSpec[] = [
+	{
+		target: 'codex',
+		label: 'Codex',
+		configFormat: 'toml',
+		configPath: (home) => path.join(home, '.codex', 'config.toml'),
+		detectPaths: (home) => [path.join(home, '.codex')],
+		skillsSentinelPath: (home) => path.join(home, '.codex', 'skills', 'otel-instrument', 'SKILL.md'),
+	},
+	{
+		target: 'claude-code',
+		label: 'Claude Code',
+		configFormat: 'json',
+		configPath: (home) => path.join(home, '.claude.json'),
+		detectPaths: (home) => [path.join(home, '.claude'), path.join(home, '.claude.json')],
+		skillsSentinelPath: (home) => path.join(home, '.claude', 'skills', 'otel-instrument', 'SKILL.md'),
+	},
+	{
+		target: 'cursor',
+		label: 'Cursor',
+		configFormat: 'json',
+		configPath: (home) => path.join(home, '.cursor', 'mcp.json'),
+		detectPaths: (home) => [path.join(home, '.cursor')],
+		skillsSentinelPath: (home) => path.join(home, '.cursor', 'skills', 'otel-instrument', 'SKILL.md'),
+	},
+];
 
 export async function activate(context: vscode.ExtensionContext) {
 	observerOutputChannel = vscode.window.createOutputChannel('Splunk Observability Studio');
@@ -91,6 +139,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				try {
 					await ensureObserverRunning(context);
 					refreshObserverPanel();
+					void maybeOfferDetectedAgentIntegrations(context);
 				} catch {
 					refreshObserverPanel();
 				}
@@ -98,7 +147,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 	);
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => {
-		if (!event.affectsConfiguration(`observability-studio.${sharedObserverUrlSetting}`)) {
+		if (
+			!event.affectsConfiguration(`observability-studio.${sharedObserverUrlSetting}`)
+			&& !event.affectsConfiguration(`observability-studio.${managedObserverPortSetting}`)
+		) {
 			return;
 		}
 		void restartObserver(context);
@@ -121,6 +173,14 @@ export async function activate(context: vscode.ExtensionContext) {
 		appendObserverOutputLine(`Observer startup failed: ${message}`);
 		void vscode.window.showErrorMessage(`Splunk Observability Studio could not start: ${message}`);
 	});
+	void ensureObserverRunning(context)
+		.then(() => maybeOfferDetectedAgentIntegrations(context))
+		.catch((error) => {
+			if (isObserverLifecycleCancelled(error)) {
+				return;
+			}
+			logObserverLifecycle(`Skipping automatic agent integration prompt: ${getErrorMessage(error)}`);
+		});
 
 	const openObserverDisposable = vscode.commands.registerCommand('observability-studio.openObserver', () => {
 		openObserverPanel(context);
@@ -138,7 +198,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				{
 					placeHolder: observerUsesSharedServer
 						? `Observer is reusing ${observerBaseUrl ?? 'a shared backend'}`
-						: `Observer is running on port ${observerLifecycleState.port ?? '?'}`,
+						: `Observer is running at ${observerBaseUrl ?? `http://${managedObserverHost}:${observerLifecycleState.port ?? '?'}`}`,
 				},
 			);
 			if (pick?.id === 'open') {
@@ -198,6 +258,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		try {
 			await ensureObserverRunning(context);
 			refreshObserverPanel();
+			void maybeOfferDetectedAgentIntegrations(context);
 		} catch (error) {
 			if (isObserverLifecycleCancelled(error)) {
 				refreshObserverPanel();
@@ -223,6 +284,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		try {
 			await ensureObserverRunning(context);
 			refreshObserverPanel();
+			void maybeOfferDetectedAgentIntegrations(context);
 		} catch (error) {
 			if (isObserverLifecycleCancelled(error)) {
 				refreshObserverPanel();
@@ -244,6 +306,30 @@ export async function activate(context: vscode.ExtensionContext) {
 	const configureCursorDisposable = vscode.commands.registerCommand(
 		'observability-studio.configureCursorMCP',
 		() => configureAgentMCP(context, 'cursor', 'Cursor'),
+	);
+	const internalConfigureDetectedAgentsDisposable = vscode.commands.registerCommand(
+		'observability-studio.internal.configureDetectedAgentIntegrations',
+		() => configureDetectedAgentIntegrations(context),
+	);
+	const internalGetAgentIntegrationPromptsDisposable = vscode.commands.registerCommand(
+		'observability-studio.internal.getAgentIntegrationPrompts',
+		() => recentAgentIntegrationPrompts.map((item) => ({ ...item })),
+	);
+	const internalClearAgentIntegrationPromptsDisposable = vscode.commands.registerCommand(
+		'observability-studio.internal.clearAgentIntegrationPrompts',
+		() => {
+			recentAgentIntegrationPrompts = [];
+		},
+	);
+	const internalResetAgentIntegrationPromptStateDisposable = vscode.commands.registerCommand(
+		'observability-studio.internal.resetAgentIntegrationPromptState',
+		async () => {
+			agentIntegrationPromptPromise = undefined;
+			recentAgentIntegrationPrompts = [];
+			for (const spec of agentIntegrationSpecs) {
+				await context.globalState.update(integrationPromptDismissalKey(spec.target), undefined);
+			}
+		},
 	);
 	const internalStateDisposable = vscode.commands.registerCommand(
 		'observability-studio.internal.getRuntimeState',
@@ -267,6 +353,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(configureCodexDisposable);
 	context.subscriptions.push(configureClaudeDisposable);
 	context.subscriptions.push(configureCursorDisposable);
+	context.subscriptions.push(internalConfigureDetectedAgentsDisposable);
+	context.subscriptions.push(internalGetAgentIntegrationPromptsDisposable);
+	context.subscriptions.push(internalClearAgentIntegrationPromptsDisposable);
+	context.subscriptions.push(internalResetAgentIntegrationPromptStateDisposable);
 	context.subscriptions.push(internalStateDisposable);
 	context.subscriptions.push(observerStatusBarItem);
 	context.subscriptions.push({
@@ -355,6 +445,8 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 			return;
 		}
 
+		const managedPort = getConfiguredManagedObserverPort();
+		const managedObserverBaseUrl = buildManagedObserverBaseUrl(managedPort);
 		const existingObserver = await probeObserver(managedObserverBaseUrl, 500, { requireStableOtlp: true });
 		assertObserverRunCurrent(observerLifecycleState, runId);
 
@@ -362,7 +454,7 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 			observerUsesSharedServer = true;
 			observerBaseUrl = managedObserverBaseUrl;
 			appendObserverOutputLine(`Reusing shared observer at ${managedObserverBaseUrl}`);
-			if (completeObserverStart(observerLifecycleState, runId, managedObserverPort)) {
+			if (completeObserverStart(observerLifecycleState, runId, managedPort)) {
 				syncObserverUi();
 			}
 			return;
@@ -371,12 +463,22 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 		if (existingObserver.status === 'mismatch') {
 			throw new Error(
 				`Cannot use ${managedObserverBaseUrl}: ${existingObserver.reason}. ` +
-				`Stop the conflicting service or configure observability-studio.${sharedObserverUrlSetting}.`,
+				`Stop the conflicting service or configure observability-studio.${managedObserverPortSetting} ` +
+				`or observability-studio.${sharedObserverUrlSetting}.`,
 			);
 		}
 
 		const backend = resolveBackend(context.extensionPath);
-		const observerPort = await ensurePortAvailable(managedObserverPort);
+		let observerPort: number;
+		try {
+			observerPort = await ensurePortAvailable(managedPort);
+		} catch (error) {
+			throw new Error(
+				`Cannot use ${managedObserverBaseUrl}: ${getErrorMessage(error)} ` +
+				`Configure observability-studio.${managedObserverPortSetting} or ` +
+				`observability-studio.${sharedObserverUrlSetting}.`,
+			);
+		}
 		logObserverLifecycle(`Run ${runId}: reserved UI port ${observerPort}.`);
 		assertObserverRunCurrent(observerLifecycleState, runId);
 
@@ -592,6 +694,7 @@ async function openObserverPanel(context: vscode.ExtensionContext): Promise<void
 	try {
 		await ensureObserverRunning(context);
 		refreshObserverPanel();
+		void maybeOfferDetectedAgentIntegrations(context);
 	} catch {
 		refreshObserverPanel();
 	}
@@ -836,6 +939,7 @@ async function restartObserver(context: vscode.ExtensionContext): Promise<void> 
 	try {
 		await ensureObserverRunning(context);
 		refreshObserverPanel();
+		void maybeOfferDetectedAgentIntegrations(context);
 	} catch (error) {
 		if (isObserverLifecycleCancelled(error)) {
 			refreshObserverPanel();
@@ -887,6 +991,25 @@ function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => { setTimeout(resolve, ms); });
 }
 
+function buildManagedObserverBaseUrl(port: number): string {
+	return `http://${managedObserverHost}:${port}`;
+}
+
+function getConfiguredManagedObserverPort(): number {
+	const configured = vscode.workspace.getConfiguration('observability-studio').get<number>(managedObserverPortSetting);
+	if (typeof configured === 'number' && Number.isInteger(configured) && configured > 0 && configured <= 65_535) {
+		if (configured === observerOtlpHttpPort || configured === observerOtlpGrpcPort) {
+			const signal = configured === observerOtlpHttpPort ? 'OTLP/HTTP' : 'OTLP/gRPC';
+			throw new Error(
+				`observability-studio.${managedObserverPortSetting} cannot use port ${configured}; ` +
+				`${signal} already uses that port.`,
+			);
+		}
+		return configured;
+	}
+	return defaultManagedObserverPort;
+}
+
 function appendObserverOutput(text: string): void {
 	if (observerOutputChannel === undefined) {
 		return;
@@ -920,10 +1043,189 @@ function getConfiguredSharedObserverUrl(): string | undefined {
 	return normalizeObserverBaseUrl(trimmed);
 }
 
+function getDetectedAgentIntegrations(): AgentIntegrationSpec[] {
+	const home = os.homedir();
+	return agentIntegrationSpecs.filter((spec) => spec.detectPaths(home).some((candidate) => fs.existsSync(candidate)));
+}
+
+function integrationPromptDismissalKey(target: AgentIntegrationTarget): string {
+	return `${agentIntegrationPromptDismissedPrefix}${target}`;
+}
+
+function formatAgentLabelList(labels: string[]): string {
+	if (labels.length === 0) {
+		return '';
+	}
+	if (labels.length === 1) {
+		return labels[0];
+	}
+	if (labels.length === 2) {
+		return `${labels[0]} and ${labels[1]}`;
+	}
+	return `${labels.slice(0, -1).join(', ')}, and ${labels[labels.length - 1]}`;
+}
+
+function getAgentIntegrationConfigState(spec: AgentIntegrationSpec, mcpUrl: string): AgentIntegrationConfigState {
+	const configPath = spec.configPath(os.homedir());
+	if (!fs.existsSync(configPath)) {
+		return 'missing';
+	}
+
+	try {
+		if (spec.configFormat === 'json') {
+			const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+				mcpServers?: Record<string, { type?: string; url?: string }>;
+			};
+			const server = config.mcpServers?.obstudio;
+			if (server === undefined) {
+				return 'missing';
+			}
+			return server.type === 'http' && server.url === mcpUrl ? 'matching' : 'different';
+		}
+
+		const content = fs.readFileSync(configPath, 'utf8');
+		const section = getCodexObstudioSection(content);
+		if (section === undefined) {
+			return 'missing';
+		}
+		return section.includes(`url = "${mcpUrl}"`) ? 'matching' : 'different';
+	} catch {
+		return 'different';
+	}
+}
+
+function getCodexObstudioSection(content: string): string | undefined {
+	const lines = content.split(/\r?\n/);
+	let section: string[] | undefined;
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+			if (trimmed === '[mcp_servers.obstudio]') {
+				section = [line];
+				continue;
+			}
+			if (section !== undefined) {
+				break;
+			}
+		}
+		if (section !== undefined) {
+			section.push(line);
+		}
+	}
+	return section?.join('\n');
+}
+
+function hasInstalledAgentSkills(spec: AgentIntegrationSpec): boolean {
+	return fs.existsSync(spec.skillsSentinelPath(os.homedir()));
+}
+
+function needsAgentIntegrationUpdate(spec: AgentIntegrationSpec, mcpUrl: string): boolean {
+	return getAgentIntegrationConfigState(spec, mcpUrl) !== 'matching' || !hasInstalledAgentSkills(spec);
+}
+
+async function configureDetectedAgentIntegrations(
+	context: vscode.ExtensionContext,
+	specs = getDetectedAgentIntegrations(),
+	showSuccessMessage = true,
+	forceAll = false,
+): Promise<string[]> {
+	await ensureObserverRunning(context);
+	if (observerBaseUrl === undefined) {
+		throw new Error('Observer URL is not available.');
+	}
+
+	const mcpUrl = `${normalizeObserverBaseUrl(observerBaseUrl)}/mcp`;
+	const configured: string[] = [];
+	for (const spec of specs) {
+		if (!forceAll && !needsAgentIntegrationUpdate(spec, mcpUrl)) {
+			continue;
+		}
+
+		await configureAgentMCP(context, spec.target, spec.label, false);
+		configured.push(spec.label);
+	}
+
+	if (showSuccessMessage && configured.length > 0) {
+		const labelList = formatAgentLabelList(configured);
+		const noun = configured.length === 1 ? 'integration' : 'integrations';
+		void vscode.window.showInformationMessage(
+			`${labelList} ${noun} enabled. Restart ${labelList} to load the bundled skills.`,
+		);
+	}
+	return configured;
+}
+
+async function maybeOfferDetectedAgentIntegrations(context: vscode.ExtensionContext): Promise<void> {
+	if (agentIntegrationPromptPromise !== undefined) {
+		return agentIntegrationPromptPromise;
+	}
+
+	const promptPromise = (async () => {
+		if (observerBaseUrl === undefined) {
+			return;
+		}
+
+		const mcpUrl = `${normalizeObserverBaseUrl(observerBaseUrl)}/mcp`;
+		const shownSpecs = getDetectedAgentIntegrations().filter((spec) => {
+			const dismissed = context.globalState.get<boolean>(integrationPromptDismissalKey(spec.target)) === true;
+			if (!dismissed) {
+				return true;
+			}
+			return getAgentIntegrationConfigState(spec, mcpUrl) !== 'missing';
+		});
+		if (shownSpecs.length === 0) {
+			return;
+		}
+		const needsUpdate = shownSpecs.some((spec) => needsAgentIntegrationUpdate(spec, mcpUrl));
+		if (!needsUpdate) {
+			return;
+		}
+
+		const labels = shownSpecs.map((spec) => spec.label);
+		const labelList = formatAgentLabelList(labels);
+		const promptMessage = shownSpecs.length === 1
+			? `Enable ${labels[0]} integration for Splunk Observability Studio?`
+			: 'Enable detected agent integrations for Splunk Observability Studio?';
+		const promptDetail = shownSpecs.length === 1
+			? `Install bundled skills and configure ${labels[0]} to use the local Observer at ${mcpUrl}.`
+			: `Install bundled skills and configure ${labelList} to use the local Observer at ${mcpUrl}.`;
+		recentAgentIntegrationPrompts = [...recentAgentIntegrationPrompts.slice(-9), {
+			detail: promptDetail,
+			message: promptMessage,
+		}];
+		const choice = await vscode.window.showInformationMessage(
+			promptMessage,
+			{ detail: promptDetail },
+			'Enable',
+			'Not Now',
+		);
+		if (choice === 'Enable') {
+			await configureDetectedAgentIntegrations(context, shownSpecs, true, true);
+			return;
+		}
+		if (choice === 'Not Now') {
+			for (const spec of shownSpecs) {
+				await context.globalState.update(integrationPromptDismissalKey(spec.target), true);
+			}
+			logObserverLifecycle(`${labelList} integration prompt dismissed.`);
+		}
+	})().catch((error) => {
+		appendObserverOutputLine(`Automatic agent integration check failed: ${getErrorMessage(error)}`);
+	}).finally(() => {
+		if (agentIntegrationPromptPromise === promptPromise) {
+			agentIntegrationPromptPromise = undefined;
+		}
+	});
+
+	agentIntegrationPromptPromise = promptPromise;
+	return promptPromise;
+}
+
 async function configureAgentMCP(
 	context: vscode.ExtensionContext,
-	target: 'claude-code' | 'codex' | 'cursor',
+	target: AgentIntegrationTarget,
 	label: string,
+	showSuccessMessage = true,
 ): Promise<void> {
 	if (observerOutputChannel === undefined) {
 		throw new Error('Observer output channel is not initialized.');
@@ -937,12 +1239,17 @@ async function configureAgentMCP(
 
 		const mcpUrl = `${normalizeObserverBaseUrl(observerBaseUrl)}/mcp`;
 		const backend = resolveBackend(context.extensionPath);
-		observerOutputChannel.appendLine(`Configuring ${label} MCP for ${mcpUrl}`);
+		observerOutputChannel.appendLine(`Enabling ${label} integration for ${mcpUrl}`);
 		await execFile(backend.command, ['install', '--target', target, '--shared-url', mcpUrl], backend.cwd);
-		observerOutputChannel.appendLine(`${label} MCP configured for ${mcpUrl}`);
-		void vscode.window.showInformationMessage(`${label} MCP configured for ${mcpUrl}`);
+		await context.globalState.update(integrationPromptDismissalKey(target), undefined);
+		observerOutputChannel.appendLine(`${label} integration enabled for ${mcpUrl}`);
+		if (showSuccessMessage) {
+			void vscode.window.showInformationMessage(
+				`${label} integration enabled. Restart ${label} to load the bundled skills.`,
+			);
+		}
 	} catch (error) {
-		const message = `${label} MCP configuration failed: ${getErrorMessage(error)}`;
+		const message = `${label} integration failed: ${getErrorMessage(error)}`;
 		observerOutputChannel.appendLine(message);
 		void vscode.window.showErrorMessage(message);
 		throw error;

--- a/extension/src/test/extension-vscode.test.ts
+++ b/extension/src/test/extension-vscode.test.ts
@@ -708,7 +708,7 @@ suite('VS Code Host', () => {
 			for (const snapshot of originalSnapshots) {
 				restoreSnapshot(snapshot);
 			}
-			fs.rmSync(tempHome, { force: true, recursive: true });
+			cleanupTempDir(tempHome);
 		}
 	});
 

--- a/extension/src/test/extension-vscode.test.ts
+++ b/extension/src/test/extension-vscode.test.ts
@@ -230,6 +230,33 @@ async function startSlowSharedObserver(delayMs: number): Promise<SharedObserverH
 	};
 }
 
+async function startConflictingHttpService(port: number): Promise<SharedObserverHandle> {
+	const server = http.createServer((_request, response) => {
+		response.setHeader('Content-Type', 'text/plain; charset=utf-8');
+		response.end('not-obstudio');
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(port, '127.0.0.1', () => resolve());
+	});
+
+	return {
+		baseUrl: `http://127.0.0.1:${port}`,
+		dispose: async () => {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		},
+	};
+}
+
 function readText(filePath: string): string {
 	return fs.readFileSync(filePath, 'utf8');
 }
@@ -266,6 +293,26 @@ async function assertCodexConfigured(filePaths: string[], mcpUrl: string): Promi
 	throw new Error(`Missing Codex config in any expected path: ${filePaths.join(', ')}`);
 }
 
+async function assertCodexPreservesExistingConfig(filePaths: string[], mcpUrl: string): Promise<void> {
+	for (const filePath of filePaths) {
+		try {
+			const content = await waitForFileText(filePath);
+			assert.ok(content.includes(`url = "${mcpUrl}"`));
+			assert.ok(content.includes(`model = "gpt-5.4"`));
+			assert.ok(content.includes(`[mcp_servers.other]`));
+			assert.ok(content.includes(`url = "http://example.com/mcp"`));
+			assert.ok(content.includes(`[projects."/tmp/demo"]`));
+			assert.ok(content.includes(`trust_level = "trusted"`));
+			assert.equal((content.match(/\[mcp_servers\.obstudio\]/g) ?? []).length, 1);
+			return;
+		} catch {
+			// Try the next candidate path.
+		}
+	}
+
+	throw new Error(`Missing preserved Codex config in any expected path: ${filePaths.join(', ')}`);
+}
+
 async function assertJSONMCPConfigured(filePaths: string[], serverName: string, mcpUrl: string): Promise<void> {
 	for (const filePath of filePaths) {
 		try {
@@ -279,6 +326,27 @@ async function assertJSONMCPConfigured(filePaths: string[], serverName: string, 
 	}
 
 	throw new Error(`Missing JSON MCP config in any expected path: ${filePaths.join(', ')}`);
+}
+
+async function assertJSONMCPPreservesExistingServer(
+	filePaths: string[],
+	serverName: string,
+	command: string,
+	rootKey: string,
+	rootValue: string,
+): Promise<void> {
+	for (const filePath of filePaths) {
+		try {
+			const raw = JSON.parse(await waitForFileText(filePath));
+			assert.equal(raw?.mcpServers?.[serverName]?.command, command);
+			assert.equal(raw?.[rootKey], rootValue);
+			return;
+		} catch {
+			// Try the next candidate path.
+		}
+	}
+
+	throw new Error(`Missing preserved JSON MCP config in any expected path: ${filePaths.join(', ')}`);
 }
 
 function snapshotFile(filePath: string): FileSnapshot {
@@ -305,6 +373,47 @@ function restoreSnapshot(snapshot: FileSnapshot): void {
 	}
 
 	fs.rmSync(snapshot.filePath, { force: true });
+}
+
+function cleanupTempDir(dirPath: string): void {
+	const retryableCodes = new Set(['EBUSY', 'ENOTEMPTY', 'EPERM', 'EEXIST']);
+	const sleep = (ms: number) => {
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+	};
+
+	for (let attempt = 0; attempt < 8; attempt += 1) {
+		try {
+			fs.rmSync(dirPath, {
+				force: true,
+				maxRetries: 10,
+				recursive: true,
+				retryDelay: 100,
+			});
+			return;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException | undefined)?.code;
+			if (!code || !retryableCodes.has(code)) {
+				throw error;
+			}
+			sleep(100 * (attempt + 1));
+		}
+	}
+
+	try {
+		fs.rmSync(dirPath, {
+			force: true,
+			maxRetries: 20,
+			recursive: true,
+			retryDelay: 150,
+		});
+		return;
+	} catch {}
+
+	if (process.platform !== 'win32') {
+		try {
+			cp.execFileSync('rm', ['-rf', dirPath], { stdio: 'ignore' });
+		} catch {}
+	}
 }
 
 async function postJson(url: string): Promise<any> {
@@ -348,6 +457,175 @@ suite('VS Code Host', () => {
 			isRetryableSharedObserverStartupFailure('shared observer failed to start: connect ECONNREFUSED 127.0.0.1:36715'),
 			false,
 		);
+	});
+
+	test('managed observer uses the configured port across restarts', async function () {
+		this.timeout(30_000);
+		if (process.platform === 'darwin') {
+			this.skip();
+		}
+
+		await getExtension();
+		const managedPort = await getAvailablePort();
+		const config = vscode.workspace.getConfiguration('observability-studio');
+
+		try {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await config.update('managedObserverPort', managedPort, vscode.ConfigurationTarget.Global);
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+
+			await vscode.commands.executeCommand('observability-studio.startObserver');
+			const firstState = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value?.observerUrl === `http://127.0.0.1:${managedPort}`),
+				20_000,
+			);
+			assert.equal(firstState.observerUrl, `http://127.0.0.1:${managedPort}`);
+			const firstHealth = await fetchJson(`${firstState.observerUrl}/api/health`);
+			assert.equal(firstHealth.kind, 'obstudio');
+
+			await vscode.commands.executeCommand('observability-studio.restartObserver');
+			const secondState = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value?.observerUrl === `http://127.0.0.1:${managedPort}`),
+				20_000,
+			);
+			assert.equal(secondState.observerUrl, `http://127.0.0.1:${managedPort}`);
+			const secondHealth = await fetchJson(`${secondState.observerUrl}/api/health`);
+			assert.equal(secondHealth.kind, 'obstudio');
+		} finally {
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+			await config.update('managedObserverPort', undefined, vscode.ConfigurationTarget.Global);
+		}
+	});
+
+	test('changing shared observer URL re-prompts detected agents to update their MCP endpoint', async function () {
+		this.timeout(30_000);
+
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const extension = await getExtension();
+		const firstSharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const secondSharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const firstSharedMcpUrl = `${firstSharedObserver.baseUrl}/mcp`;
+		const secondSharedMcpUrl = `${secondSharedObserver.baseUrl}/mcp`;
+		const codexConfigPath = path.join(tempHome, '.codex', 'config.toml');
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		try {
+			await config.update('sharedObserverUrl', firstSharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value && value.sharedMode && value.observerUrl === firstSharedObserver.baseUrl),
+				20_000,
+			);
+
+			fs.mkdirSync(path.join(tempHome, '.codex'), { recursive: true });
+			await vscode.commands.executeCommand('observability-studio.configureCodexMCP');
+			await assertCodexConfigured([codexConfigPath], firstSharedMcpUrl);
+
+			await vscode.commands.executeCommand('observability-studio.internal.resetAgentIntegrationPromptState');
+			await config.update('sharedObserverUrl', secondSharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value && value.sharedMode && value.observerUrl === secondSharedObserver.baseUrl),
+				20_000,
+			);
+
+			const prompts = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<Array<{ detail?: string; message: string }>>(
+					'observability-studio.internal.getAgentIntegrationPrompts',
+				)),
+				(value) => Array.isArray(value) && value.some((item) =>
+					item.message.includes('Enable Codex integration for Splunk Observability Studio?')
+					&& item.detail?.includes(secondSharedMcpUrl)
+				),
+				20_000,
+			);
+
+			const prompt = prompts.find((item) => item.message.includes('Enable Codex integration for Splunk Observability Studio?'));
+			assert.ok(prompt, 'expected the Codex integration prompt after changing the shared Observer URL');
+			assert.equal(prompt?.detail, `Install bundled skills and configure Codex to use the local Observer at ${secondSharedMcpUrl}.`);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await firstSharedObserver.dispose();
+			await secondSharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			cleanupTempDir(tempHome);
+		}
+	});
+
+	test('managed observer does not fall back when the configured port is occupied', async function () {
+		this.timeout(30_000);
+
+		await getExtension();
+		const conflictPort = await getAvailablePort();
+		const conflictService = await startConflictingHttpService(conflictPort);
+		const config = vscode.workspace.getConfiguration('observability-studio');
+
+		try {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await config.update('managedObserverPort', conflictPort, vscode.ConfigurationTarget.Global);
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+
+			await vscode.commands.executeCommand('observability-studio.openObserver');
+			const failedState = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => {
+					if (!value || value.observerPort !== undefined || value.observerUrl !== undefined) {
+						return false;
+					}
+					return typeof value.panelHtml === 'string'
+						&& value.panelHtml.includes('Observer could not start')
+						&& value.panelHtml.includes(`http://127.0.0.1:${conflictPort}`)
+						&& value.panelHtml.includes('observability-studio.managedObserverPort');
+				},
+				20_000,
+			);
+			assert.equal(failedState.sharedMode, false);
+		} finally {
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+			await config.update('managedObserverPort', undefined, vscode.ConfigurationTarget.Global);
+			await conflictService.dispose();
+		}
+	});
+
+	test('managed observer rejects ports reserved for fixed OTLP listeners', async function () {
+		this.timeout(30_000);
+
+		await getExtension();
+		const config = vscode.workspace.getConfiguration('observability-studio');
+
+		try {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await config.update('managedObserverPort', 4318, vscode.ConfigurationTarget.Global);
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+
+			await vscode.commands.executeCommand('observability-studio.openObserver');
+			const failedState = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => {
+					if (!value || value.observerPort !== undefined || value.observerUrl !== undefined) {
+						return false;
+					}
+					return typeof value.panelHtml === 'string'
+						&& value.panelHtml.includes('Observer could not start')
+						&& value.panelHtml.includes('observability-studio.managedObserverPort')
+						&& value.panelHtml.includes('4318')
+						&& value.panelHtml.includes('OTLP/HTTP');
+				},
+				20_000,
+			);
+			assert.equal(failedState.sharedMode, false);
+		} finally {
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+			await config.update('managedObserverPort', undefined, vscode.ConfigurationTarget.Global);
+		}
 	});
 
 	test('openObserver reuses configured shared backend and configures MCP targets', async function () {
@@ -431,6 +709,449 @@ suite('VS Code Host', () => {
 				restoreSnapshot(snapshot);
 			}
 			fs.rmSync(tempHome, { force: true, recursive: true });
+		}
+	});
+
+	test('configuring JSON MCP targets appends obstudio without overwriting existing servers', async function () {
+		this.timeout(30_000);
+
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const claudeConfigPath = path.join(tempHome, '.claude.json');
+		const cursorConfigPath = path.join(tempHome, '.cursor', 'mcp.json');
+		const originalClaudeConfigPath = originalHome ? path.join(originalHome, '.claude.json') : '';
+		const originalCursorConfigPath = originalHome ? path.join(originalHome, '.cursor', 'mcp.json') : '';
+		const originalSnapshots = [
+			snapshotFile(originalClaudeConfigPath),
+			snapshotFile(originalCursorConfigPath),
+		];
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		try {
+			fs.mkdirSync(path.dirname(cursorConfigPath), { recursive: true });
+			fs.writeFileSync(
+				claudeConfigPath,
+				JSON.stringify({
+					editor: 'claude',
+					mcpServers: {
+						obstudio: {
+							type: 'http',
+							url: 'http://127.0.0.1:3999/mcp',
+						},
+						existingClaude: {
+							command: 'existing-claude',
+							args: ['--serve'],
+						},
+					},
+				}, null, 2),
+			);
+			fs.writeFileSync(
+				cursorConfigPath,
+				JSON.stringify({
+					theme: 'dark',
+					mcpServers: {
+						obstudio: {
+							type: 'http',
+							url: 'http://127.0.0.1:4999/mcp',
+						},
+						existingCursor: {
+							command: 'existing-cursor',
+							args: ['--serve'],
+						},
+					},
+				}, null, 2),
+			);
+
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value && value.sharedMode && value.observerUrl === sharedObserver.baseUrl),
+				20_000,
+			);
+
+			await vscode.commands.executeCommand('observability-studio.configureClaudeCodeMCP');
+			await vscode.commands.executeCommand('observability-studio.configureCursorMCP');
+
+			await assertJSONMCPConfigured([claudeConfigPath, originalClaudeConfigPath], 'obstudio', sharedMcpUrl);
+			await assertJSONMCPConfigured([cursorConfigPath, originalCursorConfigPath], 'obstudio', sharedMcpUrl);
+			await assertJSONMCPPreservesExistingServer(
+				[claudeConfigPath, originalClaudeConfigPath],
+				'existingClaude',
+				'existing-claude',
+				'editor',
+				'claude',
+			);
+			await assertJSONMCPPreservesExistingServer(
+				[cursorConfigPath, originalCursorConfigPath],
+				'existingCursor',
+				'existing-cursor',
+				'theme',
+				'dark',
+			);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			for (const snapshot of originalSnapshots) {
+				restoreSnapshot(snapshot);
+			}
+			cleanupTempDir(tempHome);
+		}
+	});
+
+	test('detected agent integration preserves dummy MCP config across Codex, Claude, and Cursor', async function () {
+		this.timeout(30_000);
+
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const codexConfigPath = path.join(tempHome, '.codex', 'config.toml');
+		const claudeConfigPath = path.join(tempHome, '.claude.json');
+		const cursorConfigPath = path.join(tempHome, '.cursor', 'mcp.json');
+		const originalCodexConfigPath = originalHome ? path.join(originalHome, '.codex', 'config.toml') : '';
+		const originalClaudeConfigPath = originalHome ? path.join(originalHome, '.claude.json') : '';
+		const originalCursorConfigPath = originalHome ? path.join(originalHome, '.cursor', 'mcp.json') : '';
+		const originalSnapshots = [
+			snapshotFile(originalCodexConfigPath),
+			snapshotFile(originalClaudeConfigPath),
+			snapshotFile(originalCursorConfigPath),
+		];
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		try {
+			fs.mkdirSync(path.join(tempHome, '.codex'), { recursive: true });
+			fs.mkdirSync(path.join(tempHome, '.cursor'), { recursive: true });
+			fs.writeFileSync(
+				codexConfigPath,
+				[
+					`model = "gpt-5.4"`,
+					``,
+					`[mcp_servers.obstudio]`,
+					`url = "http://127.0.0.1:3999/mcp"`,
+					``,
+					`[mcp_servers.other]`,
+					`url = "http://example.com/mcp"`,
+					``,
+					`[projects."/tmp/demo"]`,
+					`trust_level = "trusted"`,
+					``,
+				].join('\n'),
+				'utf8',
+			);
+			fs.writeFileSync(
+				claudeConfigPath,
+				JSON.stringify({
+					editor: 'claude',
+					mcpServers: {
+						obstudio: {
+							type: 'http',
+							url: 'http://127.0.0.1:3999/mcp',
+						},
+						existingClaude: {
+							command: 'existing-claude',
+							args: ['--serve'],
+						},
+					},
+				}, null, 2),
+			);
+			fs.writeFileSync(
+				cursorConfigPath,
+				JSON.stringify({
+					theme: 'dark',
+					mcpServers: {
+						obstudio: {
+							type: 'http',
+							url: 'http://127.0.0.1:4999/mcp',
+						},
+						existingCursor: {
+							command: 'existing-cursor',
+							args: ['--serve'],
+						},
+					},
+				}, null, 2),
+			);
+
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value && value.sharedMode && value.observerUrl === sharedObserver.baseUrl),
+				20_000,
+			);
+
+			const configured = await vscode.commands.executeCommand<string[]>(
+				'observability-studio.internal.configureDetectedAgentIntegrations',
+			);
+			assert.deepEqual(configured, ['Codex', 'Claude Code', 'Cursor']);
+
+			await assertCodexPreservesExistingConfig([codexConfigPath, originalCodexConfigPath], sharedMcpUrl);
+			await assertJSONMCPConfigured([claudeConfigPath, originalClaudeConfigPath], 'obstudio', sharedMcpUrl);
+			await assertJSONMCPConfigured([cursorConfigPath, originalCursorConfigPath], 'obstudio', sharedMcpUrl);
+			await assertJSONMCPPreservesExistingServer(
+				[claudeConfigPath, originalClaudeConfigPath],
+				'existingClaude',
+				'existing-claude',
+				'editor',
+				'claude',
+			);
+			await assertJSONMCPPreservesExistingServer(
+				[cursorConfigPath, originalCursorConfigPath],
+				'existingCursor',
+				'existing-cursor',
+				'theme',
+				'dark',
+			);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			for (const snapshot of originalSnapshots) {
+				restoreSnapshot(snapshot);
+			}
+			cleanupTempDir(tempHome);
+		}
+	});
+
+	test('detected agent installs can be enabled together through the automatic integration path', async function () {
+		this.timeout(30_000);
+
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const codexConfigPath = path.join(tempHome, '.codex', 'config.toml');
+		const codexSkillsDir = path.join(tempHome, '.codex', 'skills');
+		const cursorConfigPath = path.join(tempHome, '.cursor', 'mcp.json');
+		const cursorSkillsDir = path.join(tempHome, '.cursor', 'skills');
+		const originalCodexConfigPath = originalHome ? path.join(originalHome, '.codex', 'config.toml') : '';
+		const originalCursorConfigPath = originalHome ? path.join(originalHome, '.cursor', 'mcp.json') : '';
+		const originalSnapshots = [
+			snapshotFile(originalCodexConfigPath),
+			snapshotFile(originalCursorConfigPath),
+		];
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+
+		try {
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value && value.sharedMode && value.observerUrl === sharedObserver.baseUrl),
+				20_000,
+			);
+
+			fs.mkdirSync(path.join(tempHome, '.codex'), { recursive: true });
+			fs.mkdirSync(path.join(tempHome, '.cursor'), { recursive: true });
+			fs.writeFileSync(
+				cursorConfigPath,
+				JSON.stringify({
+					mcpServers: {
+						obstudio: {
+							type: 'http',
+							url: 'http://127.0.0.1:4999/mcp',
+						},
+					},
+				}, null, 2),
+			);
+			const configured = await vscode.commands.executeCommand<string[]>(
+				'observability-studio.internal.configureDetectedAgentIntegrations',
+			);
+			assert.deepEqual(configured, ['Codex', 'Cursor']);
+
+			await assertCodexConfigured([codexConfigPath, originalCodexConfigPath], sharedMcpUrl);
+			await assertJSONMCPConfigured([cursorConfigPath, originalCursorConfigPath], 'obstudio', sharedMcpUrl);
+			assert.equal(fs.existsSync(path.join(codexSkillsDir, 'obstudio', 'obstudio')), true);
+			assert.equal(fs.existsSync(path.join(codexSkillsDir, 'obstudio', 'otel-audit', 'SKILL.md')), true);
+			assert.equal(fs.existsSync(path.join(codexSkillsDir, 'otel-audit', 'SKILL.md')), true);
+			assert.equal(fs.existsSync(path.join(cursorSkillsDir, 'obstudio', 'obstudio')), true);
+			assert.equal(fs.existsSync(path.join(cursorSkillsDir, 'obstudio', 'otel-audit', 'SKILL.md')), true);
+			assert.equal(fs.existsSync(path.join(cursorSkillsDir, 'otel-audit', 'SKILL.md')), true);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			for (const snapshot of originalSnapshots) {
+				restoreSnapshot(snapshot);
+			}
+			cleanupTempDir(tempHome);
+		}
+	});
+
+	test('detected Codex installs show a VS Code enable integration prompt', async function () {
+		this.timeout(30_000);
+
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		try {
+			fs.mkdirSync(path.join(tempHome, '.codex'), { recursive: true });
+			await vscode.commands.executeCommand('observability-studio.internal.resetAgentIntegrationPromptState');
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+			await vscode.commands.executeCommand('observability-studio.startObserver');
+			const prompts = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<Array<{ detail?: string; message: string }>>(
+					'observability-studio.internal.getAgentIntegrationPrompts',
+				)),
+				(value) => Array.isArray(value) && value.some((item) => item.message.includes('Enable Codex integration for Splunk Observability Studio?')),
+				20_000,
+			);
+
+			const prompt = prompts.find((item) => item.message.includes('Enable Codex integration for Splunk Observability Studio?'));
+			assert.ok(prompt, 'expected the Codex integration prompt to be shown');
+			assert.equal(prompt?.detail, `Install bundled skills and configure Codex to use the local Observer at ${sharedMcpUrl}.`);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			cleanupTempDir(tempHome);
+		}
+	});
+
+	test('matching Codex, Claude Code, and Cursor MCP config does not prompt when bundled skills are present', async function () {
+		this.timeout(30_000);
+
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		try {
+			fs.mkdirSync(path.join(tempHome, '.codex', 'skills', 'obstudio', 'otel-instrument'), { recursive: true });
+			fs.mkdirSync(path.join(tempHome, '.claude', 'skills', 'obstudio', 'otel-instrument'), { recursive: true });
+			fs.mkdirSync(path.join(tempHome, '.cursor', 'skills', 'obstudio', 'otel-instrument'), { recursive: true });
+			fs.writeFileSync(path.join(tempHome, '.codex', 'skills', 'obstudio', 'otel-instrument', 'SKILL.md'), '# Codex skill\n', 'utf8');
+			fs.writeFileSync(path.join(tempHome, '.claude', 'skills', 'obstudio', 'otel-instrument', 'SKILL.md'), '# Claude skill\n', 'utf8');
+			fs.writeFileSync(path.join(tempHome, '.cursor', 'skills', 'obstudio', 'otel-instrument', 'SKILL.md'), '# Cursor skill\n', 'utf8');
+			fs.symlinkSync(path.join('obstudio', 'otel-instrument'), path.join(tempHome, '.codex', 'skills', 'otel-instrument'));
+			fs.symlinkSync(path.join('obstudio', 'otel-instrument'), path.join(tempHome, '.claude', 'skills', 'otel-instrument'));
+			fs.mkdirSync(path.join(tempHome, '.cursor'), { recursive: true });
+			fs.symlinkSync(path.join('obstudio', 'otel-instrument'), path.join(tempHome, '.cursor', 'skills', 'otel-instrument'));
+			fs.writeFileSync(path.join(tempHome, '.codex', 'config.toml'), `model = "gpt-5.4"\n\n[mcp_servers.obstudio]\nurl = "${sharedMcpUrl}"\n`, 'utf8');
+			fs.writeFileSync(
+				path.join(tempHome, '.claude.json'),
+				JSON.stringify({
+					mcpServers: {
+						obstudio: { type: 'http', url: sharedMcpUrl },
+					},
+				}, null, 2),
+				'utf8',
+			);
+			fs.writeFileSync(
+				path.join(tempHome, '.cursor', 'mcp.json'),
+				JSON.stringify({
+					mcpServers: {
+						obstudio: { type: 'http', url: sharedMcpUrl },
+					},
+				}, null, 2),
+				'utf8',
+			);
+
+			await vscode.commands.executeCommand('observability-studio.internal.resetAgentIntegrationPromptState');
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+			await vscode.commands.executeCommand('observability-studio.startObserver');
+			await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+			const prompts = await vscode.commands.executeCommand<Array<{ detail?: string; message: string }>>(
+				'observability-studio.internal.getAgentIntegrationPrompts',
+			);
+			assert.ok(Array.isArray(prompts), 'expected prompt history to be available');
+			assert.equal(
+				prompts.some((item) => item.message.includes('Enable detected agent integrations for Splunk Observability Studio?')),
+				false,
+			);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			cleanupTempDir(tempHome);
+		}
+	});
+
+	test('re-enabling integrations rewrites obstudio without duplicating MCP entries', async function () {
+		this.timeout(30_000);
+
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-home-'));
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		const codexConfigPath = path.join(tempHome, '.codex', 'config.toml');
+		const cursorConfigPath = path.join(tempHome, '.cursor', 'mcp.json');
+		const extension = await getExtension();
+		const sharedObserver = await startSharedObserver(path.join(extension.extensionPath, 'dist', 'observer', 'obstudio'));
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `${sharedObserver.baseUrl}/mcp`;
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+
+		try {
+			fs.mkdirSync(path.join(tempHome, '.codex'), { recursive: true });
+			fs.mkdirSync(path.join(tempHome, '.cursor'), { recursive: true });
+
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+			await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => Boolean(value && value.sharedMode && value.observerUrl === sharedObserver.baseUrl),
+				20_000,
+			);
+
+			await vscode.commands.executeCommand('observability-studio.configureCodexMCP');
+			await vscode.commands.executeCommand('observability-studio.configureCursorMCP');
+			await vscode.commands.executeCommand('observability-studio.configureCodexMCP');
+			await vscode.commands.executeCommand('observability-studio.configureCursorMCP');
+
+			const codexConfig = await waitForFileText(codexConfigPath);
+			assert.equal((codexConfig.match(/\[mcp_servers\.obstudio\]/g) ?? []).length, 1);
+			assert.equal((codexConfig.match(/# BEGIN OBSTUDIO MCP CONFIG/g) ?? []).length, 1);
+			assert.ok(codexConfig.includes(`url = "${sharedMcpUrl}"`));
+
+			const cursorConfig = JSON.parse(await waitForFileText(cursorConfigPath));
+			assert.equal(Object.keys(cursorConfig.mcpServers).filter((name) => name === 'obstudio').length, 1);
+			assert.equal(cursorConfig.mcpServers.obstudio.type, 'http');
+			assert.equal(cursorConfig.mcpServers.obstudio.url, sharedMcpUrl);
+		} finally {
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
+			await sharedObserver.dispose();
+			process.env.HOME = originalHome;
+			process.env.USERPROFILE = originalUserProfile;
+			cleanupTempDir(tempHome);
 		}
 	});
 

--- a/observer/cmd/obstudio/install.go
+++ b/observer/cmd/obstudio/install.go
@@ -31,6 +31,9 @@ const (
 	defaultSharedObserverMCPURL  = defaultSharedObserverBaseURL + "/mcp"
 	defaultSharedObserverHealth  = defaultSharedObserverBaseURL + "/api/health"
 	sharedObserverHealthTimeout  = 750 * time.Millisecond
+
+	sharedObserverStateDirName  = ".obstudio"
+	sharedObserverStateFileName = "shared-observer.json"
 )
 
 type mcpConfigTarget struct {
@@ -53,6 +56,14 @@ type sharedObserverHealth struct {
 	APIVersion string            `json:"apiVersion"`
 	Endpoints  map[string]string `json:"endpoints"`
 	Kind       string            `json:"kind"`
+}
+
+type sharedObserverState struct {
+	BaseURL   string    `json:"baseUrl,omitempty"`
+	HealthURL string    `json:"healthUrl,omitempty"`
+	MCPURL    string    `json:"mcpUrl,omitempty"`
+	PID       int       `json:"pid,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt,omitempty"`
 }
 
 var targets = map[string]agentTarget{
@@ -115,7 +126,7 @@ func runInstall(target, sharedURL string) error {
 	resolvedSharedURL := sharedURL
 	autodetectedSharedURL := false
 	if resolvedSharedURL == "" {
-		if detectedURL, ok := detectSharedObserverURL(defaultSharedObserverHealth, http.DefaultClient); ok {
+		if detectedURL, ok := detectConfiguredSharedObserverURL(http.DefaultClient); ok {
 			resolvedSharedURL = detectedURL
 			autodetectedSharedURL = true
 		}
@@ -204,6 +215,13 @@ func runInstall(target, sharedURL string) error {
 	fmt.Printf("\nDone. Start the shared obstudio server before using %s:\n", target)
 	fmt.Println("  obstudio")
 	return nil
+}
+
+func detectConfiguredSharedObserverURL(client *http.Client) (string, bool) {
+	if detectedURL, ok := detectSharedObserverURLFromStateFile(sharedObserverStatePath(), client); ok {
+		return detectedURL, true
+	}
+	return detectSharedObserverURL(defaultSharedObserverHealth, client)
 }
 
 func ensureInstallWeaverRuntime(exePath, destDir string, requireLocalRuntime bool) (bool, string, error) {
@@ -302,6 +320,69 @@ func detectSharedObserverURL(healthURL string, client *http.Client) (string, boo
 		return mcpURL, true
 	}
 	return defaultSharedObserverMCPURL, true
+}
+
+func detectSharedObserverURLFromStateFile(statePath string, client *http.Client) (string, bool) {
+	state, err := readSharedObserverState(statePath)
+	if err != nil {
+		return "", false
+	}
+
+	healthURL := strings.TrimSpace(state.HealthURL)
+	if healthURL == "" {
+		return "", false
+	}
+	return detectSharedObserverURL(healthURL, client)
+}
+
+func sharedObserverStatePath() string {
+	return filepath.Join(userHome(), sharedObserverStateDirName, sharedObserverStateFileName)
+}
+
+func readSharedObserverState(statePath string) (sharedObserverState, error) {
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		return sharedObserverState{}, err
+	}
+
+	var state sharedObserverState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return sharedObserverState{}, fmt.Errorf("parse shared observer state %q: %w", statePath, err)
+	}
+	return state, nil
+}
+
+func writeSharedObserverState(statePath string, state sharedObserverState) error {
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		return fmt.Errorf("create parent directory for %q: %w", statePath, err)
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal shared observer state %q: %w", statePath, err)
+	}
+	if err := os.WriteFile(statePath, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write shared observer state %q: %w", statePath, err)
+	}
+	return nil
+}
+
+func clearSharedObserverStateIfOwned(statePath string, state sharedObserverState) error {
+	current, err := readSharedObserverState(statePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	if current.PID != state.PID || current.MCPURL != state.MCPURL || current.HealthURL != state.HealthURL {
+		return nil
+	}
+	if err := os.Remove(statePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 func configureMCP(target mcpConfigTarget, binaryPath, sharedURL string) error {

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -642,3 +642,124 @@ func TestReinstallCleansStaleSymlinks(t *testing.T) {
 		t.Fatalf("expected new-skill symlink after reinstall: %v", err)
 	}
 }
+
+func TestDetectSharedObserverURLFromStateFile(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kind":       "obstudio",
+			"apiVersion": "v1",
+			"endpoints": map[string]string{
+				"mcp": server.URL + "/mcp",
+			},
+		})
+	}))
+	defer server.Close()
+
+	statePath := filepath.Join(t.TempDir(), "shared-observer.json")
+	err := writeSharedObserverState(statePath, sharedObserverState{
+		HealthURL: server.URL,
+		MCPURL:    server.URL + "/mcp",
+		PID:       42,
+	})
+	if err != nil {
+		t.Fatalf("writeSharedObserverState returned error: %v", err)
+	}
+
+	detected, ok := detectSharedObserverURLFromStateFile(statePath, server.Client())
+	if !ok {
+		t.Fatal("expected state-file discovery to succeed")
+	}
+	if want := server.URL + "/mcp"; detected != want {
+		t.Fatalf("detectSharedObserverURLFromStateFile = %q, want %q", detected, want)
+	}
+}
+
+func TestClearSharedObserverStateIfOwned(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "shared-observer.json")
+	state := sharedObserverState{
+		BaseURL:   "http://127.0.0.1:41234",
+		HealthURL: "http://127.0.0.1:41234/api/health",
+		MCPURL:    "http://127.0.0.1:41234/mcp",
+		PID:       4242,
+	}
+	if err := writeSharedObserverState(statePath, state); err != nil {
+		t.Fatalf("writeSharedObserverState returned error: %v", err)
+	}
+
+	if err := clearSharedObserverStateIfOwned(statePath, state); err != nil {
+		t.Fatalf("clearSharedObserverStateIfOwned returned error: %v", err)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("expected owned state file to be removed, got err=%v", err)
+	}
+}
+
+func TestClearSharedObserverStateIfOwnedLeavesNewerStateAlone(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "shared-observer.json")
+	owned := sharedObserverState{
+		BaseURL:   "http://127.0.0.1:41234",
+		HealthURL: "http://127.0.0.1:41234/api/health",
+		MCPURL:    "http://127.0.0.1:41234/mcp",
+		PID:       4242,
+	}
+	newer := sharedObserverState{
+		BaseURL:   "http://127.0.0.1:42345",
+		HealthURL: "http://127.0.0.1:42345/api/health",
+		MCPURL:    "http://127.0.0.1:42345/mcp",
+		PID:       5252,
+	}
+	if err := writeSharedObserverState(statePath, newer); err != nil {
+		t.Fatalf("writeSharedObserverState returned error: %v", err)
+	}
+
+	if err := clearSharedObserverStateIfOwned(statePath, owned); err != nil {
+		t.Fatalf("clearSharedObserverStateIfOwned returned error: %v", err)
+	}
+
+	got, err := readSharedObserverState(statePath)
+	if err != nil {
+		t.Fatalf("readSharedObserverState returned error: %v", err)
+	}
+	if got.PID != newer.PID || got.MCPURL != newer.MCPURL {
+		t.Fatalf("shared observer state was unexpectedly removed or replaced: %#v", got)
+	}
+}
+
+func TestValidateRunConfigRejectsOverlappingPorts(t *testing.T) {
+	t.Parallel()
+
+	err := validateRunConfig(runConfig{
+		host:             "127.0.0.1",
+		observerHTTPPort: "4318",
+		otlpHTTPPort:     "4318",
+		otlpGRPCPort:     "4317",
+	})
+	if err == nil {
+		t.Fatal("expected validateRunConfig to reject overlapping listener ports")
+	}
+	if !strings.Contains(err.Error(), "--otlp-http-port cannot use port 4318") {
+		t.Fatalf("unexpected overlap error: %v", err)
+	}
+}
+
+func TestBuildSharedObserverStateNormalizesWildcardHost(t *testing.T) {
+	t.Parallel()
+
+	state := buildSharedObserverState("0.0.0.0", "41234")
+	if state.BaseURL != "http://127.0.0.1:41234" {
+		t.Fatalf("BaseURL = %q, want %q", state.BaseURL, "http://127.0.0.1:41234")
+	}
+	if state.HealthURL != "http://127.0.0.1:41234/api/health" {
+		t.Fatalf("HealthURL = %q, want %q", state.HealthURL, "http://127.0.0.1:41234/api/health")
+	}
+	if state.MCPURL != "http://127.0.0.1:41234/mcp" {
+		t.Fatalf("MCPURL = %q, want %q", state.MCPURL, "http://127.0.0.1:41234/mcp")
+	}
+}

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -39,6 +39,23 @@ func TestCodexTargetUsesConfigTOML(t *testing.T) {
 	}
 }
 
+func TestRootCommandOnlyExposesObserverHTTPPortOverride(t *testing.T) {
+	t.Parallel()
+
+	var config runConfig
+	root := newRootCmd(&config)
+
+	if root.Flags().Lookup("observer-http-port") == nil {
+		t.Fatal("expected --observer-http-port flag to be registered")
+	}
+	if root.Flags().Lookup("otlp-http-port") != nil {
+		t.Fatal("did not expect --otlp-http-port to be exposed")
+	}
+	if root.Flags().Lookup("otlp-grpc-port") != nil {
+		t.Fatal("did not expect --otlp-grpc-port to be exposed")
+	}
+}
+
 func TestCopySiblingWeaverRuntimeCopiesBundledRuntime(t *testing.T) {
 	t.Parallel()
 
@@ -732,7 +749,7 @@ func TestClearSharedObserverStateIfOwnedLeavesNewerStateAlone(t *testing.T) {
 	}
 }
 
-func TestValidateRunConfigRejectsOverlappingPorts(t *testing.T) {
+func TestValidateRunConfigRejectsObserverPortOverlappingFixedListeners(t *testing.T) {
 	t.Parallel()
 
 	err := validateRunConfig(runConfig{

--- a/observer/cmd/obstudio/main.go
+++ b/observer/cmd/obstudio/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -24,17 +25,34 @@ import (
 
 var version = "dev"
 
+type runConfig struct {
+	host             string
+	observerHTTPPort string
+	otlpGRPCPort     string
+	otlpHTTPPort     string
+}
+
 func main() {
+	var config runConfig
 	root := &cobra.Command{
 		Use:     "obstudio",
 		Short:   "Observability Studio -- local OTel collector, MCP server, and skill installer",
 		Version: version,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			run()
+			resolved := resolveRunConfig(config)
+			if err := validateRunConfig(resolved); err != nil {
+				return err
+			}
+			run(resolved)
 			return nil
 		},
 		SilenceUsage: true,
 	}
+
+	root.Flags().StringVar(&config.host, "host", "", "Bind address for the Observer UI, MCP HTTP endpoint, and OTLP receivers")
+	root.Flags().StringVar(&config.observerHTTPPort, "observer-http-port", "", "Observer web UI, REST API, and MCP HTTP port")
+	root.Flags().StringVar(&config.otlpHTTPPort, "otlp-http-port", "", "OTLP/HTTP receiver port")
+	root.Flags().StringVar(&config.otlpGRPCPort, "otlp-grpc-port", "", "OTLP/gRPC receiver port")
 
 	root.AddCommand(newInstallCmd())
 
@@ -43,7 +61,7 @@ func main() {
 	}
 }
 
-func run() {
+func run(config runConfig) {
 	s := store.New()
 	v := validator.NewStore()
 	validatorManager := validator.NewManager(v, s)
@@ -51,10 +69,22 @@ func run() {
 	s.SetChangeCallback(validatorManager.MarkTelemetryChanged)
 	startedAt := time.Now().UTC()
 
-	host := envOr("HOST", "127.0.0.1")
-	port := envOr("PORT", "3000")
-	otlpHTTPPort := envOr("OTLP_HTTP_PORT", envOr("OTLP_PORT", "4318"))
-	otlpGRPCPort := envOr("OTLP_GRPC_PORT", "4317")
+	host := config.host
+	port := config.observerHTTPPort
+	otlpHTTPPort := config.otlpHTTPPort
+	otlpGRPCPort := config.otlpGRPCPort
+
+	observerState := buildSharedObserverState(host, port)
+	observerStatePath := sharedObserverStatePath()
+	if err := writeSharedObserverState(observerStatePath, observerState); err != nil {
+		log.Printf("failed to write shared observer state: %v", err)
+	} else {
+		defer func() {
+			if err := clearSharedObserverStateIfOwned(observerStatePath, observerState); err != nil {
+				log.Printf("failed to clear shared observer state: %v", err)
+			}
+		}()
+	}
 
 	mainAddr := net.JoinHostPort(host, port)
 	otlpHTTPAddr := net.JoinHostPort(host, otlpHTTPPort)
@@ -95,11 +125,7 @@ func run() {
 		}
 	}()
 
-	fmt.Fprintf(os.Stderr, "\nObservability Studio (collector)\n")
-	fmt.Fprintf(os.Stderr, "  Telemetry Explorer:  http://%s\n", mainAddr)
-	fmt.Fprintf(os.Stderr, "  OTLP/HTTP receiver:  http://%s\n", otlpHTTPAddr)
-	fmt.Fprintf(os.Stderr, "  OTLP/gRPC receiver:  %s\n", otlpGRPCAddr)
-	fmt.Fprintf(os.Stderr, "  MCP endpoint:        http://%s/mcp\n\n", mainAddr)
+	fmt.Fprint(os.Stderr, renderStartupBanner(mainAddr, otlpHTTPAddr, otlpGRPCAddr))
 
 	go mcp.RunStdio(s, os.Stdin, os.Stdout, v, validatorManager)
 
@@ -121,4 +147,86 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func resolveRunConfig(config runConfig) runConfig {
+	return runConfig{
+		host:             valueOrEnv(config.host, "HOST", "127.0.0.1"),
+		observerHTTPPort: valueOrEnv(config.observerHTTPPort, "PORT", "3000"),
+		otlpHTTPPort:     valueOrEnv(config.otlpHTTPPort, "OTLP_HTTP_PORT", envOr("OTLP_PORT", "4318")),
+		otlpGRPCPort:     valueOrEnv(config.otlpGRPCPort, "OTLP_GRPC_PORT", "4317"),
+	}
+}
+
+func valueOrEnv(value, envKey, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return envOr(envKey, fallback)
+}
+
+func validateRunConfig(config runConfig) error {
+	ports := []struct {
+		flagName string
+		label    string
+		value    string
+	}{
+		{flagName: "--observer-http-port", label: "Observer UI, REST API, and MCP HTTP", value: config.observerHTTPPort},
+		{flagName: "--otlp-http-port", label: "OTLP/HTTP", value: config.otlpHTTPPort},
+		{flagName: "--otlp-grpc-port", label: "OTLP/gRPC", value: config.otlpGRPCPort},
+	}
+
+	seen := map[int]string{}
+	seenFlags := map[int]string{}
+	for _, port := range ports {
+		parsed, err := strconv.Atoi(port.value)
+		if err != nil || parsed < 1 || parsed > 65_535 {
+			return fmt.Errorf("%s must be a valid TCP port between 1 and 65535, got %q", port.flagName, port.value)
+		}
+		if otherLabel, ok := seen[parsed]; ok {
+			return fmt.Errorf(
+				"%s cannot use port %d; %s already uses that port (%s)",
+				port.flagName,
+				parsed,
+				otherLabel,
+				seenFlags[parsed],
+			)
+		}
+		seen[parsed] = port.label
+		seenFlags[parsed] = port.flagName
+	}
+
+	return nil
+}
+
+func buildSharedObserverState(host, port string) sharedObserverState {
+	connectHost := host
+	switch connectHost {
+	case "", "0.0.0.0", "::", "[::]":
+		connectHost = "127.0.0.1"
+	}
+
+	baseURL := fmt.Sprintf("http://%s", net.JoinHostPort(connectHost, port))
+	return sharedObserverState{
+		BaseURL:   baseURL,
+		HealthURL: baseURL + "/api/health",
+		MCPURL:    baseURL + "/mcp",
+		PID:       os.Getpid(),
+		UpdatedAt: time.Now().UTC(),
+	}
+}
+
+func renderStartupBanner(mainAddr, otlpHTTPAddr, otlpGRPCAddr string) string {
+	return fmt.Sprintf(
+		"\nObservability Studio (collector)\n"+
+			"  Telemetry Explorer:  http://%s\n"+
+			"  OTLP/HTTP receiver:  http://%s\n"+
+			"  OTLP/gRPC receiver:  %s\n"+
+			"  MCP endpoint:        http://%s/mcp\n"+
+			"  Agent setup:         obstudio install --target=<agent>\n\n",
+		mainAddr,
+		otlpHTTPAddr,
+		otlpGRPCAddr,
+		mainAddr,
+	)
 }

--- a/observer/cmd/obstudio/main.go
+++ b/observer/cmd/obstudio/main.go
@@ -34,12 +34,20 @@ type runConfig struct {
 
 func main() {
 	var config runConfig
+	root := newRootCmd(&config)
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd(config *runConfig) *cobra.Command {
 	root := &cobra.Command{
 		Use:     "obstudio",
 		Short:   "Observability Studio -- local OTel collector, MCP server, and skill installer",
 		Version: version,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			resolved := resolveRunConfig(config)
+			resolved := resolveRunConfig(*config)
 			if err := validateRunConfig(resolved); err != nil {
 				return err
 			}
@@ -51,14 +59,9 @@ func main() {
 
 	root.Flags().StringVar(&config.host, "host", "", "Bind address for the Observer UI, MCP HTTP endpoint, and OTLP receivers")
 	root.Flags().StringVar(&config.observerHTTPPort, "observer-http-port", "", "Observer web UI, REST API, and MCP HTTP port")
-	root.Flags().StringVar(&config.otlpHTTPPort, "otlp-http-port", "", "OTLP/HTTP receiver port")
-	root.Flags().StringVar(&config.otlpGRPCPort, "otlp-grpc-port", "", "OTLP/gRPC receiver port")
 
 	root.AddCommand(newInstallCmd())
-
-	if err := root.Execute(); err != nil {
-		os.Exit(1)
-	}
+	return root
 }
 
 func run(config runConfig) {

--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -1,6 +1,5 @@
 ---
-
-## name: otel-audit
+name: otel-audit
 description: >-
   Scan a codebase for existing OpenTelemetry instrumentation and report
   on observability coverage gaps. Read-only -- does not modify code.
@@ -13,6 +12,7 @@ metadata:
   author: otel-studio
   version: 0.6.0
   category: observability
+---
 
 # Audit -- Observability Coverage Scan
 


### PR DESCRIPTION
## Summary

This PR fixes the agent onboarding gap where installing the VS Code extension did not make the bundled observability skills available in Codex, Claude Code, or Cursor without extra manual setup.

It keeps the latest `main` skill packaging model:
- bundled files live under `~/.<agent>/skills/obstudio/`
- top-level discoverable skill entries (`otel-audit`, `otel-instrument`) are created for agent discovery

It also aligns standalone `obstudio` and the VS Code extension around one user-configurable local Observer endpoint override:
- standalone: `obstudio --observer-http-port <port>`
- VS Code extension: `observability-studio.managedObserverPort`

OTLP receiver ports remain fixed at `4318` and `4317`.

## What Changed

### VS Code extension
- Detects local Codex, Claude Code, and Cursor installs on activation
- Shows a one-time `Enable ... Integration` prompt instead of silently rewriting external configs
- Installs bundled skills and configures MCP to the current shared Observer endpoint when the user accepts
- Adds `observability-studio.sharedObserverUrl`
- Adds `observability-studio.managedObserverPort`
- Re-prompts for integration when the configured Observer endpoint changes
- Rejects managed Observer ports that collide with the fixed OTLP listener ports

### Standalone `obstudio`
- Adds explicit `--observer-http-port`
- Validates that the Observer HTTP port does not overlap the fixed OTLP listener ports
- Persists the active shared Observer endpoint so `obstudio install --target=<agent>` can reuse a running nondefault shared server
- Cleans up shared endpoint state safely on shutdown

### Installer / skills
- Keeps latest `main` install layout under `skills/obstudio`
- Creates top-level discoverable skill entries for agent loading
- Preserves existing MCP config and only updates the `obstudio` entry
- Avoids duplicate `obstudio` MCP entries on repeated enable/re-enable flows
- Fixes `skills/otel-audit/SKILL.md` frontmatter so the bundled skill loads correctly

### Docs
- Updates user and extension docs for:
  - actual install paths
  - Claude config path (`~/.claude.json`)
  - Observer HTTP port override behavior
  - one-time integration prompt behavior
  - shared Observer reuse

## Agent Plan

1. Keep the latest `main` skill packaging and discovery model intact.
2. Make extension install lead directly to usable agent integrations through a consented prompt.
3. Support explicit local/shared Observer endpoint overrides without breaking MCP consumers.
4. Add regression coverage for MCP updates, port validation, shared endpoint discovery, and prompt behavior.

## Testing

Automated:
- `go test -cover ./cmd/obstudio`
- `npm run test:host`

Manual:
- Verified fresh skill loading for Codex and Claude Code
- Verified Cursor skill loading with authenticated local CLI
- Verified standalone shared-server reuse on a nondefault `--observer-http-port`
- Verified repeated integration enablement preserves sibling MCP servers and does not duplicate `obstudio` entries
- Verified the VS Code extension accepts `observability-studio.managedObserverPort` as the equivalent Observer HTTP port override
fixes #87 
