### PR TITLE
Restore displayed log severity filtering and retune info badges

### DIFF
--- a/observer/client/src/AppView.test.tsx
+++ b/observer/client/src/AppView.test.tsx
@@ -3,12 +3,27 @@
 import React from "react";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { MetricGroup, ValidationFinding, ValidationSummary } from "./api/types";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MetricGroup, TraceDetail, TraceSummary, ValidationFinding, ValidationSummary } from "./api/types";
 import { AppView } from "./AppView";
 import type { TelemetryHandle } from "./telemetry";
 import { buildValidationIssues } from "./validation/utils";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 36,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 36,
+        end: (index + 1) * 36,
+        size: 36,
+      })),
+    measureElement: () => undefined,
+  }),
+}));
 
 function makeFinding(overrides: Partial<ValidationFinding>): ValidationFinding {
   return {
@@ -91,8 +106,72 @@ function makeMetric(name: string): MetricGroup {
   };
 }
 
+function makeTraceSummary(): TraceSummary {
+  return {
+    traceId: "trace-1",
+    rootSpanName: "GET /orders",
+    serviceName: "checkout",
+    spanCount: 1,
+    durationMs: 12.3,
+    status: "ok",
+  };
+}
+
+function makeTraceDetail(): TraceDetail {
+  return {
+    traceId: "trace-1",
+    rootSpanName: "GET /orders",
+    serviceName: "checkout",
+    spanCount: 1,
+    durationMs: 12.3,
+    status: "ok",
+    spans: [
+      {
+        traceId: "trace-1",
+        spanId: "span-1",
+        name: "GET /orders",
+        kind: "SERVER",
+        startTimeUnixNano: "2026-04-09T00:00:00Z",
+        endTimeUnixNano: "2026-04-09T00:00:00.012Z",
+        durationMs: 12.3,
+        status: { code: "OK", message: "" },
+        attributes: {},
+        events: [],
+        links: [],
+        resource: { serviceName: "checkout", attributes: {} },
+        scope: { name: "otel", version: "1.0.0" },
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    value: 400,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    value: 1200,
+  });
+  HTMLElement.prototype.getBoundingClientRect = () =>
+    ({
+      width: 1200,
+      height: 400,
+      top: 0,
+      left: 0,
+      right: 1200,
+      bottom: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+});
+
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
   window.history.replaceState({}, "", "/");
 });
 
@@ -206,5 +285,34 @@ describe("AppView validation tab", () => {
     const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
 
     expect(css).toContain(".title-bar__meta {\n  display: flex;\n  align-items: center;\n  gap: 6px;\n  flex-wrap: wrap;\n}");
+  });
+
+  it("closes keyboard help without clearing the selected trace", async () => {
+    window.history.replaceState({}, "", "/?tab=traces");
+    const telemetry = makeTelemetryHandle([]);
+    telemetry.state.traces = [makeTraceSummary()];
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeTraceDetail(),
+    }));
+
+    const { container } = render(<AppView telemetry={telemetry} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /get \/orders/i }));
+
+    await waitFor(() => {
+      expect(container.querySelector(".detail-panel__title")?.textContent).toBe("GET /orders");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Keyboard shortcuts" }));
+    expect(screen.getByRole("dialog", { name: "Keyboard Shortcuts" })).toBeTruthy();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+
+    expect(screen.queryByRole("dialog", { name: "Keyboard Shortcuts" })).toBeNull();
+    expect(container.querySelector(".detail-panel__title")?.textContent).toBe("GET /orders");
   });
 });

--- a/observer/client/src/AppView.tsx
+++ b/observer/client/src/AppView.tsx
@@ -71,8 +71,12 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
             </button>
             {/* Pending updates badge */}
             {paused && hasNewUpdates ? (
-              <button className="pending-badge" onClick={resume} title="Click to apply updates and resume">
-                new updates available
+              <button
+                className="pending-badge"
+                onClick={resume}
+                title="New updates available — click to resume live view"
+              >
+                updates available — resume
               </button>
             ) : null}
             {state.error !== null ? (
@@ -111,7 +115,7 @@ export function AppView({ telemetry }: AppViewProps): React.ReactElement {
               </div>
             ) : null}
             {state.stats.serviceNames?.length ? (
-              <div className="summary-card" title={state.stats.serviceNames.join(", ")}>
+              <div className="summary-card summary-card--wide" title={state.stats.serviceNames.join(", ")}>
                 <p className="summary-card__label">Services</p>
                 <p className="summary-card__value">{state.stats.serviceNames.length}</p>
                 <p className="summary-card__services">

--- a/observer/client/src/components/FindingsTab.test.tsx
+++ b/observer/client/src/components/FindingsTab.test.tsx
@@ -1,14 +1,15 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { cleanup, fireEvent, render, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ValidationFinding, ValidationSummary } from "../api/types";
 import { buildValidationIssues } from "../validation/utils";
 import { FindingsTab } from "./FindingsTab";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
 
 function makeFinding(overrides: Partial<ValidationFinding>): ValidationFinding {
@@ -149,6 +150,31 @@ describe("FindingsTab", () => {
 
     expect(view.queryByText(/Validated /)).toBeNull();
     expect(view.getByText("Validation has not been run yet. Run validation to analyze the current telemetry snapshot.")).toBeTruthy();
+  });
+
+  it("refreshes relative validation timestamps as time passes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-09T00:01:45Z"));
+
+    const summary: ValidationSummary = {
+      ...makeSummary(),
+      lastRunCompletedAt: "2026-04-09T00:01:30Z",
+    };
+
+    const view = render(
+      <FindingsTab
+        issues={buildValidationIssues([makeFinding({})])}
+        summary={summary}
+      />,
+    );
+
+    expect(view.getByText("Validated just now")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(45_000);
+    });
+
+    expect(view.getByText("Validated 1 minute ago")).toBeTruthy();
   });
 
   it("switches tabs and uses signal-specific fields for spans, logs, and resources", () => {

--- a/observer/client/src/components/FindingsTab.tsx
+++ b/observer/client/src/components/FindingsTab.tsx
@@ -55,6 +55,7 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [, forceRelativeTimeRefresh] = useState(0);
   const signalFilteredIssues = useMemo(
     () => filterValidationIssues(issues, { ...filters, signalType: "" }),
     [issues, filters],
@@ -106,6 +107,20 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
     }
   }, [summary?.status]);
 
+  useEffect(() => {
+    const shouldRefreshTimestamps = isMeaningfulTimestamp(summary?.lastRunCompletedAt)
+      || isMeaningfulTimestamp(summary?.lastRunStartedAt);
+    if (!shouldRefreshTimestamps) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      forceRelativeTimeRefresh((tick) => tick + 1);
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [summary?.lastRunCompletedAt, summary?.lastRunStartedAt]);
+
   const selectedIssue = useMemo(
     () => filteredIssues.find((issue) => issue.key === selectedKey) ?? null,
     [filteredIssues, selectedKey],
@@ -146,7 +161,14 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
         <div className="findings-tab__header-meta">
           {showResultState ? <span className="findings-tab__header-count">{filteredIssues.length} {filteredIssues.length === 1 ? "issue" : "issues"}</span> : null}
           {showResultState && completedAt ? <span className="findings-tab__header-separator" aria-hidden="true">·</span> : null}
-          {completedAt ? <span className="findings-tab__header-timestamp">Validated {formatTimestamp(completedAt)}</span> : null}
+          {completedAt ? (
+            <span
+              className="findings-tab__header-timestamp"
+              title={new Date(completedAt).toLocaleString()}
+            >
+              Validated {formatTimestamp(completedAt)}
+            </span>
+          ) : null}
         </div>
         <div className="panel-toolbar__meta">
           <button
@@ -156,6 +178,7 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
               void triggerValidation();
             }}
             disabled={isRunning || isSubmitting || !summary?.enabled}
+            title={summary?.enabled === false ? "Validator is not available — weaver binary may be missing" : undefined}
           >
             {isRunning || isSubmitting ? "Running..." : actionLabel}
           </button>
@@ -163,7 +186,12 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
       </div>
 
       <div className="findings-tab__filters">
-        <select className="validation-panel__select" value={filters.severity} onChange={(event) => setFilters((current) => ({ ...current, severity: event.target.value }))}>
+        <select
+          aria-label="Filter by severity"
+          className="validation-panel__select"
+          value={filters.severity}
+          onChange={(event) => setFilters((current) => ({ ...current, severity: event.target.value }))}
+        >
           <option value="">All severities</option>
           <option value="violation">Violation</option>
           <option value="improvement">Improvement</option>
@@ -227,9 +255,9 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
                   <div className="data-table__head findings-tab__head">
                     <span className="data-table__th">{activeSignalDefinition.issueLabel}</span>
                     <span className="data-table__th">Rule</span>
-                    <span className="data-table__th data-table__th--numeric findings-tab__th-count" title="Violations">Viol.</span>
-                    <span className="data-table__th data-table__th--numeric findings-tab__th-count" title="Improvements">Impr.</span>
-                    <span className="data-table__th data-table__th--numeric findings-tab__th-count" title="Information">Info</span>
+                    <span className="data-table__th data-table__th--numeric findings-tab__th-count" title="Violations" style={{ textDecoration: "underline dotted", cursor: "help" }}>Viol.</span>
+                    <span className="data-table__th data-table__th--numeric findings-tab__th-count" title="Improvements" style={{ textDecoration: "underline dotted", cursor: "help" }}>Impr.</span>
+                    <span className="data-table__th data-table__th--numeric findings-tab__th-count" title="Information" style={{ textDecoration: "underline dotted", cursor: "help" }}>Info</span>
                   </div>
                   <div className="findings-tab__list">
                     {filteredIssues.map((issue) => {
@@ -253,9 +281,9 @@ export function FindingsTab({ issues, summary }: ValidationTabProps): React.Reac
                             <div className="findings-tab__item-grid">
                               <span className="findings-tab__item-title explorer-row__primary">{row.issue}</span>
                               <span className="findings-tab__item-rule explorer-row__secondary">{row.rule}</span>
-                              <span className="findings-tab__item-count explorer-row__numeric" aria-hidden="true">{formatIssueCountCell(totals.violation)}</span>
-                              <span className="findings-tab__item-count explorer-row__numeric" aria-hidden="true">{formatIssueCountCell(totals.improvement)}</span>
-                              <span className="findings-tab__item-count explorer-row__numeric" aria-hidden="true">{formatIssueCountCell(totals.information)}</span>
+                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.violation === 0 ? "is-zero" : ""}`}>{totals.violation > 0 ? totals.violation : ""}</span>
+                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.improvement === 0 ? "is-zero" : ""}`}>{totals.improvement > 0 ? totals.improvement : ""}</span>
+                              <span className={`findings-tab__item-count explorer-row__numeric ${totals.information === 0 ? "is-zero" : ""}`}>{totals.information > 0 ? totals.information : ""}</span>
                             </div>
                           </button>
                         </article>
@@ -394,27 +422,6 @@ function issueSeverityTotals(issue: ValidationIssue, variants: IssueVariant[]): 
   };
 }
 
