### PR TITLE
Fix dev-tag release packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 **/dist/
 build/
+.release/
 
 __pycache__/
 **/__pycache__/

--- a/extension/build-vsix.js
+++ b/extension/build-vsix.js
@@ -3,6 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const MARKETPLACE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const DEV_TAG_VERSION_PATTERN = /^((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))-dev$/;
 
 function normalizeReleaseVersion(rawVersion) {
 	const trimmed = String(rawVersion ?? "").trim();
@@ -14,9 +15,13 @@ function normalizeReleaseVersion(rawVersion) {
 		? trimmed.slice("refs/tags/".length)
 		: trimmed;
 	const normalized = withoutRefPrefix.replace(/^v/i, "");
+	const devTagMatch = normalized.match(DEV_TAG_VERSION_PATTERN);
+	if (devTagMatch) {
+		return devTagMatch[1];
+	}
 	if (!MARKETPLACE_VERSION_PATTERN.test(normalized)) {
 		throw new Error(
-			`Release version "${trimmed}" must be a stable major.minor.patch version for VS Code Marketplace`
+			`Release version "${trimmed}" must resolve to a stable major.minor.patch version for VS Code Marketplace packaging`
 		);
 	}
 

--- a/extension/build-vsix.js
+++ b/extension/build-vsix.js
@@ -3,7 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const MARKETPLACE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
-const DEV_TAG_VERSION_PATTERN = /^((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))-dev$/;
+const SUFFIXED_TAG_VERSION_PATTERN = /^((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))(?:$|[^\d].*)/;
 
 function normalizeReleaseVersion(rawVersion) {
 	const trimmed = String(rawVersion ?? "").trim();
@@ -15,9 +15,9 @@ function normalizeReleaseVersion(rawVersion) {
 		? trimmed.slice("refs/tags/".length)
 		: trimmed;
 	const normalized = withoutRefPrefix.replace(/^v/i, "");
-	const devTagMatch = normalized.match(DEV_TAG_VERSION_PATTERN);
-	if (devTagMatch) {
-		return devTagMatch[1];
+	const suffixedTagMatch = normalized.match(SUFFIXED_TAG_VERSION_PATTERN);
+	if (suffixedTagMatch) {
+		return suffixedTagMatch[1];
 	}
 	if (!MARKETPLACE_VERSION_PATTERN.test(normalized)) {
 		throw new Error(

--- a/extension/src/test/build-vsix.test.ts
+++ b/extension/src/test/build-vsix.test.ts
@@ -17,9 +17,11 @@ const {
 	}) => string | null;
 };
 
-test('normalizeReleaseVersion strips tag prefixes', () => {
+test('normalizeReleaseVersion strips tag prefixes and dev suffixes', () => {
 	assert.equal(normalizeReleaseVersion('v1.2.3'), '1.2.3');
 	assert.equal(normalizeReleaseVersion('refs/tags/v2.3.4'), '2.3.4');
+	assert.equal(normalizeReleaseVersion('v3.4.5-dev'), '3.4.5');
+	assert.equal(normalizeReleaseVersion('refs/tags/v4.5.6-dev'), '4.5.6');
 });
 
 test('normalizeReleaseVersion rejects invalid values', () => {
@@ -57,10 +59,29 @@ test('resolveReleaseVersion uses GitHub tag metadata when available', () => {
 	}), '4.5.6');
 });
 
+test('resolveReleaseVersion normalizes repo prerelease tags from GitHub metadata', () => {
+	assert.equal(resolveReleaseVersion({
+		env: {
+			GITHUB_REF_TYPE: 'tag',
+			GITHUB_REF_NAME: 'v4.5.6-dev',
+		},
+		getExactTag: () => {
+			throw new Error('git fallback should not be called');
+		},
+	}), '4.5.6');
+});
+
 test('resolveReleaseVersion falls back to the exact git tag', () => {
 	assert.equal(resolveReleaseVersion({
 		env: {},
 		getExactTag: () => 'v5.6.7',
+	}), '5.6.7');
+});
+
+test('resolveReleaseVersion normalizes repo prerelease tags from the exact git tag', () => {
+	assert.equal(resolveReleaseVersion({
+		env: {},
+		getExactTag: () => 'v5.6.7-dev',
 	}), '5.6.7');
 });
 

--- a/extension/src/test/build-vsix.test.ts
+++ b/extension/src/test/build-vsix.test.ts
@@ -17,11 +17,14 @@ const {
 	}) => string | null;
 };
 
-test('normalizeReleaseVersion strips tag prefixes and dev suffixes', () => {
+test('normalizeReleaseVersion strips tag prefixes and extracts the stable core from suffixed tags', () => {
 	assert.equal(normalizeReleaseVersion('v1.2.3'), '1.2.3');
 	assert.equal(normalizeReleaseVersion('refs/tags/v2.3.4'), '2.3.4');
 	assert.equal(normalizeReleaseVersion('v3.4.5-dev'), '3.4.5');
 	assert.equal(normalizeReleaseVersion('refs/tags/v4.5.6-dev'), '4.5.6');
+	assert.equal(normalizeReleaseVersion('v5.6.7-test'), '5.6.7');
+	assert.equal(normalizeReleaseVersion('v6.7.8_tagverify'), '6.7.8');
+	assert.equal(normalizeReleaseVersion('v7.8.9+build.1'), '7.8.9');
 });
 
 test('normalizeReleaseVersion rejects invalid values', () => {
@@ -30,11 +33,11 @@ test('normalizeReleaseVersion rejects invalid values', () => {
 		/stable major\.minor\.patch version/
 	);
 	assert.throws(
-		() => normalizeReleaseVersion('v1.2.3-rc.1'),
+		() => normalizeReleaseVersion('v1.2'),
 		/stable major\.minor\.patch version/
 	);
 	assert.throws(
-		() => normalizeReleaseVersion('v1.2.3-tagverify'),
+		() => normalizeReleaseVersion('vx.y.z'),
 		/stable major\.minor\.patch version/
 	);
 });
@@ -59,11 +62,11 @@ test('resolveReleaseVersion uses GitHub tag metadata when available', () => {
 	}), '4.5.6');
 });
 
-test('resolveReleaseVersion normalizes repo prerelease tags from GitHub metadata', () => {
+test('resolveReleaseVersion normalizes suffixed release tags from GitHub metadata', () => {
 	assert.equal(resolveReleaseVersion({
 		env: {
 			GITHUB_REF_TYPE: 'tag',
-			GITHUB_REF_NAME: 'v4.5.6-dev',
+			GITHUB_REF_NAME: 'v4.5.6-test',
 		},
 		getExactTag: () => {
 			throw new Error('git fallback should not be called');
@@ -78,10 +81,10 @@ test('resolveReleaseVersion falls back to the exact git tag', () => {
 	}), '5.6.7');
 });
 
-test('resolveReleaseVersion normalizes repo prerelease tags from the exact git tag', () => {
+test('resolveReleaseVersion normalizes suffixed release tags from the exact git tag', () => {
 	assert.equal(resolveReleaseVersion({
 		env: {},
-		getExactTag: () => 'v5.6.7-dev',
+		getExactTag: () => 'v5.6.7-preview',
 	}), '5.6.7');
 });
 

--- a/extension/src/test/extension-integration.test.ts
+++ b/extension/src/test/extension-integration.test.ts
@@ -142,6 +142,28 @@ it('integration: VSIX manifest version can be derived from release metadata', { 
 	}
 });
 
+it('integration: VSIX manifest version normalizes repo dev release tags', { timeout: 120_000 }, async () => {
+	const context: TestContext = {};
+
+	try {
+		const vsixFile = buildVsix({
+			...process.env,
+			OBSTUDIO_EXTENSION_VERSION: 'v0.0.6-dev',
+		});
+		context.vsixFile = vsixFile;
+
+		const packagedManifest = execSync(
+			`unzip -p "${vsixFile}" extension/package.json`,
+			{ stdio: 'pipe', encoding: 'utf-8' },
+		);
+		const packagedPackageJson = JSON.parse(packagedManifest) as { version: string };
+
+		assert.equal(packagedPackageJson.version, '0.0.6');
+	} finally {
+		cleanup(context);
+	}
+});
+
 it('integration: VSIX contains observer binary', { timeout: 120_000 }, async () => {
 	const context: TestContext = {};
 

--- a/extension/src/test/extension-integration.test.ts
+++ b/extension/src/test/extension-integration.test.ts
@@ -142,13 +142,13 @@ it('integration: VSIX manifest version can be derived from release metadata', { 
 	}
 });
 
-it('integration: VSIX manifest version normalizes repo dev release tags', { timeout: 120_000 }, async () => {
+it('integration: VSIX manifest version normalizes suffixed release tags', { timeout: 120_000 }, async () => {
 	const context: TestContext = {};
 
 	try {
 		const vsixFile = buildVsix({
 			...process.env,
-			OBSTUDIO_EXTENSION_VERSION: 'v0.0.6-dev',
+			OBSTUDIO_EXTENSION_VERSION: 'v0.0.6-test',
 		});
 		context.vsixFile = vsixFile;
 

--- a/observer/cmd/fetch-weaver/main_test.go
+++ b/observer/cmd/fetch-weaver/main_test.go
@@ -207,6 +207,20 @@ func TestReleaseArchivesWrapContentsInDirectory(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkspaceIsGitIgnored(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, ".release/") {
+		t.Fatal(".gitignore must ignore .release/ so release-prep does not leave the repository in a dirty state")
+	}
+}
+
 func TestInstallGuidesChangeIntoExtractedArchiveDirectory(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- normalize repo release tags like `v0.0.6-dev` to a VS Code-safe extension version such as `0.0.6` during VSIX packaging
- keep rejecting unsupported tag formats while preserving the checked-in extension manifest version
- ignore `.release/` and add a regression test so `make release-prep` does not leave GoReleaser with a dirty worktree

## Testing
- `npm run test:unit` (in `extension/`)
- `npm run test:integration` (in `extension/`)
- `go test ./cmd/fetch-weaver` (in `observer/`)
- local release verification with a temporary `v0.0.6-dev` tag via `make release-prep`, `make build-vsix`, and `go run github.com/goreleaser/goreleaser/v2@latest release --clean --skip=publish`