### PR TITLE
Fix log and validation detail accessibility

### DIFF
--- a/observer/client/src/AppView.test.tsx
+++ b/observer/client/src/AppView.test.tsx
@@ -178,12 +178,16 @@ describe("AppView validation tab", () => {
 
     expect(metricsTab.textContent).toContain("Metrics");
     expect(metricsTab.querySelector(".tab-button__count")?.textContent).toBe("3");
+    expect(metricsTab.getAttribute("aria-label")).toBe("Metrics, 3 metric names");
     expect(tracesTab.textContent).toContain("Traces");
     expect(tracesTab.querySelector(".tab-button__count")?.textContent).toBe("2");
+    expect(tracesTab.getAttribute("aria-label")).toBe("Traces, 2 traces");
     expect(logsTab.textContent).toContain("Logs");
     expect(logsTab.querySelector(".tab-button__count")?.textContent).toBe("5");
+    expect(logsTab.getAttribute("aria-label")).toBe("Logs, 5 logs");
     expect(validationTab.textContent).toContain("Validation");
     expect(validationTab.querySelector(".tab-button__count")?.textContent).toBe("1");
+    expect(validationTab.getAttribute("aria-label")).toBe("Validation, 1 issue");
     expect(container.querySelector(".tab-button__glyph")).toBeNull();
   });
 

--- a/observer/client/src/AppView.tsx
+++ b/observer/client/src/AppView.tsx
@@ -129,41 +129,45 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             type="button"
             role="tab"
             aria-selected={activeTab === "metrics"}
+            aria-label={formatTabAriaLabel("Metrics", state.stats?.metricNameCount, "metric name", "metric names")}
             className={activeTab === "metrics" ? "tab-button is-active" : "tab-button"}
             onClick={() => switchTab("metrics")}
           >
             Metrics
-            {state.stats?.metricNameCount ? <span className="tab-button__count">{state.stats.metricNameCount}</span> : null}
+            {state.stats?.metricNameCount ? <span className="tab-button__count" aria-hidden="true">{state.stats.metricNameCount}</span> : null}
           </button>
           <button
             type="button"
             role="tab"
             aria-selected={activeTab === "traces"}
+            aria-label={formatTabAriaLabel("Traces", state.stats?.traceCount, "trace", "traces")}
             className={activeTab === "traces" ? "tab-button is-active" : "tab-button"}
             onClick={() => switchTab("traces")}
           >
             Traces
-            {state.stats?.traceCount ? <span className="tab-button__count">{state.stats.traceCount}</span> : null}
+            {state.stats?.traceCount ? <span className="tab-button__count" aria-hidden="true">{state.stats.traceCount}</span> : null}
           </button>
           <button
             type="button"
             role="tab"
             aria-selected={activeTab === "logs"}
+            aria-label={formatTabAriaLabel("Logs", state.stats?.logCount, "log", "logs")}
             className={activeTab === "logs" ? "tab-button is-active" : "tab-button"}
             onClick={() => switchTab("logs")}
           >
             Logs
-            {state.stats?.logCount ? <span className="tab-button__count">{state.stats.logCount}</span> : null}
+            {state.stats?.logCount ? <span className="tab-button__count" aria-hidden="true">{state.stats.logCount}</span> : null}
           </button>
           <button
             type="button"
             role="tab"
             aria-selected={activeTab === "validation"}
+            aria-label={formatTabAriaLabel("Validation", validationIssues.length, "issue", "issues")}
             className={activeTab === "validation" ? "tab-button is-active" : "tab-button"}
             onClick={() => switchTab("validation")}
           >
             Validation
-            {validationIssues.length > 0 ? <span className="tab-button__count tab-button__count--warn">{validationIssues.length}</span> : null}
+            {validationIssues.length > 0 ? <span className="tab-button__count tab-button__count--warn" aria-hidden="true">{validationIssues.length}</span> : null}
           </button>
         </div>
 