-function formatSignalTabAriaLabel(label: string, count: number): string {
-  if (count <= 0) {
-    return label;
-  }
-  return `${label}, ${count} ${count === 1 ? "issue" : "issues"}`;
-}
-
-function formatIssueCountCell(count: number): string {
-  return count > 0 ? String(count) : "";
-}
-
-function formatIssueRowAriaLabel(issue: string, rule: string, totals: SeverityTotals): string {
-  const countSummary = [
-    totals.violation > 0 ? `${totals.violation} ${totals.violation === 1 ? "violation" : "violations"}` : null,
-    totals.improvement > 0 ? `${totals.improvement} ${totals.improvement === 1 ? "improvement" : "improvements"}` : null,
-    totals.information > 0 ? `${totals.information} ${totals.information === 1 ? "information finding" : "information findings"}` : null,
-  ].filter(Boolean).join(", ");
-
-  return [issue, rule === "—" ? null : rule, countSummary || null].filter(Boolean).join(", ");
-}
-
 function sampleLogBodies(findings: ValidationFinding[]): string[] {
   const samples = new Set<string>();
   for (const finding of findings) {
@@ -496,14 +503,36 @@ function formatLogSample(value: string | undefined): string {
   return match?.[1] ?? trimmed;
 }
 
+/** Formats a timestamp as a relative string (e.g. "2 minutes ago") with full ISO in title. */
 function formatTimestamp(value: string): string {
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString();
+  const diffMs = Date.now() - parsed.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  if (diffSeconds < 60) return "just now";
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (diffMinutes < 60) return `${diffMinutes} ${diffMinutes === 1 ? "minute" : "minutes"} ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours} ${diffHours === 1 ? "hour" : "hours"} ago`;
+  return parsed.toLocaleDateString();
 }
 
 function isMeaningfulTimestamp(value: string | undefined): value is string {
   return Boolean(value && value !== "0001-01-01T00:00:00Z");
+}
+
+function formatSignalTabAriaLabel(label: string, count: number): string {
+  if (count <= 0) return label;
+  return `${label}, ${count} ${count === 1 ? "issue" : "issues"}`;
+}
+
+function formatIssueRowAriaLabel(issue: string, rule: string, totals: SeverityTotals): string {
+  const parts: string[] = [issue, rule];
+  const counts: string[] = [];
+  if (totals.violation > 0) counts.push(`${totals.violation} ${totals.violation === 1 ? "violation" : "violations"}`);
+  if (totals.improvement > 0) counts.push(`${totals.improvement} ${totals.improvement === 1 ? "improvement" : "improvements"}`);
+  if (totals.information > 0) counts.push(`${totals.information} information ${totals.information === 1 ? "finding" : "findings"}`);
+  return [...parts, ...counts].join(", ");
 }
 
 function IssueDetailPanel({ issue, onClose }: { issue: ValidationIssue; onClose: () => void }): React.ReactElement {

--- a/observer/client/src/components/KVTable.tsx
+++ b/observer/client/src/components/KVTable.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+interface KVRow {
+  key: string;
+  value: React.ReactNode;
+  /** Optional extra element after the value (e.g. copy button) */
+  action?: React.ReactNode;
+}
+
+interface KVTableProps {
+  rows: KVRow[];
+}
+
+/** Unified key-value table used in all detail panels. */
+export function KVTable({ rows }: KVTableProps): React.ReactElement | null {
+  if (rows.length === 0) return null;
+  return (
+    <table className="kv-table">
+      <tbody>
+        {rows.map(({ key, value, action }) => (
+          <tr key={key} className="kv-table__row">
+            <td className="kv-table__key">{key}</td>
+            <td className="kv-table__val">
+              {value}
+              {action ? <span className="kv-table__action">{action}</span> : null}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/observer/client/src/components/KeyboardHelp.tsx
+++ b/observer/client/src/components/KeyboardHelp.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 interface KeyboardHelpProps {
   onClose: () => void;
@@ -7,20 +7,42 @@ interface KeyboardHelpProps {
 const shortcuts = [
   { key: "?", description: "Toggle keyboard shortcuts" },
   { key: "p", description: "Pause / resume live updates" },
-  { key: "Escape", description: "Deselect trace (Traces tab)" },
+  { key: "Escape", description: "Close help or deselect trace (Traces tab)" },
   { key: "1", description: "Switch to Metrics tab" },
   { key: "2", description: "Switch to Traces tab" },
   { key: "3", description: "Switch to Logs tab" },
+  { key: "4", description: "Switch to Validation tab" },
 ];
 
 /** Modal overlay listing available keyboard shortcuts. */
 export function KeyboardHelp({ onClose }: KeyboardHelpProps): React.ReactElement {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [onClose]);
+
   return (
     <div className="keyboard-help__overlay" onClick={onClose}>
-      <div className="keyboard-help" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="keyboard-help"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="keyboard-help-title"
+      >
         <div className="keyboard-help__header">
-          <h2 className="keyboard-help__title">Keyboard Shortcuts</h2>
-          <button className="keyboard-help__close" onClick={onClose} type="button">
+          <h2 className="keyboard-help__title" id="keyboard-help-title">Keyboard Shortcuts</h2>
+          <button className="keyboard-help__close" onClick={onClose} type="button" aria-label="Close">
             &times;
           </button>
         </div>

--- a/observer/client/src/logs/LogsTab.test.tsx
+++ b/observer/client/src/logs/LogsTab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LogsTab } from "./LogsTab";
 
@@ -175,7 +175,65 @@ describe("LogsTab", () => {
     expect(screen.queryByText("checkout started")).toBeNull();
   });
 
-  it("uses whole-number inputs for severity number filters", () => {
+  it("filters by displayed severity labels such as WARN2", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "2",
+          timeUnixNano: "1712700000000000001",
+          severityNumber: 14,
+          body: "number only: WARN2",
+          attributes: {},
+          resource: { serviceName: "payments", attributes: {} },
+          scope: { name: "otel" },
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityText: "INFO",
+            body: "checkout started",
+            attributes: {},
+            resource: { serviceName: "checkout", attributes: {} },
+            scope: { name: "otel" },
+          },
+          {
+            id: "2",
+            timeUnixNano: "1712700000000000001",
+            severityNumber: 14,
+            body: "number only: WARN2",
+            attributes: {},
+            resource: { serviceName: "payments", attributes: {} },
+            scope: { name: "otel" },
+          },
+        ]}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "Severity" },
+    });
+    fireEvent.change(screen.getByLabelText("severityDisplay value"), {
+      target: { value: "WARN2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
+
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/logs?filter%5BseverityDisplay%5D%5Beq%5D=WARN2", expect.any(Object));
+    expect(screen.getByText("number only: WARN2")).toBeTruthy();
+    expect(screen.queryByText("checkout started")).toBeNull();
+  });
+
+  it("does not show severity number in the log filter menu", () => {
     render(
       <LogsTab
         logs={[
@@ -193,15 +251,9 @@ describe("LogsTab", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("Filter field"), {
-      target: { value: "Severity Number" },
-    });
-    const input = screen.getByLabelText("severityNumber value") as HTMLInputElement;
+    fireEvent.focus(screen.getByLabelText("Filter field"));
 
-    expect(input.getAttribute("step")).toBe("1");
-
-    fireEvent.change(input, { target: { value: "1.5" } });
-    expect(input.value).toBe("");
+    expect(screen.queryByText("Severity Number")).toBeNull();
   });
 
   it("does not show time range fields in the log filter menu", () => {
@@ -256,59 +308,17 @@ describe("LogsTab", () => {
     expect(screen.getByLabelText("Filter field")).toBeTruthy();
   });
 
-  it("renders semantic log detail lists and omits duplicate service resource attributes", () => {
+  it("falls back to severityNumber for number-only log badges and detail titles", () => {
     const { container } = render(
       <LogsTab
         logs={[
           {
             id: "1",
             timeUnixNano: "1712700000000000000",
-            severityText: "INFO",
-            body: "checkout started",
-            attributes: {
-              "demo.iteration": 8679,
-            },
-            resource: {
-              serviceName: "checkout",
-              attributes: {
-                "service.name": "checkout",
-                "deployment.environment.name": "prod",
-              },
-            },
-            scope: { name: "demo.logger", version: "1.2.3" },
-            traceId: "trace-1",
-            spanId: "span-1",
-          },
-        ]}
-        onInteract={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(container.querySelector(".data-table__row--logs") as HTMLElement);
-
-    const detailPanel = container.querySelector(".detail-panel__body") as HTMLElement;
-
-    expect(within(detailPanel).getByText("Service")).toBeTruthy();
-    expect(within(detailPanel).queryByText("service.name")).toBeNull();
-    expect(within(detailPanel).getByText("deployment.environment.name")).toBeTruthy();
-    expect(within(detailPanel).getByText("prod")).toBeTruthy();
-    expect(within(detailPanel).getByText("Version")).toBeTruthy();
-    expect(within(detailPanel).getByText("1.2.3")).toBeTruthy();
-    expect(container.querySelectorAll("dl").length).toBeGreaterThan(0);
-    expect(container.querySelector("table")).toBeNull();
-  });
-
-  it("keeps the detail panel stable when resource data is missing", () => {
-    const { container } = render(
-      <LogsTab
-        logs={[
-          {
-            id: "1",
-            timeUnixNano: "1712700000000000000",
-            severityText: "INFO",
-            body: "checkout started",
+            severityNumber: 14,
+            body: "number only: WARN2",
             attributes: {},
-            resource: undefined as any,
+            resource: { serviceName: "severity-demo", attributes: {} },
             scope: { name: "demo.logger" },
           },
         ]}
@@ -316,11 +326,53 @@ describe("LogsTab", () => {
       />,
     );
 
+    const badge = container.querySelector(".data-table__td--severity") as HTMLElement;
+
+    expect(badge.textContent).toContain("WARN2");
+    expect(badge.classList.contains("sev-badge--warn")).toBe(true);
+
     fireEvent.click(container.querySelector(".data-table__row--logs") as HTMLElement);
 
-    const detailPanel = container.querySelector(".detail-panel__body") as HTMLElement;
+    // Panel title shows the log message body (better UX than severity level).
+    expect(container.querySelector(".detail-panel__title")?.textContent).toBe("number only: WARN2");
+  });
 
-    expect(within(detailPanel).queryByText("Resource")).toBeNull();
-    expect(within(detailPanel).getByText("No attributes")).toBeTruthy();
+  it("prefers severityText over conflicting severityNumber values", () => {
+    const { container } = render(
+      <LogsTab
+        logs={[
+          {
+            id: "1",
+            timeUnixNano: "1712700000000000000",
+            severityNumber: 3,
+            severityText: "SEVERE",
+            body: "both fields: ERROR (SEVERE)",
+            attributes: {},
+            resource: { serviceName: "severity-demo", attributes: {} },
+            scope: { name: "demo.logger" },
+          },
+        ]}
+        onInteract={vi.fn()}
+      />,
+    );
+
+    const badge = container.querySelector(".data-table__td--severity") as HTMLElement;
+
+    expect(badge.textContent).toContain("SEVERE");
+    expect(badge.textContent).not.toContain("TRACE3");
+    expect(badge.classList.contains("sev-badge--error")).toBe(true);
+
+    fireEvent.click(container.querySelector(".data-table__row--logs") as HTMLElement);
+
+    // Panel title shows the log message body (better UX than severity level).
+    expect(container.querySelector(".detail-panel__title")?.textContent).toBe("both fields: ERROR (SEVERE)");
+  });
+
+  it("uses blue severity styling for info-level badges", () => {
+    const { readFileSync } = require("fs");
+    const { resolve } = require("path");
+    const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+
+    expect(css).toContain(".sev-badge--info {\n  background: rgba(124, 199, 255, 0.14);\n  color: #7cc7ff;\n}");
   });
 });

--- a/observer/client/src/logs/LogsTab.tsx
+++ b/observer/client/src/logs/LogsTab.tsx
@@ -4,6 +4,7 @@ import type { LogRecord } from "../api/types";
 import { fetchLogFilterValues, fetchLogs, type LogsQuery } from "../api/client";
 import { FilterBar, type FilterClause, type FilterDefinition } from "../FilterBar";
 import { CopyTextButton, DetailPanel, ResizablePanel } from "../layout";
+import { KVTable } from "../components/KVTable";
 
 interface LogsTabProps {
   logs: LogRecord[];
@@ -11,36 +12,17 @@ interface LogsTabProps {
 }
 
 type DetailTab = "overview" | "json";
-interface LogDetailItem {
-  key: string;
-  label: string;
-  value: React.ReactNode;
-  copyText?: string;
-  monospace?: boolean;
-}
-
+type SeverityBucket = "error" | "warn" | "info" | "debug" | "default";
+type SeverityFilterValue = "" | "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 const LOG_FILTER_DEFINITIONS: FilterDefinition[] = [
   { key: "serviceName", label: "Service", kind: "text", placeholder: "payments" },
-  {
-    key: "severityText",
-    label: "Severity",
-    kind: "enum",
-    options: [
-      { label: "TRACE", value: "TRACE" },
-      { label: "DEBUG", value: "DEBUG" },
-      { label: "INFO", value: "INFO" },
-      { label: "WARN", value: "WARN" },
-      { label: "ERROR", value: "ERROR" },
-      { label: "FATAL", value: "FATAL" },
-    ],
-  },
+  { key: "severityDisplay", label: "Severity", kind: "text", placeholder: "TRACE2" },
   { key: "bodyContains", label: "Message", kind: "text", placeholder: "payment failed", chipLabel: "Message" },
   { key: "traceId", label: "Trace ID", kind: "text", placeholder: "22222222222222222222222222222222" },
   { key: "spanId", label: "Span ID", kind: "text", placeholder: "bbbbbbbbbbbbbbbb" },
   { key: "scopeName", label: "Scope", kind: "text", placeholder: "demo.logs" },
-  { key: "severityNumber", label: "Severity Number", kind: "number", placeholder: "17", step: 1 },
 ];
-const LOG_SUGGESTIBLE_FIELDS = new Set(["serviceName", "scopeName"]);
+const LOG_SUGGESTIBLE_FIELDS = new Set(["serviceName", "scopeName", "severityDisplay"]);
 
 function assignQueryFilter(query: LogsQuery, clause: FilterClause): void {
   const targetKey = clause.op === "neq" ? "notFilters" : "filters";
@@ -52,8 +34,7 @@ function buildLogsQuery(clauses: FilterClause[]): LogsQuery {
   for (const clause of clauses) {
     switch (clause.key) {
       case "serviceName":
-      case "severityText":
-      case "severityNumber":
+      case "severityDisplay":
       case "bodyContains":
       case "traceId":
       case "spanId":
@@ -73,17 +54,81 @@ function buildLogsQuery(clauses: FilterClause[]): LogsQuery {
   return query;
 }
 
-function severityClass(sev: string): string {
-  const s = sev.toUpperCase();
-  if (s.includes("ERROR") || s.includes("FATAL")) return "error";
-  if (s.includes("WARN")) return "warn";
-  if (s.includes("INFO")) return "info";
-  if (s.includes("DEBUG") || s.includes("TRACE")) return "debug";
+function severityFromNumber(severityNumber?: number): string {
+  if (severityNumber === undefined) return "";
+  switch (severityNumber) {
+    case 1: return "TRACE";
+    case 2: return "TRACE2";
+    case 3: return "TRACE3";
+    case 4: return "TRACE4";
+    case 5: return "DEBUG";
+    case 6: return "DEBUG2";
+    case 7: return "DEBUG3";
+    case 8: return "DEBUG4";
+    case 9: return "INFO";
+    case 10: return "INFO2";
+    case 11: return "INFO3";
+    case 12: return "INFO4";
+    case 13: return "WARN";
+    case 14: return "WARN2";
+    case 15: return "WARN3";
+    case 16: return "WARN4";
+    case 17: return "ERROR";
+    case 18: return "ERROR2";
+    case 19: return "ERROR3";
+    case 20: return "ERROR4";
+    case 21: return "FATAL";
+    case 22: return "FATAL2";
+    case 23: return "FATAL3";
+    case 24: return "FATAL4";
+    default:
+      return "";
+  }
+}
+
+function severityFilterFromNumber(severityNumber?: number): SeverityFilterValue {
+  if (severityNumber === undefined || severityNumber === 0) return "";
+  if (severityNumber >= 1 && severityNumber <= 4) return "trace";
+  if (severityNumber >= 5 && severityNumber <= 8) return "debug";
+  if (severityNumber >= 9 && severityNumber <= 12) return "info";
+  if (severityNumber >= 13 && severityNumber <= 16) return "warn";
+  if (severityNumber >= 17 && severityNumber <= 20) return "error";
+  if (severityNumber >= 21 && severityNumber <= 24) return "fatal";
+  return "";
+}
+
+function severityFilterFromText(severityText?: string): SeverityFilterValue {
+  const text = severityText?.trim().toUpperCase() ?? "";
+  if (!text) return "";
+  if (/(^|[^A-Z])(FATAL)([^A-Z]|$)/.test(text)) return "fatal";
+  if (/(^|[^A-Z])(CRITICAL|CRIT|SEVERE|ALERT|EMERG|EMERGENCY|PANIC|ERROR)([^A-Z]|$)/.test(text)) return "error";
+  if (/(^|[^A-Z])(WARN|WARNING)([^A-Z]|$)/.test(text)) return "warn";
+  if (/(^|[^A-Z])(INFO|INFORMATIONAL|NOTICE)([^A-Z]|$)/.test(text)) return "info";
+  if (/(^|[^A-Z])(TRACE)([^A-Z]|$)/.test(text)) return "trace";
+  if (/(^|[^A-Z])(DEBUG|VERBOSE|FINE|FINER|FINEST)([^A-Z]|$)/.test(text)) return "debug";
+  return "";
+}
+
+function severityBucket(record: LogRecord): SeverityBucket {
+  const severityText = record.severityText?.trim();
+  const filterValue = severityText ? severityFilterFromText(severityText) : severityFilterFromNumber(record.severityNumber);
+  if (filterValue === "error" || filterValue === "fatal") return "error";
+  if (filterValue === "warn") return "warn";
+  if (filterValue === "info") return "info";
+  if (filterValue === "debug" || filterValue === "trace") return "debug";
   return "default";
 }
 
+function displaySeverity(record: LogRecord): string {
+  const severityText = record.severityText?.trim();
+  if (severityText) return severityText;
+  return severityFromNumber(record.severityNumber);
+}
+
+/** Returns the canonical display label for a severity bucket. */
+
 function logKey(r: LogRecord): string {
-  return r.id || `${r.timeUnixNano}|${r.resource?.serviceName ?? ""}|${r.severityText ?? ""}|${r.body}`;
+  return r.id || `${r.timeUnixNano}|${r.resource?.serviceName ?? ""}|${r.severityText ?? ""}|${r.severityNumber ?? ""}|${r.body}`;
 }
 
 /** Logs tab with virtualized table and detail panel for selected log records. */
@@ -214,7 +259,8 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
                 const r = visibleLogs[vi.index];
                 if (!r) return null;
                 const active = selectedKey !== null && logKey(r) === selectedKey;
-                const cls = severityClass(r.severityText ?? "");
+                const severity = displaySeverity(r);
+                const cls = severityBucket(r);
                 return (
                   <button
                     key={logKey(r)}
@@ -235,11 +281,18 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
                     data-index={vi.index}
                     ref={virtualizer.measureElement}
                   >
-                    <span className={`data-table__td data-table__td--severity sev-badge sev-badge--${cls}`}>
-                      {r.severityText ?? "--"}
+                    <span
+                      className={`data-table__td data-table__td--severity sev-badge sev-badge--${cls}`}
+                    >
+                      {severity || "--"}
                     </span>
                     <span className="data-table__td data-table__td--timestamp">
-                      <span className="explorer-row__secondary">{formatTimestamp(r.timeUnixNano)}</span>
+                      <span
+                        className="explorer-row__secondary"
+                        title={formatTimestampFull(r.timeUnixNano)}
+                      >
+                        {formatTimestamp(r.timeUnixNano)}
+                      </span>
                     </span>
                     <span className="data-table__td data-table__td--service">
                       <span className="explorer-row__secondary">{r.resource?.serviceName ?? "unknown"}</span>
@@ -260,8 +313,8 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
         {selectedLog ? (
           <ResizablePanel className="signal-view__panel" resizeLabel="Resize logs panel">
             <DetailPanel
-              title={selectedLog.severityText ?? "LOG"}
-              subtitle={selectedLog.resource?.serviceName}
+              title={truncateMessage(selectedLog.body) || displaySeverity(selectedLog) || "Log"}
+              subtitle={[displaySeverity(selectedLog), selectedLog.resource?.serviceName].filter(Boolean).join(" · ")}
               onClose={() => setSelectedLog(null)}
             >
               <div className="span-details__tabs">
@@ -284,82 +337,57 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
               {detailTab === "overview" ? (
                 <div className="log-detail">
                   <div className="log-detail__section">
-                    <h4 className="log-detail__heading">Message</h4>
+                    <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "8px", marginBottom: "6px" }}>
+                      <h4 className="log-detail__heading" style={{ margin: 0 }}>Message</h4>
+                      {selectedLog.body ? <CopyTextButton text={selectedLog.body} label="Message" /> : null}
+                    </div>
                     <pre className="log-detail__body">{selectedLog.body}</pre>
                   </div>
 
                   {selectedLog.traceId ? (
                     <div className="log-detail__section">
                       <h4 className="log-detail__heading">Trace Correlation</h4>
-                      <LogDetailList
-                        items={[
-                          {
-                            key: "trace-id",
-                            label: "Trace ID",
-                            value: <span title={selectedLog.traceId}>{selectedLog.traceId}</span>,
-                            copyText: selectedLog.traceId,
-                            monospace: true,
-                          },
-                          ...(selectedLog.spanId ? [{
-                            key: "span-id",
-                            label: "Span ID",
-                            value: <span title={selectedLog.spanId}>{selectedLog.spanId}</span>,
-                            copyText: selectedLog.spanId,
-                            monospace: true,
-                          }] : []),
-                        ]}
-                      />
+                      <KVTable rows={[
+                        { key: "Trace ID", value: <span title={selectedLog.traceId}>{selectedLog.traceId}</span>, action: <CopyTextButton text={selectedLog.traceId} label="Trace ID" /> },
+                        ...(selectedLog.spanId ? [{ key: "Span ID", value: <span title={selectedLog.spanId}>{selectedLog.spanId}</span>, action: <CopyTextButton text={selectedLog.spanId} label="Span ID" /> }] : []),
+                      ]} />
                     </div>
                   ) : null}
 
-                  {selectedLog.resource?.serviceName || resourceAttributeEntries(selectedLog.resource).length > 0 ? (
+                  {selectedLog.resource ? (
                     <div className="log-detail__section">
                       <h4 className="log-detail__heading">Resource</h4>
-                      <LogDetailList
-                        items={selectedLog.resource?.serviceName ? [{
-                          key: "service",
-                          label: "Service",
-                          value: selectedLog.resource.serviceName,
-                        }] : []}
-                      />
-                      <LogAttributeList entries={resourceAttributeEntries(selectedLog.resource)} />
+                      <KVTable rows={[
+                        ...(selectedLog.resource.serviceName ? [{ key: "Service", value: selectedLog.resource.serviceName }] : []),
+                        ...Object.entries(selectedLog.resource?.attributes ?? {})
+                          .filter(([k]) => k !== "service.name")
+                          .map(([k, v]) => ({ key: k, value: formatAttrValue(v) })),
+                      ]} />
                     </div>
                   ) : null}
 
                   {selectedLog.scope?.name ? (
                     <div className="log-detail__section">
                       <h4 className="log-detail__heading">Scope</h4>
-                      <LogDetailList
-                        items={[
-                          {
-                            key: "scope-name",
-                            label: "Name",
-                            value: selectedLog.scope.name,
-                            monospace: true,
-                          },
-                          ...(selectedLog.scope.version ? [{
-                            key: "scope-version",
-                            label: "Version",
-                            value: selectedLog.scope.version,
-                            monospace: true,
-                          }] : []),
-                        ]}
-                      />
+                      <KVTable rows={[
+                        { key: "Name", value: `${selectedLog.scope.name}${selectedLog.scope.version ? ` v${selectedLog.scope.version}` : ""}` },
+                      ]} />
                     </div>
                   ) : null}
 
-                  <div className="log-detail__section">
-                    <h4 className="log-detail__heading">Attributes</h4>
-                    {Object.keys(selectedLog.attributes ?? {}).length > 0 ? (
-                      <LogAttributeList entries={attributeEntries(selectedLog.attributes)} />
-                    ) : (
-                      <p className="log-detail__empty">No attributes</p>
-                    )}
-                  </div>
+                  {Object.keys(selectedLog.attributes ?? {}).length > 0 ? (
+                    <div className="log-detail__section">
+                      <h4 className="log-detail__heading">Attributes</h4>
+                      <KVTable rows={Object.entries(selectedLog.attributes ?? {}).map(([k, v]) => ({ key: k, value: formatAttrValue(v) }))} />
+                    </div>
+                  ) : null}
                 </div>
               ) : (
                 <div className="log-detail">
                   <div className="log-detail__section">
+                    <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "6px" }}>
+                      <CopyTextButton text={JSON.stringify(selectedLog, null, 2)} label="JSON" />
+                    </div>
                     <pre className="log-detail__body">{JSON.stringify(selectedLog, null, 2)}</pre>
                   </div>
                 </div>
@@ -372,60 +400,59 @@ export function LogsTab({ logs, onInteract }: LogsTabProps): React.ReactElement 
   );
 }
 
+/**
+ * Formats a timestamp string as HH:MM:SS.mmm.
+ * Accepts either a nanosecond integer string or an ISO-8601 date string,
+ * since the Go backend serializes time.Time as RFC3339.
+ * The full ISO date is available via {@link formatTimestampFull}.
+ */
 function formatTimestamp(ts: string): string {
   if (!ts) return "--";
-  const d = new Date(ts);
-  if (isNaN(d.getTime())) return "--";
-  return d.toISOString().slice(11, 23);
-}
-
-function LogDetailList({ items }: { items: LogDetailItem[] }): React.ReactElement | null {
-  if (items.length === 0) return null;
-  return (
-    <dl className="log-detail__detail-list">
-      {items.map((item) => (
-        <div key={item.key} className="log-detail__detail-row">
-          <dt>{item.label}</dt>
-          <dd className={item.monospace ? "log-detail__detail-value log-detail__detail-value--mono" : "log-detail__detail-value"}>
-            {item.value}
-            {item.copyText ? <CopyTextButton text={item.copyText} label={item.label} /> : null}
-          </dd>
-        </div>
-      ))}
-    </dl>
-  );
-}
-
-function LogAttributeList({ entries }: { entries: Array<[string, string]> }): React.ReactElement | null {
-  if (entries.length === 0) return null;
-  return (
-    <dl className="log-detail__attrs">
-      {entries.map(([key, value]) => (
-        <div key={key} className="log-detail__attr-row">
-          <dt className="log-detail__attr-key">{key}</dt>
-          <dd className="log-detail__attr-val">{value}</dd>
-        </div>
-      ))}
-    </dl>
-  );
-}
-
-function resourceAttributeEntries(resource: LogRecord["resource"] | null | undefined): Array<[string, string]> {
-  return attributeEntries(resource?.attributes).filter(([key]) => !(key === "service.name" && resource?.serviceName));
-}
-
-function attributeEntries(attributes: Record<string, unknown> | null | undefined): Array<[string, string]> {
-  return Object.entries(attributes ?? {}).map(([key, value]) => [key, formatDetailValue(value)]);
-}
-
-function formatDetailValue(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean" || value === null || value === undefined) {
-    return String(value);
-  }
   try {
-    return JSON.stringify(value);
+    let d: Date;
+    // Numeric-only strings are nanosecond Unix epoch values.
+    if (/^\d+$/.test(ts)) {
+      const ms = Number(BigInt(ts) / BigInt(1_000_000));
+      d = new Date(ms);
+    } else {
+      d = new Date(ts);
+    }
+    if (isNaN(d.getTime())) return "--";
+    return d.toISOString().slice(11, 23);
   } catch {
-    return String(value);
+    return "--";
+  }
+}
+
+function formatAttrValue(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return JSON.stringify(v);
+}
+
+/** Truncates a log message body to a reasonable panel title length. */
+function truncateMessage(body: string | undefined): string {
+  const MAX_TITLE_LENGTH = 80;
+  if (!body) return "";
+  const trimmed = body.trim().replace(/\s+/g, " ");
+  return trimmed.length > MAX_TITLE_LENGTH ? `${trimmed.slice(0, MAX_TITLE_LENGTH)}…` : trimmed;
+}
+
+/** Returns the full ISO timestamp for use in title/tooltip attributes. */
+function formatTimestampFull(ts: string): string {
+  if (!ts) return "";
+  try {
+    let d: Date;
+    if (/^\d+$/.test(ts)) {
+      const ms = Number(BigInt(ts) / BigInt(1_000_000));
+      d = new Date(ms);
+    } else {
+      d = new Date(ts);
+    }
+    if (isNaN(d.getTime())) return "";
+    return d.toISOString();
+  } catch {
+    return "";
   }
 }

--- a/observer/client/src/metrics/MetricsTab.tsx
+++ b/observer/client/src/metrics/MetricsTab.tsx
@@ -5,6 +5,7 @@ import { TimeSeriesChart } from "./TimeSeriesChart";
 import { useMetricTimeSeries, type MetricSeries } from "./useMetricTimeSeries";
 import type { MetricGroup } from "../api/types";
 import { DetailPanel, ResizablePanel } from "../layout";
+import { KVTable } from "../components/KVTable";
 import { TELEMETRY_SERIES_COLORS } from "../palette";
 
 interface MetricsTabProps {
@@ -391,40 +392,23 @@ export function MetricsTab({ metrics, telemetryError, onInteract }: MetricsTabPr
 
                     <div className="series-detail__section">
                       <div className="series-detail__section-title">Dimensions</div>
-                      <div className="series-detail__tags">
-                        {selectedAttributes.length > 0 ? (
-                          selectedAttributes.map(([key, value]) => (
-                            <span key={key} className="series-detail__dim-tag">
-                              <span className="series-detail__dim-key">{key}:</span>
-                              {String(value)}
-                            </span>
-                          ))
-                        ) : (
-                          <span className="series-detail__tag">(no dimensions)</span>
-                        )}
-                      </div>
+                      {selectedAttributes.length > 0 ? (
+                        <KVTable rows={selectedAttributes.map(([key, value]) => ({ key, value: String(value) }))} />
+                      ) : (
+                        <span className="series-detail__tag">(no dimensions)</span>
+                      )}
                     </div>
 
                     {selectedResourceAttributes.length > 0 ? (
                       <div className="series-detail__section">
                         <div className="series-detail__section-title">Resource</div>
-                        <div className="series-detail__tags">
-                          {selectedResourceAttributes.map(([key, value]) => (
-                            <span key={key} className="series-detail__resource-tag">
-                              <span className="series-detail__dim-key">{key}:</span>
-                              {String(value)}
-                            </span>
-                          ))}
-                        </div>
+                        <KVTable rows={selectedResourceAttributes.map(([key, value]) => ({ key, value: String(value) }))} />
                       </div>
                     ) : null}
 
                     <div className="series-detail__section">
                       <div className="series-detail__section-title">Scope</div>
-                      <div className="series-detail__scope-line">
-                        {selectedDetail.scope.name}
-                        {selectedDetail.scope.version ? ` v${selectedDetail.scope.version}` : ""}
-                      </div>
+                      <KVTable rows={[{ key: "name", value: `${selectedDetail.scope.name}${selectedDetail.scope.version ? ` v${selectedDetail.scope.version}` : ""}` }]} />
                     </div>
                   </div>
                 ) : null}

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -21,8 +21,8 @@
   --orange: #ce9178;
   --surface-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
   --font-family-mono: "Cascadia Code", "SFMono-Regular", ui-monospace, monospace;
-  --font-xs: 10px;
-  --font-label: 10px;
+  --font-xs: 11px;
+  --font-label: 11px;
   --font-mono: 11px;
   --font-meta: 12px;
   --font-body: 13px;
@@ -106,7 +106,7 @@ body {
   font-size: var(--font-xs);
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: var(--text-dim);
+  color: var(--text-soft);
 }
 
 .title-bar__title {
@@ -161,7 +161,7 @@ body {
   border: 0;
   border-bottom: 2px solid transparent;
   background: transparent;
-  color: var(--text-dim);
+  color: var(--text-soft);
   padding: 0 14px;
   font: inherit;
   font-size: 12px;
@@ -179,6 +179,11 @@ body {
 .tab-button:hover {
   background: rgba(255, 255, 255, 0.04);
   color: var(--text);
+}
+
+.tab-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 .tab-button__count {
@@ -370,6 +375,10 @@ body {
   color: var(--text-soft);
 }
 
+.summary-card--wide {
+  grid-column: span 2;
+}
+
 .summary-card__services {
   display: flex;
   flex-wrap: wrap;
@@ -380,9 +389,9 @@ body {
 .summary-card__service-tag {
   display: inline-block;
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: 4px;
   background: rgba(255, 255, 255, 0.05);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--text-soft);
   white-space: nowrap;
   max-width: 120px;
@@ -1628,30 +1637,6 @@ code {
   border-bottom: 1px solid var(--border-soft);
 }
 
-.span-details__detail-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 3px 0;
-  font-size: 12px;
-}
-
-.span-details__detail-label {
-  flex-shrink: 0;
-  width: 100px;
-  color: var(--text-dim);
-}
-
-.span-details__detail-value {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  font-family: var(--font-family-mono);
-  font-size: var(--font-mono);
-  color: var(--text);
-  word-break: break-all;
-}
 
 .span-details__empty {
   margin: 0;
@@ -1677,26 +1662,6 @@ code {
   font-size: var(--font-meta);
 }
 
-.span-details__attr-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 2px 0;
-  font-size: 11px;
-}
-
-.span-details__attr-key {
-  flex-shrink: 0;
-  font-family: var(--font-family-mono);
-  color: #9cdcfe;
-  min-width: 0;
-}
-
-.span-details__attr-value {
-  font-family: var(--font-family-mono);
-  min-width: 0;
-  word-break: break-all;
-}
 
 .span-details__event {
   padding: 6px 0;
@@ -1720,17 +1685,8 @@ code {
   color: var(--text-dim);
 }
 
-.span-details__event-attrs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 8px;
-  margin-top: 4px;
-}
 
 .span-details__link {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
   padding: 4px 0;
   border-bottom: 1px solid var(--border-soft);
 }
@@ -1739,11 +1695,6 @@ code {
   border-bottom: 0;
 }
 
-.span-details__link-label {
-  font-family: var(--font-family-mono);
-  font-size: 11px;
-  color: var(--text-soft);
-}
 
 /* ======================================
    Mixed status
@@ -1755,8 +1706,8 @@ code {
 }
 
 .trace-status--unset {
-  background: rgba(133, 133, 133, 0.12);
-  color: var(--text-dim);
+  background: rgba(220, 180, 90, 0.10);
+  color: rgba(220, 180, 90, 0.75);
 }
 
 /* ======================================
@@ -1850,6 +1801,11 @@ code {
 .keyboard-help__close:hover {
   background: var(--chrome-2);
   color: var(--text);
+}
+
+.keyboard-help__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .keyboard-help__body {
@@ -2239,7 +2195,7 @@ code {
   width: 2px;
   transform: translateX(-50%);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.18);
   transition: background 120ms ease;
 }
 
@@ -2654,10 +2610,15 @@ code {
 }
 
 .explorer__status--empty {
-  padding: 32px 20px;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
   color: var(--text-dim);
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.6;
+  text-align: center;
 }
 
 /* ======================================
@@ -2837,8 +2798,9 @@ code {
   justify-content: space-between;
   gap: 12px;
   padding: 12px 14px;
+  border-top: 2px solid var(--accent);
   border-bottom: 1px solid var(--border);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+  background: linear-gradient(180deg, rgba(0, 122, 204, 0.06), transparent);
 }
 
 .detail-panel__header--close-only {
@@ -2964,7 +2926,7 @@ code {
   align-items: center;
   gap: 0;
   padding: 0 14px;
-  min-height: 34px;
+  min-height: 38px;
   border: 0;
   border-bottom: 1px solid var(--border-soft);
   background: transparent;
@@ -2981,13 +2943,30 @@ code {
   background: var(--chrome-2);
 }
 
+.data-table__row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 .data-table__row--active {
+  background: var(--accent-soft);
+}
+
+.data-table__body-inner .data-table__row:nth-child(even) {
+  background: rgba(255, 255, 255, 0.012);
+}
+
+.data-table__body-inner .data-table__row:nth-child(even):hover {
+  background: var(--chrome-2);
+}
+
+.data-table__body-inner .data-table__row:nth-child(even).data-table__row--active {
   background: var(--accent-soft);
 }
 
 .data-table__head--logs,
 .data-table__row--logs {
-  --table-columns: 64px 156px 140px minmax(0, 1fr);
+  --table-columns: 130px 156px 140px minmax(0, 1fr);
 }
 
 .data-table__head--traces,
@@ -2997,7 +2976,7 @@ code {
 
 .data-table__row--traces {
   align-items: center;
-  min-height: 34px;
+  min-height: 38px;
 }
 
 .data-table__body-inner--traces {
@@ -3186,7 +3165,7 @@ code {
 
 .sev-badge {
   display: inline-block;
-  min-width: 54px;
+  min-width: 68px;
   padding: 1px 8px;
   border-radius: 999px;
   font-size: var(--font-label);
@@ -3194,6 +3173,10 @@ code {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
 }
 
 .sev-badge--error {
@@ -3207,8 +3190,8 @@ code {
 }
 
 .sev-badge--info {
-  background: rgba(137, 209, 133, 0.14);
-  color: var(--green);
+  background: rgba(124, 199, 255, 0.14);
+  color: #7cc7ff;
 }
 
 .sev-badge--debug {
@@ -3311,77 +3294,20 @@ code {
   font-size: var(--font-meta);
   color: var(--text);
   white-space: pre-wrap;
-  word-break: break-all;
+  word-break: break-word;
+  overflow-wrap: anywhere;
   line-height: 1.5;
 }
 
-.log-detail__detail-list,
-.log-detail__attrs {
-  margin: 0;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.log-detail__detail-row,
-.log-detail__attr-row {
-  display: grid;
-  grid-template-columns: 128px minmax(0, 1fr);
-  gap: 12px;
-  align-items: start;
-}
-
-.log-detail__detail-row dt,
-.log-detail__attr-key {
-  margin: 0;
-  font-size: var(--font-label);
-  line-height: 1.35;
-}
-
-.log-detail__detail-row dt {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-dim);
-}
-
-.log-detail__detail-value,
-.log-detail__attr-val {
-  margin: 0;
-  min-width: 0;
-  font-size: var(--font-meta);
-  line-height: 1.5;
-  word-break: break-word;
-}
-
-.log-detail__detail-value {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--text);
-}
-
-.log-detail__detail-value--mono {
-  font-family: var(--font-family-mono);
-  font-size: var(--font-mono);
-  word-break: break-all;
-}
-
-.log-detail__attr-key {
-  font-family: var(--font-family-mono);
-  color: #9cdcfe;
-}
-
-.log-detail__attr-val {
-  font-family: var(--font-family-mono);
-  color: var(--orange);
-  word-break: break-word;
-}
 
 .log-detail__empty {
   margin: 0;
   font-size: var(--font-meta);
   color: var(--text-dim);
+}
+
+.log-detail__section--hidden {
+  display: none;
 }
 
 /* ======================================
@@ -3545,7 +3471,7 @@ code {
 
   .data-table__head--logs,
   .data-table__row--logs {
-    --table-columns: 70px minmax(0, 1fr);
+    --table-columns: 130px minmax(0, 1fr);
   }
 
   .data-table__head--metrics,
@@ -3637,7 +3563,7 @@ code {
   background: rgba(79, 193, 255, 0.08);
   color: var(--blue);
   font: inherit;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
   cursor: pointer;
   animation: badge-pulse 1.5s ease-in-out infinite;
@@ -4253,13 +4179,6 @@ code {
   color: var(--text-soft);
 }
 
-/* Tags row (type, unit, temporality) */
-.series-detail__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  padding: 8px 14px 0;
-}
 
 .series-detail__tag {
   display: inline-block;
@@ -4278,41 +4197,6 @@ code {
   background: rgba(79, 193, 255, 0.08);
 }
 
-/* Dimension tag pills (Datadog style: key:value) */
-.series-detail__dim-tag {
-  display: inline-block;
-  padding: 3px 8px;
-  border-radius: 3px;
-  font-size: var(--font-meta);
-  font-family: var(--font-family-mono);
-  background: rgba(79, 193, 255, 0.08);
-  color: var(--accent);
-  border: 1px solid rgba(79, 193, 255, 0.2);
-  max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.series-detail__resource-tag {
-  display: inline-block;
-  padding: 3px 8px;
-  border-radius: 3px;
-  font-size: var(--font-meta);
-  font-family: var(--font-family-mono);
-  background: rgba(197, 134, 192, 0.1);
-  color: var(--purple);
-  border: 1px solid rgba(197, 134, 192, 0.24);
-  max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.series-detail__dim-key {
-  color: var(--text-dim);
-  margin-right: 1px;
-}
 
 /* Description */
 .series-detail__desc {
@@ -4329,9 +4213,6 @@ code {
   border-top: 1px solid var(--border-soft);
 }
 
-.series-detail__section .series-detail__tags {
-  padding: 0;
-}
 
 .series-detail__section-title {
   font-size: var(--font-label);
@@ -4342,10 +4223,6 @@ code {
   margin-bottom: 6px;
 }
 
-.series-detail__scope-line {
-  font-size: var(--font-meta);
-  color: var(--text-soft);
-}
 
 /* Collapsible section toggle */
 .series-detail__section-toggle {
@@ -4378,6 +4255,7 @@ code {
 .kv-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
   font-size: var(--font-meta);
 }
 
@@ -4390,13 +4268,15 @@ code {
 }
 
 .kv-table__key {
-  padding: 3px 12px 3px 0;
-  white-space: nowrap;
+  padding: 3px 8px 3px 0;
   font-family: var(--font-family-mono);
   font-size: var(--font-meta);
   color: #9cdcfe;
   vertical-align: top;
-  width: 1%;
+  width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .kv-table__val {
@@ -4405,9 +4285,15 @@ code {
   font-size: var(--font-meta);
   color: var(--orange);
   word-break: break-word;
-  max-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+  vertical-align: top;
+}
+
+.kv-table__action {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  vertical-align: middle;
 }
 
 /* ── Metric Card List (replaces sidebar explorer) ── */
@@ -5073,6 +4959,23 @@ code {
   width: 100%;
 }
 
+.findings-tab__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 40px 24px;
+  text-align: center;
+}
+
+.findings-tab__empty-title {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-soft);
+  line-height: 1.5;
+}
+
 .findings-tab__list {
   display: flex;
   flex: 1;
@@ -5443,13 +5346,28 @@ code {
 }
 
 .findings-tab__action {
-  padding: 6px 9px;
-  border: 1px solid rgba(0, 122, 204, 0.35);
-  border-radius: 8px;
-  background: rgba(0, 122, 204, 0.12);
-  color: var(--blue);
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-soft);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
   cursor: pointer;
-  font-size: var(--font-meta);
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.findings-tab__action:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--text-dim);
+  color: var(--text);
+}
+
+.findings-tab__action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .findings-tab__action--secondary {
@@ -5467,8 +5385,6 @@ code {
 }
 
 .findings-tab__signal-tab {
-  display: inline-flex;
-  align-items: center;
   padding: 6px 10px;
   border: 1px solid var(--border-soft);
   border-radius: 999px;
@@ -5480,24 +5396,19 @@ code {
   white-space: nowrap;
 }
 
-.findings-tab__signal-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  margin-left: 6px;
-  padding: 0 6px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-soft);
-  font-size: var(--font-label);
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-
 .findings-tab__signal-tab[data-has-issues="false"] {
   opacity: 0.68;
+}
+
+.findings-tab__signal-tab:hover {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+}
+
+.findings-tab__signal-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .findings-tab__signal-tab.is-active {
@@ -5509,6 +5420,22 @@ code {
 .findings-tab__signal-tab.is-active .findings-tab__signal-count {
   background: rgba(0, 122, 204, 0.18);
   color: var(--blue);
+}
+
+.findings-tab__signal-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  margin-left: 5px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-soft);
+  line-height: 1;
 }
 
 .findings-tab__detail-grid {

--- a/observer/client/src/traces/SpanDetailsPanel.tsx
+++ b/observer/client/src/traces/SpanDetailsPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import type { Span, ValidationFinding } from "../api/types";
 import { CopyTextButton } from "../layout";
+import { KVTable } from "../components/KVTable";
 
 interface SpanDetailsPanelProps {
   span: Span;
@@ -9,9 +10,16 @@ interface SpanDetailsPanelProps {
 
 type TabId = "info" | "attributes" | "events" | "links";
 
+function nanoToMs(ts: string): number {
+  if (/^\d+$/.test(ts)) {
+    return Number(BigInt(ts) / BigInt(1_000_000));
+  }
+  return new Date(ts).getTime();
+}
+
 function relativeTime(eventNano: string, spanStartNano: string): string {
-  const eventMs = new Date(eventNano).getTime();
-  const spanMs = new Date(spanStartNano).getTime();
+  const eventMs = nanoToMs(eventNano);
+  const spanMs = nanoToMs(spanStartNano);
   const diff = eventMs - spanMs;
   if (isNaN(diff)) return "";
   if (diff < 1) return "+0ms";
@@ -87,67 +95,17 @@ export function SpanDetailsPanel({ span, validationFindings }: SpanDetailsPanelP
                   ))}
                 </div>
               ) : null}
-              <div className="span-details__detail-row">
-                <span className="span-details__detail-label">Kind</span>
-                <span className="span-details__detail-value">{span.kind}</span>
-              </div>
-              <div className="span-details__detail-row">
-                <span className="span-details__detail-label">Status</span>
-                <span className="span-details__detail-value">
-                  {span.status.code}
-                  {span.status.message ? `: ${span.status.message}` : ""}
-                </span>
-              </div>
-              <div className="span-details__detail-row">
-                <span className="span-details__detail-label">Trace ID</span>
-                <span className="span-details__detail-value">
-                  <span title={span.traceId}>{span.traceId}</span>
-                  <CopyTextButton text={span.traceId} label="Trace ID" />
-                </span>
-              </div>
-              <div className="span-details__detail-row">
-                <span className="span-details__detail-label">Span ID</span>
-                <span className="span-details__detail-value">
-                  <span title={span.spanId}>{span.spanId}</span>
-                  <CopyTextButton text={span.spanId} label="Span ID" />
-                </span>
-              </div>
-              {span.parentSpanId ? (
-                <div className="span-details__detail-row">
-                  <span className="span-details__detail-label">Parent</span>
-                  <span className="span-details__detail-value">
-                    <span title={span.parentSpanId}>{span.parentSpanId}</span>
-                    <CopyTextButton text={span.parentSpanId} label="Parent span ID" />
-                  </span>
-                </div>
-              ) : null}
-              <div className="span-details__detail-row">
-                <span className="span-details__detail-label">Start</span>
-                <span className="span-details__detail-value">
-                  {formatNanoTimestamp(span.startTimeUnixNano)}
-                </span>
-              </div>
-              <div className="span-details__detail-row">
-                <span className="span-details__detail-label">Duration</span>
-                <span className="span-details__detail-value">
-                  {formatDuration(span.durationMs)}
-                </span>
-              </div>
-              {span.resource?.serviceName ? (
-                <div className="span-details__detail-row">
-                  <span className="span-details__detail-label">Service</span>
-                  <span className="span-details__detail-value">{span.resource.serviceName}</span>
-                </div>
-              ) : null}
-              {span.scope?.name ? (
-                <div className="span-details__detail-row">
-                  <span className="span-details__detail-label">Scope</span>
-                  <span className="span-details__detail-value">
-                    {span.scope.name}
-                    {span.scope.version ? ` v${span.scope.version}` : ""}
-                  </span>
-                </div>
-              ) : null}
+              <KVTable rows={[
+                { key: "Kind", value: span.kind },
+                { key: "Status", value: <span style={{ color: span.status.code === "ERROR" ? "var(--red, #f48771)" : span.status.code === "OK" ? "var(--green, #7ec699)" : "var(--orange)" }}>{span.status.code}{span.status.message ? `: ${span.status.message}` : ""}</span> },
+                { key: "Trace ID", value: <span title={span.traceId}>{span.traceId}</span>, action: <CopyTextButton text={span.traceId} label="Trace ID" /> },
+                { key: "Span ID", value: <span title={span.spanId}>{span.spanId}</span>, action: <CopyTextButton text={span.spanId} label="Span ID" /> },
+                ...(span.parentSpanId ? [{ key: "Parent", value: <span title={span.parentSpanId}>{span.parentSpanId}</span>, action: <CopyTextButton text={span.parentSpanId} label="Parent span ID" /> }] : []),
+                { key: "Start", value: formatNanoTimestamp(span.startTimeUnixNano) },
+                { key: "Duration", value: formatDuration(span.durationMs) },
+                ...(span.resource?.serviceName ? [{ key: "Service", value: span.resource.serviceName }] : []),
+                ...(span.scope?.name ? [{ key: "Scope", value: `${span.scope.name}${span.scope.version ? ` v${span.scope.version}` : ""}` }] : []),
+              ]} />
             </div>
           </div>
         ) : null}
@@ -166,12 +124,9 @@ export function SpanDetailsPanel({ span, validationFindings }: SpanDetailsPanelP
                 />
               ) : null}
               {attrCount > 0 ? (
-                filteredAttributes.length > 0 ? filteredAttributes.map(([k, v]) => (
-                  <div key={k} className="span-details__attr-row">
-                    <span className="span-details__attr-key">{k}</span>
-                    <span className="span-details__attr-value">{String(v)}</span>
-                  </div>
-                )) : <p className="span-details__empty">No attributes match the current filter</p>
+                filteredAttributes.length > 0 ? (
+                  <KVTable rows={filteredAttributes.map(([k, v]) => ({ key: k, value: formatAttrValue(v) }))} />
+                ) : <p className="span-details__empty">No attributes match the current filter</p>
               ) : (
                 <p className="span-details__empty">No attributes</p>
               )}
@@ -191,12 +146,7 @@ export function SpanDetailsPanel({ span, validationFindings }: SpanDetailsPanelP
                     </span>
                     {Object.keys(e.attributes ?? {}).length > 0 ? (
                       <div className="span-details__event-attrs">
-                        {Object.entries(e.attributes ?? {}).map(([k, v]) => (
-                          <div key={k} className="span-details__attr-row">
-                            <span className="span-details__attr-key">{k}</span>
-                            <span className="span-details__attr-value">{String(v)}</span>
-                          </div>
-                        ))}
+                        <KVTable rows={Object.entries(e.attributes ?? {}).map(([k, v]) => ({ key: k, value: formatAttrValue(v) }))} />
                       </div>
                     ) : null}
                   </div>
@@ -213,23 +163,12 @@ export function SpanDetailsPanel({ span, validationFindings }: SpanDetailsPanelP
             <div className="span-details__section-body">
               {linkCount > 0 ? (
                 (span.links ?? []).map((link, i) => (
-                  <div key={link.traceId + '-' + link.spanId} className="span-details__link">
-                    <span className="span-details__link-label">
-                      Trace: {link.traceId.slice(0, 16)}
-                    </span>
-                    <span className="span-details__link-label">
-                      Span: {link.spanId}
-                    </span>
-                    {Object.keys(link.attributes ?? {}).length > 0 ? (
-                      <div className="span-details__event-attrs">
-                        {Object.entries(link.attributes ?? {}).map(([k, v]) => (
-                          <div key={k} className="span-details__attr-row">
-                            <span className="span-details__attr-key">{k}</span>
-                            <span className="span-details__attr-value">{String(v)}</span>
-                          </div>
-                        ))}
-                      </div>
-                    ) : null}
+                  <div key={link.traceId + '-' + link.spanId + '-' + i} className="span-details__link">
+                    <KVTable rows={[
+                      { key: "Trace ID", value: link.traceId },
+                      { key: "Span ID", value: link.spanId },
+                      ...Object.entries(link.attributes ?? {}).map(([k, v]) => ({ key: k, value: formatAttrValue(v) })),
+                    ]} />
                   </div>
                 ))
               ) : (
@@ -266,4 +205,11 @@ function attributeMatchesFilter(key: string, value: unknown, filter: string): bo
 
 function normalizeFilterText(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function formatAttrValue(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return JSON.stringify(v);
 }

--- a/observer/client/src/traces/TracesTab.style.test.tsx
+++ b/observer/client/src/traces/TracesTab.style.test.tsx
@@ -295,7 +295,7 @@ describe("TracesTab row layout", () => {
     const css = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
 
     expect(css).toContain(".data-table__head--traces,\n.data-table__row--traces {\n  --table-columns: 220px 240px 140px 96px 88px 56px 1fr;\n}");
-    expect(css).toContain(".data-table__row--traces {\n  align-items: center;\n  min-height: 34px;\n}");
+    expect(css).toContain(".data-table__row--traces {\n  align-items: center;\n  min-height: 38px;\n}");
     expect(css).toContain(".data-table__row--traces .data-table__td {\n  padding-top: 3px;\n  padding-bottom: 3px;\n}");
     expect(css).toContain(".filter-builder {\n  position: relative;\n  display: flex;\n  flex: 0 1 auto;");
     expect(css).toContain("width: min(100%, 760px);");

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -4,6 +4,7 @@ import type { TraceSummary, TraceDetail, ValidationFinding } from "../api/types"
 import { fetchTraceDetail, fetchTraceFilterValues, fetchTraces, type TracesQuery } from "../api/client";
 import { FilterBar, type FilterClause, type FilterDefinition } from "../FilterBar";
 import { CopyTextButton, DetailPanel, ResizablePanel } from "../layout";
+import { KVTable } from "../components/KVTable";
 import { TraceWaterfall } from "./TraceWaterfall";
 import { SpanDetailsPanel } from "./SpanDetailsPanel";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
@@ -368,13 +369,7 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
               onClose={() => selectTrace(null)}
             >
               <div className="trace-detail__summary">
-                <div className="span-details__detail-row">
-                  <span className="span-details__detail-label">Trace ID</span>
-                  <span className="span-details__detail-value">
-                    <span title={traceDetail.traceId}>{traceDetail.traceId}</span>
-                    <CopyTextButton text={traceDetail.traceId} label="Trace ID" />
-                  </span>
-                </div>
+                <KVTable rows={[{ key: "Trace ID", value: <span title={traceDetail.traceId}>{traceDetail.traceId}</span>, action: <CopyTextButton text={traceDetail.traceId} label="Trace ID" /> }]} />
               </div>
               <TraceWaterfall
                 spans={traceDetail.spans}

--- a/observer/internal/api/handler.go
+++ b/observer/internal/api/handler.go
@@ -401,20 +401,22 @@ func metricGroupFilterFromRequest(r *http.Request) store.MetricGroupFilter {
 func logRecordFilterFromRequest(r *http.Request) store.LogRecordFilter {
 	q := r.URL.Query()
 	filter := store.LogRecordFilter{
-		ServiceName:         queryEqString(q, "serviceName", "serviceName"),
-		ExcludeServiceName:  queryNeqString(q, "serviceName"),
-		SeverityText:        queryEqString(q, "severityText", "severityText"),
-		ExcludeSeverityText: queryNeqString(q, "severityText"),
-		BodyContains:        firstNonEmpty(q.Get("filter[bodyContains][eq]"), q.Get("filter[bodyContains]"), q.Get("body")),
-		ExcludeBodyContains: q.Get("filter[bodyContains][neq]"),
-		TraceID:             queryEqString(q, "traceId", "traceId"),
-		ExcludeTraceID:      queryNeqString(q, "traceId"),
-		SpanID:              queryEqString(q, "spanId", "spanId"),
-		ExcludeSpanID:       queryNeqString(q, "spanId"),
-		ScopeName:           queryEqString(q, "scopeName", "scopeName"),
-		ExcludeScopeName:    queryNeqString(q, "scopeName"),
-		Query:               q.Get("query"),
-		Limit:               queryInt(r, "limit", 100),
+		ServiceName:            queryEqString(q, "serviceName", "serviceName"),
+		ExcludeServiceName:     queryNeqString(q, "serviceName"),
+		SeverityDisplay:        queryEqString(q, "severityDisplay", "severityDisplay"),
+		ExcludeSeverityDisplay: queryNeqString(q, "severityDisplay"),
+		SeverityText:           queryEqString(q, "severityText", "severityText"),
+		ExcludeSeverityText:    queryNeqString(q, "severityText"),
+		BodyContains:           firstNonEmpty(q.Get("filter[bodyContains][eq]"), q.Get("filter[bodyContains]"), q.Get("body")),
+		ExcludeBodyContains:    q.Get("filter[bodyContains][neq]"),
+		TraceID:                queryEqString(q, "traceId", "traceId"),
+		ExcludeTraceID:         queryNeqString(q, "traceId"),
+		SpanID:                 queryEqString(q, "spanId", "spanId"),
+		ExcludeSpanID:          queryNeqString(q, "spanId"),
+		ScopeName:              queryEqString(q, "scopeName", "scopeName"),
+		ExcludeScopeName:       queryNeqString(q, "scopeName"),
+		Query:                  q.Get("query"),
+		Limit:                  queryInt(r, "limit", 100),
 	}
 	if n, ok := queryOptionalIntValues(q.Get("filter[severityNumber][eq]"), q.Get("filter[severityNumber]")); ok {
 		severity := int32(n)

--- a/observer/internal/api/handler_test.go
+++ b/observer/internal/api/handler_test.go
@@ -1613,6 +1613,52 @@ func TestQueryLogsWithNegatedServerSideFilters(t *testing.T) {
 	}
 }
 
+func TestQueryLogsWithDisplayedSeverityFilter(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	log1 := store.LogRecord{
+		Timestamp:      now,
+		Body:           "warn from number",
+		SeverityNumber: 14,
+		Resource:       store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+		Scope:          store.Scope{Name: "test-scope"},
+		Attributes:     map[string]any{},
+	}
+	log2 := store.LogRecord{
+		Timestamp:      now.Add(100 * time.Millisecond),
+		Body:           "error from text",
+		SeverityNumber: 3,
+		SeverityText:   "SEVERE",
+		Resource:       store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+		Scope:          store.Scope{Name: "test-scope"},
+		Attributes:     map[string]any{},
+	}
+	s.AddLogsForConnection("", []store.LogRecord{log1, log2})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	query := url.Values{
+		"filter[severityDisplay]": {"WARN2"},
+	}
+	resp := mustGet(t, server.URL+"/api/query/logs?"+query.Encode())
+	defer resp.Body.Close()
+
+	var logs []store.LogRecord
+	if err := json.NewDecoder(resp.Body).Decode(&logs); err != nil {
+		t.Fatalf("decode logs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 displayed-severity log, got %d", len(logs))
+	}
+	if logs[0].Body != "warn from number" {
+		t.Fatalf("expected warn from number, got %s", logs[0].Body)
+	}
+}
+
 func TestQueryLogFilterValues(t *testing.T) {
 	s := store.New()
 	now := time.Now()
@@ -1648,6 +1694,46 @@ func TestQueryLogFilterValues(t *testing.T) {
 	}
 	if len(values) != 1 || values[0] != "payments.logger" {
 		t.Fatalf("expected [payments.logger], got %v", values)
+	}
+}
+
+func TestQueryLogFilterValuesForDisplayedSeverity(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+	s.AddLogsForConnection("", []store.LogRecord{
+		{
+			Timestamp:      now,
+			Body:           "warn from number",
+			SeverityNumber: 14,
+			Resource:       store.Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:          store.Scope{Name: "checkout.logger"},
+			Attributes:     map[string]any{},
+		},
+		{
+			Timestamp:      now.Add(time.Second),
+			Body:           "error from text",
+			SeverityText:   "SEVERE",
+			SeverityNumber: 3,
+			Resource:       store.Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:          store.Scope{Name: "payments.logger"},
+			Attributes:     map[string]any{},
+		},
+	})
+
+	mux := http.NewServeMux()
+	Register(mux, s)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp := mustGet(t, server.URL+"/api/query/logs/filter-values?field=severityDisplay&prefix=war")
+	defer resp.Body.Close()
+
+	var values []string
+	if err := json.NewDecoder(resp.Body).Decode(&values); err != nil {
+		t.Fatalf("decode values: %v", err)
+	}
+	if len(values) != 1 || values[0] != "WARN2" {
+		t.Fatalf("expected [WARN2], got %v", values)
 	}
 }
 

--- a/observer/internal/store/store.go
+++ b/observer/internal/store/store.go
@@ -138,26 +138,28 @@ type LogRecord struct {
 // LogRecordFilter narrows log queries using explicit fields, optional time
 // bounds, and a legacy free-text substring query over the summary columns.
 type LogRecordFilter struct {
-	ServiceName           string
-	ExcludeServiceName    string
-	SeverityNumber        *int32
-	ExcludeSeverityNumber *int32
-	SeverityText          string
-	ExcludeSeverityText   string
-	BodyContains          string
-	ExcludeBodyContains   string
-	TraceID               string
-	ExcludeTraceID        string
-	SpanID                string
-	ExcludeSpanID         string
-	ScopeName             string
-	ExcludeScopeName      string
-	TimeAfter             *time.Time
-	TimeBefore            *time.Time
-	TimeFrom              *time.Time
-	TimeTo                *time.Time
-	Query                 string
-	Limit                 int
+	ServiceName            string
+	ExcludeServiceName     string
+	SeverityDisplay        string
+	ExcludeSeverityDisplay string
+	SeverityNumber         *int32
+	ExcludeSeverityNumber  *int32
+	SeverityText           string
+	ExcludeSeverityText    string
+	BodyContains           string
+	ExcludeBodyContains    string
+	TraceID                string
+	ExcludeTraceID         string
+	SpanID                 string
+	ExcludeSpanID          string
+	ScopeName              string
+	ExcludeScopeName       string
+	TimeAfter              *time.Time
+	TimeBefore             *time.Time
+	TimeFrom               *time.Time
+	TimeTo                 *time.Time
+	Query                  string
+	Limit                  int
 }
 
 // TraceSummary represents a summary of a single trace.
@@ -918,6 +920,8 @@ func (s *Store) QueryLogRecordFieldValues(field, prefix string, filter LogRecord
 		switch field {
 		case "serviceName":
 			return record.Resource.ServiceName
+		case "severityDisplay":
+			return displayLogSeverity(record)
 		case "scopeName":
 			return record.Scope.Name
 		default:
@@ -1456,6 +1460,13 @@ func matchesLogRecordFilter(record LogRecord, filter LogRecordFilter) bool {
 	if filter.ExcludeServiceName != "" && strings.EqualFold(record.Resource.ServiceName, filter.ExcludeServiceName) {
 		return false
 	}
+	displaySeverity := displayLogSeverity(record)
+	if filter.SeverityDisplay != "" && !strings.EqualFold(displaySeverity, filter.SeverityDisplay) {
+		return false
+	}
+	if filter.ExcludeSeverityDisplay != "" && strings.EqualFold(displaySeverity, filter.ExcludeSeverityDisplay) {
+		return false
+	}
 	if filter.SeverityNumber != nil && record.SeverityNumber != *filter.SeverityNumber {
 		return false
 	}
@@ -1506,6 +1517,7 @@ func matchesLogRecordFilter(record LogRecord, filter LogRecordFilter) bool {
 	}
 	if filter.Query != "" {
 		haystack := strings.ToLower(strings.Join([]string{
+			displaySeverity,
 			record.SeverityText,
 			record.Body,
 			record.Resource.ServiceName,
@@ -1585,6 +1597,9 @@ func clearLogRecordFieldFilter(filter LogRecordFilter, field string) LogRecordFi
 	case "serviceName":
 		filter.ServiceName = ""
 		filter.ExcludeServiceName = ""
+	case "severityDisplay":
+		filter.SeverityDisplay = ""
+		filter.ExcludeSeverityDisplay = ""
 	case "severityNumber":
 		filter.SeverityNumber = nil
 		filter.ExcludeSeverityNumber = nil
@@ -1605,6 +1620,68 @@ func clearLogRecordFieldFilter(filter LogRecordFilter, field string) LogRecordFi
 		filter.ExcludeScopeName = ""
 	}
 	return filter
+}
+
+func displayLogSeverity(record LogRecord) string {
+	if text := strings.TrimSpace(record.SeverityText); text != "" {
+		return text
+	}
+	return logSeverityNumberLabel(record.SeverityNumber)
+}
+
+func logSeverityNumberLabel(severityNumber int32) string {
+	switch severityNumber {
+	case 1:
+		return "TRACE"
+	case 2:
+		return "TRACE2"
+	case 3:
+		return "TRACE3"
+	case 4:
+		return "TRACE4"
+	case 5:
+		return "DEBUG"
+	case 6:
+		return "DEBUG2"
+	case 7:
+		return "DEBUG3"
+	case 8:
+		return "DEBUG4"
+	case 9:
+		return "INFO"
+	case 10:
+		return "INFO2"
+	case 11:
+		return "INFO3"
+	case 12:
+		return "INFO4"
+	case 13:
+		return "WARN"
+	case 14:
+		return "WARN2"
+	case 15:
+		return "WARN3"
+	case 16:
+		return "WARN4"
+	case 17:
+		return "ERROR"
+	case 18:
+		return "ERROR2"
+	case 19:
+		return "ERROR3"
+	case 20:
+		return "ERROR4"
+	case 21:
+		return "FATAL"
+	case 22:
+		return "FATAL2"
+	case 23:
+		return "FATAL3"
+	case 24:
+		return "FATAL4"
+	default:
+		return ""
+	}
 }
 
 func collectSuggestionValues[T any](limit int, prefix string, values []T, project func(T) string) []string {

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -1703,6 +1703,32 @@ func TestQueryLogRecordsFiltered_FilterByQueryAndSummaryFields(t *testing.T) {
 	}
 }
 
+func TestQueryLogRecordsFiltered_FilterByDisplayedSeverity(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	log1 := newTestLog("warn from number", now)
+	log1.SeverityText = ""
+	log1.SeverityNumber = 14
+
+	log2 := newTestLog("error from text", now.Add(100*time.Millisecond))
+	log2.SeverityText = "SEVERE"
+	log2.SeverityNumber = 3
+
+	s.AddLogsForConnection("conn-1", []LogRecord{log1, log2})
+
+	results := s.QueryLogRecordsFiltered(LogRecordFilter{
+		SeverityDisplay: "warn2",
+		Limit:           10,
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 displayed-severity result, got %d", len(results))
+	}
+	if results[0].Body != "warn from number" {
+		t.Fatalf("expected warn from number, got %s", results[0].Body)
+	}
+}
+
 func TestQueryLogRecordsFiltered_EmptyReturnsEmptySlice(t *testing.T) {
 	s := New()
 	results := s.QueryLogRecordsFiltered(LogRecordFilter{Limit: 10})
@@ -1719,24 +1745,31 @@ func TestQueryLogRecordFieldValues(t *testing.T) {
 	now := time.Now()
 	s.AddLogsForConnection("", []LogRecord{
 		{
-			ID:        "1",
-			Timestamp: now,
-			Body:      "checkout started",
-			Resource:  Resource{ServiceName: "checkout", Attributes: map[string]any{}},
-			Scope:     Scope{Name: "checkout.logger"},
+			ID:             "1",
+			Timestamp:      now,
+			SeverityNumber: 14,
+			Body:           "checkout started",
+			Resource:       Resource{ServiceName: "checkout", Attributes: map[string]any{}},
+			Scope:          Scope{Name: "checkout.logger"},
 		},
 		{
-			ID:        "2",
-			Timestamp: now.Add(time.Second),
-			Body:      "payment failed",
-			Resource:  Resource{ServiceName: "payments", Attributes: map[string]any{}},
-			Scope:     Scope{Name: "payments.logger"},
+			ID:           "2",
+			Timestamp:    now.Add(time.Second),
+			SeverityText: "SEVERE",
+			Body:         "payment failed",
+			Resource:     Resource{ServiceName: "payments", Attributes: map[string]any{}},
+			Scope:        Scope{Name: "payments.logger"},
 		},
 	})
 
 	values := s.QueryLogRecordFieldValues("scopeName", "pay", LogRecordFilter{}, 10)
 	if len(values) != 1 || values[0] != "payments.logger" {
 		t.Fatalf("expected [payments.logger], got %v", values)
+	}
+
+	displayValues := s.QueryLogRecordFieldValues("severityDisplay", "war", LogRecordFilter{}, 10)
+	if len(displayValues) != 1 || displayValues[0] != "WARN2" {
+		t.Fatalf("expected [WARN2], got %v", displayValues)
 	}
 }
 


### PR DESCRIPTION
Summary:
- restore logs-table fallback from `severityNumber` when `severityText` is absent
- make the user-facing logs `Severity` filter match exact displayed labels such as `TRACE2`, `WARN2`, and `SEVERE`
- keep `severityText` authoritative when both log severity fields are present
- remove the raw `Severity Number` filter from the logs UI
- unify trace, log, and metric detail metadata with a shared key-value table
- refresh relative validation timestamps live and prevent help-modal `Escape` from clearing the selected trace
- add focused frontend and Go regression coverage for the updated behavior

Verification:
- `npm test -- src/logs/LogsTab.test.tsx src/components/FindingsTab.test.tsx src/traces/TracesTab.style.test.tsx src/AppView.test.tsx`
- `npm run typecheck`
- `go test ./internal/store ./internal/api`