@@ -212,4 +216,11 @@ function initialTabFromLocation(): AppTab {
     default:
       return "metrics";
   }
+}
+
+function formatTabAriaLabel(label: string, count: number | undefined, singular: string, plural: string): string {
+  if (!count || count <= 0) {
+    return label;
+  }
+  return `${label}, ${count} ${count === 1 ? singular : plural}`;
 }

--- a/observer/client/src/components/FindingsTab.test.tsx
+++ b/observer/client/src/components/FindingsTab.test.tsx
@@ -106,6 +106,8 @@ describe("FindingsTab", () => {
     // Signal tabs show issue counts
     expect(metricsTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("1");
     expect(spansTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("1");
+    expect(metricsTab.getAttribute("aria-label")).toBe("Metrics, 1 issue");
+    expect(spansTab.getAttribute("aria-label")).toBe("Spans, 1 issue");
 
     const head = view.container.querySelector(".findings-tab__head");
     expect(head).toBeTruthy();
@@ -122,6 +124,7 @@ describe("FindingsTab", () => {
     expect(within(rowButton as HTMLElement).getByText("unit_mismatch +2 more")).toBeTruthy();
     const counts = Array.from((rowButton as HTMLElement).querySelectorAll(".findings-tab__item-count")).map((node) => node.textContent?.trim());
     expect(counts).toEqual(["1", "1", "1"]);
+    expect((rowButton as HTMLElement).getAttribute("aria-label")).toBe("http.server.duration, unit_mismatch +2 more, 1 violation, 1 improvement, 1 information finding");
     expect((rowButton as HTMLElement).querySelector(".findings-tab__item-title")?.classList.contains("explorer-row__primary")).toBe(true);
     expect((rowButton as HTMLElement).querySelector(".findings-tab__item-rule")?.classList.contains("explorer-row__secondary")).toBe(true);
     expect((rowButton as HTMLElement).querySelector(".findings-tab__item-rule")?.classList.contains("mono")).toBe(false);
@@ -255,14 +258,20 @@ describe("FindingsTab", () => {
     const metricsTab = within(tablist).getByRole("tab", { name: /^Metrics/ });
     const spansTab = within(tablist).getByRole("tab", { name: /^Spans/ });
 
-    expect(metricsTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("0");
+    expect(metricsTab.querySelector(".findings-tab__signal-count")).toBeNull();
+    expect(metricsTab.getAttribute("aria-label")).toBe("Metrics");
     expect(spansTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("1");
+    expect(spansTab.getAttribute("aria-label")).toBe("Spans, 1 issue");
     expect(spansTab.getAttribute("aria-selected")).toBe("true");
     expect(view.queryByText("No metrics validation issues match the current filters.")).toBeNull();
 
     const master = view.container.querySelector(".findings-tab__master");
     expect(master?.classList.contains("findings-tab__master--span")).toBe(true);
-    expect(within(master as HTMLElement).getByText("POST /orders")).toBeTruthy();
+    const rowButton = within(master as HTMLElement).getByText("POST /orders").closest("button");
+    expect(rowButton).toBeTruthy();
+    const rowCounts = Array.from((rowButton as HTMLElement).querySelectorAll(".findings-tab__item-count")).map((node) => node.textContent?.trim());
+    expect(rowCounts).toEqual(["", "", "1"]);
+    expect((rowButton as HTMLElement).getAttribute("aria-label")).toBe("POST /orders, missing_http_method, 1 information finding");
   });
 
   it("auto-selects the first non-empty tab when results arrive before any explicit tab choice", () => {
@@ -320,7 +329,8 @@ describe("FindingsTab", () => {
     const tablist = view.getByRole("tablist", { name: "Validation signals" });
     const resourcesTab = within(tablist).getByRole("tab", { name: /^Resources/ });
 
-    expect(resourcesTab.querySelector(".findings-tab__signal-count")?.textContent).toBe("0");
+    expect(resourcesTab.querySelector(".findings-tab__signal-count")).toBeNull();
+    expect(resourcesTab.getAttribute("aria-label")).toBe("Resources");
 
     fireEvent.click(resourcesTab);
 

--- a/observer/client/src/components/FindingsTab.tsx
+++ b/observer/client/src/components/FindingsTab.tsx
@@ -179,6 +179,7 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
                 role="tab"
                 className={tab.key === activeSignalTab ? "findings-tab__signal-tab is-active" : "findings-tab__signal-tab"}
                 aria-selected={tab.key === activeSignalTab}
+                aria-label={formatSignalTabAriaLabel(tab.label, count)}
                 data-has-issues={count > 0 ? "true" : "false"}
                 onClick={() => {
                   setHasExplicitSignalTabSelection(true);
@@ -186,7 +187,7 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
                 }}
               >
                 {tab.label}
-                <span className="findings-tab__signal-count">{count}</span>
+                {count > 0 ? <span className="findings-tab__signal-count" aria-hidden="true">{count}</span> : null}
               </button>
             );
           })}
@@ -247,14 +248,14 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
                             onClick={() => setSelectedKey(issue.key)}
                             aria-pressed={isSelected}
                             aria-controls="validation-issue-detail"
-                            aria-label={`${row.issue} ${row.rule} ${totals.violation} violations ${totals.improvement} improvements ${totals.information} information`}
+                            aria-label={formatIssueRowAriaLabel(row.issue, row.rule, totals)}
                           >
                             <div className="findings-tab__item-grid">
                               <span className="findings-tab__item-title explorer-row__primary">{row.issue}</span>
                               <span className="findings-tab__item-rule explorer-row__secondary">{row.rule}</span>
-                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.violation === 0 ? "is-zero" : ""}`}>{totals.violation}</span>
-                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.improvement === 0 ? "is-zero" : ""}`}>{totals.improvement}</span>
-                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.information === 0 ? "is-zero" : ""}`}>{totals.information}</span>
+                              <span className="findings-tab__item-count explorer-row__numeric" aria-hidden="true">{formatIssueCountCell(totals.violation)}</span>
+                              <span className="findings-tab__item-count explorer-row__numeric" aria-hidden="true">{formatIssueCountCell(totals.improvement)}</span>
+                              <span className="findings-tab__item-count explorer-row__numeric" aria-hidden="true">{formatIssueCountCell(totals.information)}</span>
                             </div>
                           </button>
                         </article>
@@ -391,6 +392,27 @@ function issueSeverityTotals(issue: ValidationIssue, variants: IssueVariant[]): 
     improvement: issue.improvementCount || fallbackCounts.improvement,
     information: issue.informationCount || fallbackCounts.information,
   };
+}
+
+function formatSignalTabAriaLabel(label: string, count: number): string {
+  if (count <= 0) {
+    return label;
+  }
+  return `${label}, ${count} ${count === 1 ? "issue" : "issues"}`;
+}
+
+function formatIssueCountCell(count: number): string {
+  return count > 0 ? String(count) : "";
+}
+
+function formatIssueRowAriaLabel(issue: string, rule: string, totals: SeverityTotals): string {
+  const countSummary = [
+    totals.violation > 0 ? `${totals.violation} ${totals.violation === 1 ? "violation" : "violations"}` : null,
+    totals.improvement > 0 ? `${totals.improvement} ${totals.improvement === 1 ? "improvement" : "improvements"}` : null,
+    totals.information > 0 ? `${totals.information} ${totals.information === 1 ? "information finding" : "information findings"}` : null,
+  ].filter(Boolean).join(", ");
+
+  return [issue, rule === "—" ? null : rule, countSummary || null].filter(Boolean).join(", ");
 }
 
 function sampleLogBodies(findings: ValidationFinding[]): string[] {

--- a/observer/client/src/logs/LogsTab.test.tsx
+++ b/observer/client/src/logs/LogsTab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LogsTab } from "./LogsTab";
 
@@ -254,5 +254,73 @@ describe("LogsTab", () => {
     expect(screen.queryByText("Validation")).toBeNull();
     expect(screen.getByRole("button", { name: "Close panel" })).toBeTruthy();
     expect(screen.getByLabelText("Filter field")).toBeTruthy();
+  });
+
+  it("renders semantic log detail lists and omits duplicate service resource attributes", () => {
+    const { container } = render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityText: "INFO",
+            body: "checkout started",
+            attributes: {
+              "demo.iteration": 8679,
+            },
+            resource: {
+              serviceName: "checkout",
+              attributes: {
+                "service.name": "checkout",
+                "deployment.environment.name": "prod",
+              },
+            },
+            scope: { name: "demo.logger", version: "1.2.3" },
+            traceId: "trace-1",
+            spanId: "span-1",
+          },
+        ]}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(container.querySelector(".data-table__row--logs") as HTMLElement);
+
+    const detailPanel = container.querySelector(".detail-panel__body") as HTMLElement;
+
+    expect(within(detailPanel).getByText("Service")).toBeTruthy();
+    expect(within(detailPanel).queryByText("service.name")).toBeNull();
+    expect(within(detailPanel).getByText("deployment.environment.name")).toBeTruthy();
+    expect(within(detailPanel).getByText("prod")).toBeTruthy();
+    expect(within(detailPanel).getByText("Version")).toBeTruthy();
+    expect(within(detailPanel).getByText("1.2.3")).toBeTruthy();
+    expect(container.querySelectorAll("dl").length).toBeGreaterThan(0);
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  it("keeps the detail panel stable when resource data is missing", () => {
+    const { container } = render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityText: "INFO",
+            body: "checkout started",
+            attributes: {},
+            resource: undefined as any,
+            scope: { name: "demo.logger" },
+          },
+        ]}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(container.querySelector(".data-table__row--logs") as HTMLElement);
+
+    const detailPanel = container.querySelector(".detail-panel__body") as HTMLElement;
+
+    expect(within(detailPanel).queryByText("Resource")).toBeNull();
+    expect(within(detailPanel).getByText("No attributes")).toBeTruthy();
   });
 });

--- a/observer/client/src/logs/LogsTab.tsx
+++ b/observer/client/src/logs/LogsTab.tsx
@@ -11,6 +11,14 @@ interface LogsTabProps {
 }
 
 type DetailTab = "overview" | "json";
+interface LogDetailItem {
+  key: string;
+  label: string;
+  value: React.ReactNode;
+  copyText?: string;
+  monospace?: boolean;
+}
+
 const LOG_FILTER_DEFINITIONS: FilterDefinition[] = [
   { key: "serviceName", label: "Service", kind: "text", placeholder: "payments" },
   {
@@ -283,75 +291,67 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
                   {selectedLog.traceId ? (
                     <div className="log-detail__section">
                       <h4 className="log-detail__heading">Trace Correlation</h4>
-                      <div className="span-details__detail-row">
-                        <span className="span-details__detail-label">Trace ID</span>
-                        <span className="span-details__detail-value">
-                          <span title={selectedLog.traceId}>{selectedLog.traceId}</span>
-                          <CopyTextButton text={selectedLog.traceId} label="Trace ID" />
-                        </span>
-                      </div>
-                      {selectedLog.spanId ? (
-                        <div className="span-details__detail-row">
-                          <span className="span-details__detail-label">Span ID</span>
-                          <span className="span-details__detail-value">
-                            <span title={selectedLog.spanId}>{selectedLog.spanId}</span>
-                            <CopyTextButton text={selectedLog.spanId} label="Span ID" />
-                          </span>
-                        </div>
-                      ) : null}
+                      <LogDetailList
+                        items={[
+                          {
+                            key: "trace-id",
+                            label: "Trace ID",
+                            value: <span title={selectedLog.traceId}>{selectedLog.traceId}</span>,
+                            copyText: selectedLog.traceId,
+                            monospace: true,
+                          },
+                          ...(selectedLog.spanId ? [{
+                            key: "span-id",
+                            label: "Span ID",
+                            value: <span title={selectedLog.spanId}>{selectedLog.spanId}</span>,
+                            copyText: selectedLog.spanId,
+                            monospace: true,
+                          }] : []),
+                        ]}
+                      />
                     </div>
                   ) : null}
 
-                  {selectedLog.resource ? (
+                  {selectedLog.resource?.serviceName || resourceAttributeEntries(selectedLog.resource).length > 0 ? (
                     <div className="log-detail__section">
                       <h4 className="log-detail__heading">Resource</h4>
-                      {selectedLog.resource.serviceName ? (
-                        <div className="span-details__detail-row">
-                          <span className="span-details__detail-label">Service</span>
-                          <span className="span-details__detail-value">{selectedLog.resource.serviceName}</span>
-                        </div>
-                      ) : null}
-                      {Object.keys(selectedLog.resource?.attributes ?? {}).length > 0 ? (
-                        <table className="log-detail__attrs">
-                          <tbody>
-                            {Object.entries(selectedLog.resource?.attributes ?? {}).map(([k, v]) => (
-                              <tr key={k}>
-                                <td className="log-detail__attr-key">{k}</td>
-                                <td className="log-detail__attr-val">{String(v)}</td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      ) : null}
+                      <LogDetailList
+                        items={selectedLog.resource?.serviceName ? [{
+                          key: "service",
+                          label: "Service",
+                          value: selectedLog.resource.serviceName,
+                        }] : []}
+                      />
+                      <LogAttributeList entries={resourceAttributeEntries(selectedLog.resource)} />
                     </div>
                   ) : null}
 
                   {selectedLog.scope?.name ? (
                     <div className="log-detail__section">
                       <h4 className="log-detail__heading">Scope</h4>
-                      <div className="span-details__detail-row">
-                        <span className="span-details__detail-label">Name</span>
-                        <span className="span-details__detail-value">
-                          {selectedLog.scope.name}
-                          {selectedLog.scope.version ? ` v${selectedLog.scope.version}` : ""}
-                        </span>
-                      </div>
+                      <LogDetailList
+                        items={[
+                          {
+                            key: "scope-name",
+                            label: "Name",
+                            value: selectedLog.scope.name,
+                            monospace: true,
+                          },
+                          ...(selectedLog.scope.version ? [{
+                            key: "scope-version",
+                            label: "Version",
+                            value: selectedLog.scope.version,
+                            monospace: true,
+                          }] : []),
+                        ]}
+                      />
                     </div>
                   ) : null}
 
                   <div className="log-detail__section">
                     <h4 className="log-detail__heading">Attributes</h4>
                     {Object.keys(selectedLog.attributes ?? {}).length > 0 ? (
-                      <table className="log-detail__attrs">
-                        <tbody>
-                          {Object.entries(selectedLog.attributes ?? {}).map(([k, v]) => (
-                            <tr key={k}>
-                              <td className="log-detail__attr-key">{k}</td>
-                              <td className="log-detail__attr-val">{String(v)}</td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
+                      <LogAttributeList entries={attributeEntries(selectedLog.attributes)} />
                     ) : (
                       <p className="log-detail__empty">No attributes</p>
                     )}
@@ -377,4 +377,55 @@ function formatTimestamp(ts: string): string {
   const d = new Date(ts);
   if (isNaN(d.getTime())) return "--";
   return d.toISOString().slice(11, 23);
+}
+
+function LogDetailList({ items }: { items: LogDetailItem[] }): React.ReactElement | null {
+  if (items.length === 0) return null;
+  return (
+    <dl className="log-detail__detail-list">
+      {items.map((item) => (
+        <div key={item.key} className="log-detail__detail-row">
+          <dt>{item.label}</dt>
+          <dd className={item.monospace ? "log-detail__detail-value log-detail__detail-value--mono" : "log-detail__detail-value"}>
+            {item.value}
+            {item.copyText ? <CopyTextButton text={item.copyText} label={item.label} /> : null}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function LogAttributeList({ entries }: { entries: Array<[string, string]> }): React.ReactElement | null {
+  if (entries.length === 0) return null;
+  return (
+    <dl className="log-detail__attrs">
+      {entries.map(([key, value]) => (
+        <div key={key} className="log-detail__attr-row">
+          <dt className="log-detail__attr-key">{key}</dt>
+          <dd className="log-detail__attr-val">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function resourceAttributeEntries(resource: LogRecord["resource"] | null | undefined): Array<[string, string]> {
+  return attributeEntries(resource?.attributes).filter(([key]) => !(key === "service.name" && resource?.serviceName));
+}
+
+function attributeEntries(attributes: Record<string, unknown> | null | undefined): Array<[string, string]> {
+  return Object.entries(attributes ?? {}).map(([key, value]) => [key, formatDetailValue(value)]);
+}
+
+function formatDetailValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || value === null || value === undefined) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -3315,30 +3315,67 @@ code {
   line-height: 1.5;
 }
 
+.log-detail__detail-list,
 .log-detail__attrs {
+  margin: 0;
   width: 100%;
-  border-collapse: collapse;
-  font-size: var(--font-meta);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.log-detail__attrs td {
-  padding: 3px 0;
-  vertical-align: top;
+.log-detail__detail-row,
+.log-detail__attr-row {
+  display: grid;
+  grid-template-columns: 128px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.log-detail__detail-row dt,
+.log-detail__attr-key {
+  margin: 0;
+  font-size: var(--font-label);
+  line-height: 1.35;
+}
+
+.log-detail__detail-row dt {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.log-detail__detail-value,
+.log-detail__attr-val {
+  margin: 0;
+  min-width: 0;
+  font-size: var(--font-meta);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.log-detail__detail-value {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
+}
+
+.log-detail__detail-value--mono {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-mono);
+  word-break: break-all;
 }
 
 .log-detail__attr-key {
   font-family: var(--font-family-mono);
-  font-size: var(--font-meta);
   color: #9cdcfe;
-  padding-right: 12px;
-  white-space: nowrap;
 }
 
 .log-detail__attr-val {
   font-family: var(--font-family-mono);
-  font-size: var(--font-meta);
   color: var(--orange);
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .log-detail__empty {
@@ -5430,6 +5467,8 @@ code {
 }
 
 .findings-tab__signal-tab {
+  display: inline-flex;
+  align-items: center;
   padding: 6px 10px;
   border: 1px solid var(--border-soft);
   border-radius: 999px;
@@ -5441,6 +5480,22 @@ code {
   white-space: nowrap;
 }
 
+.findings-tab__signal-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  margin-left: 6px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-soft);
+  font-size: var(--font-label);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
 .findings-tab__signal-tab[data-has-issues="false"] {
   opacity: 0.68;
 }
@@ -5449,6 +5504,11 @@ code {
   border-color: rgba(0, 122, 204, 0.3);
   background: rgba(0, 122, 204, 0.12);
   color: var(--text);
+}
+
+.findings-tab__signal-tab.is-active .findings-tab__signal-count {
+  background: rgba(0, 122, 204, 0.18);
+  color: var(--blue);
 }
 
 .findings-tab__detail-grid {


### PR DESCRIPTION
## Summary
- render log detail metadata as semantic key/value lists so labels and values stay adjacent and duplicate `service.name` is suppressed when the service row is already shown
- hide zero-value validation counts and add accessible labels for the observer and validation tabs
- cover the updated log detail and validation behaviors with focused client tests

## Testing
- `npm run typecheck`
- `npm test`
- `make build`