### PR TITLE
Fix platform-specific packaging and add smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,35 @@ jobs:
       - name: Run tests
         run: make -C observer test
 
+  observer-smoke:
+    name: Observer smoke – ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x64
+          - os: windows-latest
+            label: win32-x64
+          - os: macos-13
+            label: darwin-x64
+          - os: macos-14
+            label: darwin-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: observer/go.mod
+          cache-dependency-path: observer/go.sum
+
+      - name: Run install smoke test
+        working-directory: observer
+        run: |
+          go run ./cmd/stage-skills
+          go test ./cmd/obstudio -run TestInstallSmokeInstallsBinaryAndAcceptsOTLP -count=1
+
   extension:
     name: Extension – test & package
     runs-on: ubuntu-latest
@@ -65,16 +94,90 @@ jobs:
         working-directory: extension
         run: xvfb-run -a npm run test:host
 
-      - name: Build VSIX
+  extension-vsix:
+    name: Extension VSIX – ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x64
+          - os: windows-latest
+            label: win32-x64
+          - os: macos-13
+            label: darwin-x64
+          - os: macos-14
+            label: darwin-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: observer/go.mod
+          cache-dependency-path: observer/go.sum
+
+      - name: Install dependencies
         working-directory: extension
-        run: npm run build:vsix
+        run: npm ci
+
+      - name: Build target VSIX
+        working-directory: extension
+        run: npm run build:vsix -- --target "${{ matrix.label }}"
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:
-          name: observability-studio-vsix
+          name: observability-studio-vsix-${{ matrix.label }}
           path: extension/*.vsix
           if-no-files-found: error
+
+  extension-smoke:
+    name: Extension smoke – ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    needs: extension-vsix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x64
+          - os: windows-latest
+            label: win32-x64
+          - os: macos-13
+            label: darwin-x64
+          - os: macos-14
+            label: darwin-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+
+      - name: Install dependencies
+        working-directory: extension
+        run: npm ci
+
+      - name: Download target VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: observability-studio-vsix-${{ matrix.label }}
+          path: extension/.smoke-vsix
+
+      - name: Run installed VSIX smoke test
+        working-directory: extension
+        env:
+          OBSTUDIO_PREBUILT_VSIX_DIR: .smoke-vsix
+        run: npm run test:integration:smoke
 
   client:
     name: Client – unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,21 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: GoReleaser + VSIX
-    runs-on: ubuntu-latest
+  build-vsix:
+    name: Build VSIX – ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: windows-latest
+            target: win32-x64
+          - os: macos-13
+            target: darwin-x64
+          - os: macos-14
+            target: darwin-arm64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,13 +46,63 @@ jobs:
           go-version-file: observer/go.mod
           cache-dependency-path: observer/go.sum
 
+      - name: Install extension dependencies
+        working-directory: extension
+        run: npm ci
+
+      - name: Build target VSIX package
+        working-directory: extension
+        timeout-minutes: 40
+        run: npm run build:vsix -- --target "${{ matrix.target }}"
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: observability-studio-vsix-${{ matrix.target }}
+          path: extension/*.vsix
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: build-vsix
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            observer/client/package-lock.json
+            extension/package-lock.json
+
+      - name: Pin npm version
+        run: |
+          npm i -g npm@11.6.2
+          npm --version
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: observer/go.mod
+          cache-dependency-path: observer/go.sum
+
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: observability-studio-vsix-*
+          path: extension
+          merge-multiple: true
+
+      - name: Install extension dependencies
+        working-directory: extension
+        run: npm ci
+
       - name: Prepare release assets
         timeout-minutes: 10
         run: make release-prep
-
-      - name: Build VSIX
-        timeout-minutes: 20
-        run: make build-vsix
 
       - uses: goreleaser/goreleaser-action@v6
         with:
@@ -53,3 +115,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${GITHUB_REF_NAME}" extension/*.vsix --clobber
+
+      - name: Publish VSIX to Marketplace
+        id: publish_marketplace
+        continue-on-error: true
+        working-directory: extension
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          set -euo pipefail
+          failures=0
+          ls -1 *.vsix
+          for vsix in *.vsix; do
+            echo "Publishing ${vsix} to VS Code Marketplace"
+            if ! npx @vscode/vsce publish --packagePath "${vsix}"; then
+              echo "::error::Failed to publish ${vsix} to the VS Code Marketplace"
+              failures=1
+            fi
+          done
+          exit "${failures}"
+
+      - name: Warn on Marketplace publish failure
+        if: steps.publish_marketplace.outcome == 'failure'
+        run: echo "::warning::Marketplace publish failed after the GitHub release completed. Upload the generated VSIX packages manually."

--- a/extension/build-observer.js
+++ b/extension/build-observer.js
@@ -2,13 +2,40 @@ const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
 
-function getBuildPaths(extensionRoot = __dirname) {
+function normalizeGoos(platform) {
+	if (platform === "win32") {
+		return "windows";
+	}
+	return platform;
+}
+
+function normalizeGoarch(arch) {
+	if (arch === "x64") {
+		return "amd64";
+	}
+	return arch;
+}
+
+function observerBinaryName(goos) {
+	return goos === "windows" ? "obstudio.exe" : "obstudio";
+}
+
+function resolveBuildTarget(env = process.env) {
+	const goos = env.OBSTUDIO_GOOS || normalizeGoos(process.platform);
+	const goarch = env.OBSTUDIO_GOARCH || normalizeGoarch(process.arch);
+	const binaryName = env.OBSTUDIO_OBSERVER_BINARY_NAME || observerBinaryName(goos);
+
+	return { binaryName, goarch, goos };
+}
+
+function getBuildPaths(extensionRoot = __dirname, env = process.env) {
 	const repoRoot = path.resolve(extensionRoot, "..");
 	const observerRoot = path.join(repoRoot, "observer");
 	const observerOutDir = path.join(extensionRoot, "dist", "observer");
-	const observerOutBinary = path.join(observerOutDir, "obstudio");
+	const target = resolveBuildTarget(env);
+	const observerOutBinary = path.join(observerOutDir, target.binaryName);
 
-	return { repoRoot, observerRoot, observerOutDir, observerOutBinary };
+	return { repoRoot, observerRoot, observerOutDir, observerOutBinary, target };
 }
 
 function resetObserverOutputDirs(paths) {
@@ -47,6 +74,11 @@ function buildObserverGo(paths) {
 
 	execFileSync("go", ["build", "-o", paths.observerOutBinary, "./cmd/obstudio"], {
 		cwd: paths.observerRoot,
+		env: {
+			...process.env,
+			GOARCH: paths.target.goarch,
+			GOOS: paths.target.goos,
+		},
 		stdio: "inherit",
 	});
 
@@ -57,7 +89,16 @@ function buildObserverGo(paths) {
 function bundleWeaverRuntime(paths) {
 	console.log("Bundling Weaver validator runtime...");
 
-	execFileSync("go", ["run", "./cmd/fetch-weaver", "-output", paths.observerOutDir], {
+	execFileSync("go", [
+		"run",
+		"./cmd/fetch-weaver",
+		"-goos",
+		paths.target.goos,
+		"-goarch",
+		paths.target.goarch,
+		"-output",
+		paths.observerOutDir,
+	], {
 		cwd: paths.observerRoot,
 		stdio: "inherit",
 	});
@@ -81,6 +122,7 @@ if (require.main === module) {
 
 module.exports = {
 	getBuildPaths,
+	resolveBuildTarget,
 	resetObserverOutputDirs,
 	stageSkills,
 	buildClientAssets,

--- a/extension/build-vsix.js
+++ b/extension/build-vsix.js
@@ -8,6 +8,12 @@ const REPOSITORY_ROOT_URL = "https://github.com/signalfx/obstudio";
 const EXTENSION_SUBDIRECTORY = "extension";
 const MARKETPLACE_BASE_CONTENT_URL = `${REPOSITORY_ROOT_URL}/blob/main/${EXTENSION_SUBDIRECTORY}`;
 const MARKETPLACE_BASE_IMAGES_URL = `${REPOSITORY_ROOT_URL}/raw/main/${EXTENSION_SUBDIRECTORY}`;
+const SUPPORTED_VSCODE_TARGETS = {
+	"darwin-arm64": { binaryName: "obstudio", goarch: "arm64", goos: "darwin" },
+	"darwin-x64": { binaryName: "obstudio", goarch: "amd64", goos: "darwin" },
+	"linux-x64": { binaryName: "obstudio", goarch: "amd64", goos: "linux" },
+	"win32-x64": { binaryName: "obstudio.exe", goarch: "amd64", goos: "windows" },
+};
 
 function normalizeReleaseVersion(rawVersion) {
 	const trimmed = String(rawVersion ?? "").trim();
@@ -75,6 +81,46 @@ function resolveReleaseVersion({
 	return normalizeReleaseVersion(gitTag);
 }
 
+function parseVsceTarget(extraArgs = []) {
+	for (let index = 0; index < extraArgs.length; index += 1) {
+		const value = extraArgs[index];
+		if (value === "--target") {
+			return extraArgs[index + 1] ?? null;
+		}
+		if (value.startsWith("--target=")) {
+			return value.slice("--target=".length);
+		}
+	}
+	return null;
+}
+
+function resolveVsceTarget(target) {
+	if (target === null || target === undefined || target === "") {
+		return null;
+	}
+	const resolved = SUPPORTED_VSCODE_TARGETS[target];
+	if (!resolved) {
+		throw new Error(
+			`Unsupported VS Code target "${target}". Supported targets: ${Object.keys(SUPPORTED_VSCODE_TARGETS).join(", ")}`
+		);
+	}
+	return resolved;
+}
+
+function buildObserverEnvironment(env = process.env, target = null) {
+	const resolved = resolveVsceTarget(target);
+	if (!resolved) {
+		return env;
+	}
+	return {
+		...env,
+		OBSTUDIO_GOARCH: resolved.goarch,
+		OBSTUDIO_GOOS: resolved.goos,
+		OBSTUDIO_OBSERVER_BINARY_NAME: resolved.binaryName,
+		OBSTUDIO_VSCODE_TARGET: target,
+	};
+}
+
 function vsceCommand(extensionRoot = __dirname) {
 	const binName = process.platform === "win32" ? "vsce.cmd" : "vsce";
 	const command = path.join(extensionRoot, "node_modules", ".bin", binName);
@@ -99,11 +145,25 @@ function buildVsceArgs({ releaseVersion = null, extraArgs = [] } = {}) {
 	return args.concat(extraArgs);
 }
 
+function vsceExecOptions({
+	cwd,
+	env,
+} = {}) {
+	return {
+		cwd,
+		env,
+		encoding: "utf-8",
+		shell: process.platform === "win32",
+		stdio: ["ignore", "pipe", "pipe"],
+	};
+}
+
 function packageVsix({
 	extensionRoot = __dirname,
 	env = process.env,
 	extraArgs = [],
 } = {}) {
+	const target = parseVsceTarget(extraArgs);
 	const releaseVersion = resolveReleaseVersion({
 		env,
 		repoRoot: path.resolve(extensionRoot, ".."),
@@ -111,12 +171,10 @@ function packageVsix({
 	const output = execFileSync(vsceCommand(extensionRoot), buildVsceArgs({
 		releaseVersion,
 		extraArgs,
-	}), {
+	}), vsceExecOptions({
 		cwd: extensionRoot,
-		env,
-		encoding: "utf-8",
-		stdio: ["ignore", "pipe", "pipe"],
-	});
+		env: buildObserverEnvironment(env, target),
+	}));
 
 	return { output, releaseVersion };
 }
@@ -145,13 +203,18 @@ if (require.main === module) {
 }
 
 module.exports = {
+	buildObserverEnvironment,
 	buildVsceArgs,
 	gitExactTag,
 	MARKETPLACE_BASE_CONTENT_URL,
 	MARKETPLACE_BASE_IMAGES_URL,
 	normalizeReleaseVersion,
+	parseVsceTarget,
 	packageVsix,
 	releaseTagFromEnvironment,
 	resolveReleaseVersion,
+	resolveVsceTarget,
+	SUPPORTED_VSCODE_TARGETS,
 	vsceCommand,
+	vsceExecOptions,
 };

--- a/extension/package.json
+++ b/extension/package.json
@@ -128,8 +128,9 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "test:unit": "npm run compile-tests && node --test --experimental-test-coverage out/test/extension.test.js out/test/webview-html.test.js out/test/observer-lifecycle.test.js out/test/build-vsix.test.js",
+    "test:unit": "npm run compile-tests && node --test --experimental-test-coverage out/test/extension.test.js out/test/webview-html.test.js out/test/observer-lifecycle.test.js out/test/build-vsix.test.js out/test/startup-errors.test.js",
     "test:integration": "tsc --outDir out --rootDir src --module Node16 --target ES2022 --strict --skipLibCheck --esModuleInterop src/test/extension-integration.test.ts && node --test out/test/extension-integration.test.js",
+    "test:integration:smoke": "tsc --outDir out --rootDir src --module Node16 --target ES2022 --strict --skipLibCheck --esModuleInterop src/test/extension-integration.test.ts && node --test --test-name-pattern=\"installed VSIX smoke test\" out/test/extension-integration.test.js",
     "test:host": "npm run compile-tests && npm run compile && vscode-test --run out/test/extension-vscode.test.js --fail-zero --timeout 30000",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:host",
     "test": "vscode-test"

--- a/extension/src/backend.ts
+++ b/extension/src/backend.ts
@@ -62,13 +62,27 @@ export function observerPortFromUrl(baseUrl: string): number | undefined {
 }
 
 export function resolveBackend(extensionPath: string): ObserverBackend {
-	const binary = path.join(extensionPath, 'dist', 'observer', 'obstudio');
+	const candidates = process.platform === 'win32'
+		? ['obstudio.exe', 'obstudio']
+		: ['obstudio', 'obstudio.exe'];
 
-	if (fs.existsSync(binary)) {
+	for (const candidate of candidates) {
+		const binary = path.join(extensionPath, 'dist', 'observer', candidate);
+		if (!fs.existsSync(binary)) {
+			continue;
+		}
+
 		const env: Record<string, string> = {};
-		const weaver = path.join(path.dirname(binary), 'weaver');
-		if (fs.existsSync(weaver)) {
+		const weaverCandidates = path.extname(binary) === '.exe'
+			? ['weaver.exe', 'weaver']
+			: ['weaver', 'weaver.exe'];
+		for (const weaverCandidate of weaverCandidates) {
+			const weaver = path.join(path.dirname(binary), weaverCandidate);
+			if (!fs.existsSync(weaver)) {
+				continue;
+			}
 			env.WEAVER_PATH = weaver;
+			break;
 		}
 		return {
 			args: [],
@@ -80,6 +94,6 @@ export function resolveBackend(extensionPath: string): ObserverBackend {
 	}
 
 	throw new Error(
-		`observer binary not found at ${binary}. Run 'npm run compile' in the extension directory.`,
+		`observer binary not found in ${path.join(extensionPath, 'dist', 'observer')}. Run 'npm run compile' in the extension directory.`,
 	);
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -32,6 +32,16 @@ import {
 	getStatusBarUpdate,
 	getErrorMessage,
 } from './webview-html';
+import {
+	describeObserverStartupFailure,
+	formatObserverProbeMismatchMessage,
+	formatObserverProbeUnavailableMessage,
+	formatPortConflictMessage,
+	getObserverProbeMismatchHint,
+	getObserverProbeUnavailableHint,
+	getObserverStartupHint,
+	type ObserverPortRole,
+} from './startup-errors';
 
 // Extension-global observer state. The extension hosts one local observer process
 // and optionally one WebView panel that embeds its UI.
@@ -99,6 +109,16 @@ type ObserverProbeResult =
 	| { health: ObserverHealth; status: 'ready' }
 	| { error: Error; status: 'unavailable' }
 	| { reason: string; status: 'mismatch' };
+
+type PortReservation = {
+	port: number;
+	role: ObserverPortRole;
+	settingName?: string;
+};
+
+type StartupHintCarrier = {
+	startupHint?: string;
+};
 
 const agentIntegrationSpecs: AgentIntegrationSpec[] = [
 	{
@@ -466,30 +486,48 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 		}
 
 		if (existingObserver.status === 'mismatch') {
-			throw new Error(
-				`Cannot use ${managedObserverBaseUrl}: ${existingObserver.reason}. ` +
+			appendObserverOutputLine(`Observer health probe mismatch at ${managedObserverBaseUrl}: ${existingObserver.reason}`);
+			logObserverLifecycle(`Run ${runId}: existing service on ${managedObserverBaseUrl} did not match observer health: ${existingObserver.reason}`);
+			const wrappedError = new Error(
+				`Cannot use ${managedObserverBaseUrl}: ${formatObserverProbeMismatchMessage(managedObserverBaseUrl, 'managed-reuse')} ` +
 				`Stop the conflicting service or configure observability-studio.${managedObserverPortSetting} ` +
 				`or observability-studio.${sharedObserverUrlSetting}.`,
 			);
+			Object.assign(wrappedError, { startupHint: getObserverProbeMismatchHint('managed-reuse') });
+			throw wrappedError;
 		}
 
 		const backend = resolveBackend(context.extensionPath);
 		let observerPort: number;
 		try {
-			observerPort = await ensurePortAvailable(managedPort);
+			observerPort = await ensurePortAvailable({
+				port: managedPort,
+				role: 'Observer UI',
+				settingName: managedObserverPortSetting,
+			});
 		} catch (error) {
-			throw new Error(
+			const wrappedError = new Error(
 				`Cannot use ${managedObserverBaseUrl}: ${getErrorMessage(error)} ` +
 				`Configure observability-studio.${managedObserverPortSetting} or ` +
 				`observability-studio.${sharedObserverUrlSetting}.`,
 			);
+			if (typeof error === 'object' && error !== null && typeof (error as StartupHintCarrier).startupHint === 'string') {
+				Object.assign(wrappedError, { startupHint: (error as StartupHintCarrier).startupHint });
+			}
+			throw wrappedError;
 		}
 		logObserverLifecycle(`Run ${runId}: reserved UI port ${observerPort}.`);
 		assertObserverRunCurrent(observerLifecycleState, runId);
 
-		const otlpHttpPort = await ensurePortAvailable(observerOtlpHttpPort);
+		const otlpHttpPort = await ensurePortAvailable({
+			port: observerOtlpHttpPort,
+			role: 'OTLP/HTTP',
+		});
 		assertObserverRunCurrent(observerLifecycleState, runId);
-		const otlpGrpcPort = await ensurePortAvailable(observerOtlpGrpcPort);
+		const otlpGrpcPort = await ensurePortAvailable({
+			port: observerOtlpGrpcPort,
+			role: 'OTLP/gRPC',
+		});
 		assertObserverRunCurrent(observerLifecycleState, runId);
 		logObserverLifecycle(`Run ${runId}: OTLP ports ready (HTTP ${otlpHttpPort}, gRPC ${otlpGrpcPort}).`);
 		observerUsesSharedServer = false;
@@ -499,20 +537,31 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 		appendObserverOutputLine(`OTLP/HTTP receiver listening on ${observerOtlpHttpEndpoint}`);
 		appendObserverOutputLine(`OTLP/gRPC receiver listening on ${observerOtlpGrpcEndpoint}`);
 
-		startedProcess = cp.spawn(backend.command, backend.args, {
-			cwd: backend.cwd,
-			env: {
-				...process.env,
-				...backend.env,
-				HOST: managedObserverHost,
-				OTLP_HOST: managedObserverHost,
-				OTLP_PORT: String(otlpHttpPort),
-				OTLP_HTTP_PORT: String(otlpHttpPort),
-				OTLP_GRPC_PORT: String(otlpGrpcPort),
-				PORT: String(observerPort),
-			},
-			stdio: ['ignore', 'pipe', 'pipe'],
-		});
+		try {
+			startedProcess = cp.spawn(backend.command, backend.args, {
+				cwd: backend.cwd,
+				env: {
+					...process.env,
+					...backend.env,
+					HOST: managedObserverHost,
+					OTLP_HOST: managedObserverHost,
+					OTLP_PORT: String(otlpHttpPort),
+					OTLP_HTTP_PORT: String(otlpHttpPort),
+					OTLP_GRPC_PORT: String(otlpGrpcPort),
+					PORT: String(observerPort),
+				},
+				stdio: ['ignore', 'pipe', 'pipe'],
+			});
+		} catch (error) {
+			const startupFailure = describeObserverStartupFailure(error as NodeJS.ErrnoException, {
+				arch: process.arch,
+				binaryPath: backend.command,
+				platform: process.platform,
+			});
+			const wrappedError = new Error(startupFailure.message);
+			Object.assign(wrappedError, { startupHint: startupFailure.hint });
+			throw wrappedError;
+		}
 		assertObserverRunCurrent(observerLifecycleState, runId);
 		logObserverLifecycle(`Run ${runId}: spawned observer PID ${startedProcess.pid ?? 'unknown'}.`);
 
@@ -540,16 +589,22 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 		});
 
 		startedProcess.on('error', (error) => {
-			appendObserverOutputLine(`Failed to start observer: ${error.message}`);
-			logObserverLifecycle(`Run ${runId}: observer process error: ${error.message}`);
+			const startupFailure = describeObserverStartupFailure(error, {
+				arch: process.arch,
+				binaryPath: backend.command,
+				platform: process.platform,
+			});
+			const startupMessage = startupFailure.message;
+			appendObserverOutputLine(`Failed to start observer: ${startupMessage}`);
+			logObserverLifecycle(`Run ${runId}: observer process error: ${startupMessage}`);
 			if (observerProcess === startedProcess) {
 				observerProcess = undefined;
 			}
-			if (failObserverStart(observerLifecycleState, runId, error.message)) {
+			if (failObserverStart(observerLifecycleState, runId, startupMessage, startupFailure.hint)) {
 				observerBaseUrl = undefined;
 				observerUsesSharedServer = false;
 				syncObserverUi();
-				void vscode.window.showErrorMessage(`Splunk Observability Studio failed to start observer: ${error.message}`);
+				void vscode.window.showErrorMessage(`Splunk Observability Studio failed to start observer: ${startupMessage}`);
 			}
 		});
 
@@ -579,10 +634,17 @@ async function startObserver(context: vscode.ExtensionContext): Promise<void> {
 			observerProcess = undefined;
 		}
 		terminateObserverProcess(startedProcess, 'SIGTERM');
-		if (failObserverStart(observerLifecycleState, runId, getErrorMessage(error))) {
+		const startupMessage = getErrorMessage(error);
+		const startupHint = typeof error === 'object'
+			&& error !== null
+			&& 'startupHint' in error
+			&& typeof (error as { startupHint?: unknown }).startupHint === 'string'
+			? (error as { startupHint: string }).startupHint
+			: getObserverStartupHint('generic');
+		if (failObserverStart(observerLifecycleState, runId, startupMessage, startupHint)) {
 			observerBaseUrl = undefined;
 			observerUsesSharedServer = false;
-			logObserverLifecycle(`Run ${runId}: startup failed: ${getErrorMessage(error)}`);
+			logObserverLifecycle(`Run ${runId}: startup failed: ${startupMessage}`);
 			syncObserverUi();
 		}
 		throw error;
@@ -733,7 +795,7 @@ function refreshObserverPanel(): void {
 		return;
 	}
 
-	const renderKey = `${observerLifecycleState.status}:${observerLifecycleState.port ?? 'none'}:${observerLifecycleState.startupError ?? 'none'}:${observerBaseUrl ?? 'none'}:${observerUsesSharedServer ? 'shared' : 'local'}`;
+	const renderKey = `${observerLifecycleState.status}:${observerLifecycleState.port ?? 'none'}:${observerLifecycleState.startupError ?? 'none'}:${observerLifecycleState.startupHint ?? 'none'}:${observerBaseUrl ?? 'none'}:${observerUsesSharedServer ? 'shared' : 'local'}`;
 	if (renderKey !== lastObserverPanelRenderKey) {
 		logObserverLifecycle(`Rendering observer panel state ${renderKey}.`);
 		lastObserverPanelRenderKey = renderKey;
@@ -748,6 +810,7 @@ function refreshObserverPanel(): void {
 		case 'error':
 			observerPanel.webview.html = getObserverErrorWebviewHtml(
 				observerLifecycleState.startupError ?? 'Observer could not start.',
+				observerLifecycleState.startupHint ?? getObserverStartupHint('generic'),
 			);
 			return;
 		case 'starting':
@@ -763,29 +826,32 @@ function refreshObserverPanel(): void {
 // Port helpers
 // ---------------------------------------------------------------------------
 
-async function ensurePortAvailable(port: number): Promise<number> {
+async function ensurePortAvailable(reservation: PortReservation): Promise<number> {
 	return new Promise((resolve, reject) => {
 		const server = net.createServer();
 		server.once('error', (error: NodeJS.ErrnoException) => {
 			if (error.code === 'EADDRINUSE') {
-				void identifyPortOwner(port).then((owner) => {
-					const detail = owner
-						? `Port ${port} is already in use by "${owner}".`
-						: `Port ${port} is already in use.`;
+				void identifyPortOwner(reservation.port).then((owner) => {
+					const detail = formatPortConflictMessage({
+						owner,
+						port: reservation.port,
+						role: reservation.role,
+						settingName: reservation.settingName,
+					});
 					logObserverLifecycle(detail);
-					reject(new Error(
-						`${detail} Stop the other process or run: kill $(lsof -ti :${port})`
-					));
+					const error = new Error(detail);
+					Object.assign(error, { startupHint: getObserverStartupHint('port-conflict') });
+					reject(error);
 				});
 				return;
 			}
-			logObserverLifecycle(`Port check failed for ${port}: ${error.message}`);
+			logObserverLifecycle(`Port check failed for ${reservation.role} port ${reservation.port}: ${error.message}`);
 			reject(error);
 		});
-		server.listen(port, '127.0.0.1', () => {
+		server.listen(reservation.port, '127.0.0.1', () => {
 			server.close((error) => {
 				if (error) { reject(error); return; }
-				resolve(port);
+				resolve(reservation.port);
 			});
 		});
 	});
@@ -822,8 +888,14 @@ async function waitForObserverReady(
 		switch (probe.status) {
 			case 'ready':
 				return;
-			case 'mismatch':
-				throw new Error(probe.reason);
+			case 'mismatch': {
+				appendObserverOutputLine(`Observer health probe mismatch at ${baseUrl}: ${probe.reason}`);
+				logObserverLifecycle(`Run ${runId}: observer health probe mismatch at ${baseUrl}: ${probe.reason}`);
+				const mismatchContext = observerUsesSharedServer ? 'shared-reuse' : 'startup-reuse';
+				const wrappedError = new Error(formatObserverProbeMismatchMessage(baseUrl, mismatchContext));
+				Object.assign(wrappedError, { startupHint: getObserverProbeMismatchHint(mismatchContext) });
+				throw wrappedError;
+			}
 			case 'unavailable':
 				lastError = probe.error;
 				if (!observerUsesSharedServer && observerProcess === undefined) {
@@ -834,9 +906,19 @@ async function waitForObserverReady(
 	}
 
 	if (lastError !== undefined) {
-		logObserverLifecycle(`Run ${runId}: readiness check timed out for ${baseUrl}: ${getErrorMessage(lastError)}`);
+		const rawProbeDetail = getErrorMessage(lastError);
+		appendObserverOutputLine(`Observer health probe unavailable at ${baseUrl}: ${rawProbeDetail}`);
+		logObserverLifecycle(`Run ${runId}: observer readiness failed for ${baseUrl}: ${rawProbeDetail}`);
+		const unavailableContext = observerUsesSharedServer ? 'shared-reuse' : 'startup';
+		const wrappedError = new Error(formatObserverProbeUnavailableMessage(baseUrl, unavailableContext));
+		Object.assign(wrappedError, { startupHint: getObserverProbeUnavailableHint(unavailableContext) });
+		throw wrappedError;
 	}
-	throw lastError ?? new Error(`Observer did not become ready in time at ${baseUrl}.`);
+	const unavailableContext = observerUsesSharedServer ? 'shared-reuse' : 'startup';
+	logObserverLifecycle(`Run ${runId}: observer readiness ended without a probe result at ${baseUrl}.`);
+	const wrappedError = new Error(formatObserverProbeUnavailableMessage(baseUrl, unavailableContext));
+	Object.assign(wrappedError, { startupHint: getObserverProbeUnavailableHint(unavailableContext) });
+	throw wrappedError;
 }
 
 async function probeObserver(

--- a/extension/src/observer-lifecycle.ts
+++ b/extension/src/observer-lifecycle.ts
@@ -5,6 +5,7 @@ export interface ObserverLifecycleState {
 	currentRunId: number;
 	port: number | undefined;
 	startupError: string | undefined;
+	startupHint: string | undefined;
 	status: ObserverLifecycleStatus;
 }
 
@@ -21,6 +22,7 @@ export function createObserverLifecycleState(): ObserverLifecycleState {
 		currentRunId: 0,
 		port: undefined,
 		startupError: undefined,
+		startupHint: undefined,
 		status: 'stopped',
 	};
 }
@@ -32,6 +34,7 @@ export function beginObserverStart(state: ObserverLifecycleState): number {
 	state.currentRunId = runId;
 	state.port = undefined;
 	state.startupError = undefined;
+	state.startupHint = undefined;
 	state.status = 'starting';
 
 	return runId;
@@ -42,6 +45,7 @@ export function stopObserverRun(state: ObserverLifecycleState): void {
 	state.currentRunId += 1;
 	state.port = undefined;
 	state.startupError = undefined;
+	state.startupHint = undefined;
 	state.status = 'stopped';
 }
 
@@ -66,6 +70,7 @@ export function completeObserverStart(
 
 	state.port = port;
 	state.startupError = undefined;
+	state.startupHint = undefined;
 	state.status = 'running';
 
 	return true;
@@ -75,6 +80,7 @@ export function failObserverStart(
 	state: ObserverLifecycleState,
 	runId: number,
 	errorMessage: string,
+	startupHint?: string,
 ): boolean {
 	if (!isObserverRunCurrent(state, runId)) {
 		return false;
@@ -83,6 +89,7 @@ export function failObserverStart(
 	state.activeRunId = undefined;
 	state.port = undefined;
 	state.startupError = errorMessage;
+	state.startupHint = startupHint;
 	state.status = 'error';
 
 	return true;
@@ -96,6 +103,7 @@ export function finishObserverRun(state: ObserverLifecycleState, runId: number):
 	state.activeRunId = undefined;
 	state.port = undefined;
 	state.startupError = undefined;
+	state.startupHint = undefined;
 	state.status = 'stopped';
 
 	return true;

--- a/extension/src/startup-errors.ts
+++ b/extension/src/startup-errors.ts
@@ -1,0 +1,159 @@
+export type ObserverPortRole = 'Observer UI' | 'OTLP/HTTP' | 'OTLP/gRPC';
+export type ObserverStartupFailureKind = 'generic' | 'not-executable' | 'port-conflict' | 'wrong-platform';
+export type ObserverStartupFailure = {
+	hint: string;
+	kind: ObserverStartupFailureKind;
+	message: string;
+};
+
+export type PortConflictDetails = {
+	owner?: string;
+	port: number;
+	role: ObserverPortRole;
+	settingName?: string;
+};
+
+export type ObserverProbeMismatchContext = 'managed-reuse' | 'shared-reuse' | 'startup-reuse';
+export type ObserverProbeUnavailableContext = 'shared-reuse' | 'startup';
+
+const observerOwnerPattern = /\bobstudio(?:\.exe)?\b/i;
+
+export function currentVsCodeTarget(
+	platform: NodeJS.Platform | string = process.platform,
+	arch: string = process.arch,
+): string {
+	if (platform === 'darwin' && arch === 'arm64') {
+		return 'darwin-arm64';
+	}
+	if (platform === 'darwin' && arch === 'x64') {
+		return 'darwin-x64';
+	}
+	if (platform === 'linux' && arch === 'x64') {
+		return 'linux-x64';
+	}
+	if (platform === 'win32' && arch === 'x64') {
+		return 'win32-x64';
+	}
+	return `${platform}-${arch}`;
+}
+
+export function formatPortConflictMessage(details: PortConflictDetails): string {
+	const ownerText = details.owner
+		? ` is already in use by "${details.owner}".`
+		: ' is already in use.';
+	const staleObserver = details.owner !== undefined && observerOwnerPattern.test(details.owner);
+	const staleObserverHint = staleObserver
+		? ' Another Splunk Observability Studio instance or a stale observer process may still be running.'
+		: '';
+
+	if (staleObserver) {
+		const resolution = details.settingName
+			? ` Close the other VS Code window or terminate the stale observer process, or change observability-studio.${details.settingName}.`
+			: ' Close the other VS Code window or terminate the stale observer process before restarting Splunk Observability Studio.';
+		return `${details.role} port ${details.port}${ownerText}${staleObserverHint}${resolution}`;
+	}
+
+	const resolution = details.settingName
+		? ` Stop the other process or change observability-studio.${details.settingName}.`
+		: ` Stop the other process that is using the fixed ${details.role} endpoint before starting Splunk Observability Studio.`;
+	return `${details.role} port ${details.port}${ownerText}${resolution}`;
+}
+
+export function getObserverStartupHint(kind: ObserverStartupFailureKind = 'generic'): string {
+	switch (kind) {
+		case 'port-conflict':
+			return 'Use the Command Palette (Cmd+Shift+P) and run Splunk Observability Studio: Restart Observer after freeing the conflicting port.';
+		case 'wrong-platform':
+			return 'Install the platform-specific extension package for this machine or configure observability-studio.sharedObserverUrl, then run Splunk Observability Studio: Restart Observer.';
+		case 'not-executable':
+			return 'Reinstall the extension or restore execute permissions, then run Splunk Observability Studio: Restart Observer.';
+		case 'generic':
+			return 'Open the Splunk Observability Studio output log, fix the startup problem, then run Splunk Observability Studio: Restart Observer.';
+	}
+}
+
+export function formatObserverProbeMismatchMessage(
+	baseUrl: string,
+	context: ObserverProbeMismatchContext,
+): string {
+	switch (context) {
+		case 'managed-reuse':
+			return `the service already using ${baseUrl} is not Splunk Observability Studio.`;
+		case 'shared-reuse':
+			return `the configured shared observer at ${baseUrl} did not respond like Splunk Observability Studio. Verify observability-studio.sharedObserverUrl.`;
+		case 'startup-reuse':
+			return `a different service responded at ${baseUrl} while Splunk Observability Studio was starting.`;
+	}
+}
+
+export function getObserverProbeMismatchHint(context: ObserverProbeMismatchContext): string {
+	switch (context) {
+		case 'managed-reuse':
+		case 'startup-reuse':
+			return getObserverStartupHint('port-conflict');
+		case 'shared-reuse':
+			return 'Verify observability-studio.sharedObserverUrl, make sure the shared observer is reachable, then run Splunk Observability Studio: Restart Observer.';
+	}
+}
+
+export function formatObserverProbeUnavailableMessage(
+	baseUrl: string,
+	context: ObserverProbeUnavailableContext,
+): string {
+	switch (context) {
+		case 'shared-reuse':
+			return `could not reach the configured shared observer at ${baseUrl}. Verify observability-studio.sharedObserverUrl and make sure Splunk Observability Studio is running there.`;
+		case 'startup':
+			return `Splunk Observability Studio did not become ready at ${baseUrl}.`;
+	}
+}
+
+export function getObserverProbeUnavailableHint(context: ObserverProbeUnavailableContext): string {
+	switch (context) {
+		case 'shared-reuse':
+			return 'Verify observability-studio.sharedObserverUrl, make sure the shared observer is reachable, then run Splunk Observability Studio: Restart Observer.';
+		case 'startup':
+			return getObserverStartupHint('generic');
+	}
+}
+
+export function describeObserverStartupFailure(
+	error: NodeJS.ErrnoException | Error | string,
+	options: {
+		arch?: string;
+		binaryPath?: string;
+		platform?: NodeJS.Platform | string;
+	} = {},
+): ObserverStartupFailure {
+	const errorMessage = error instanceof Error ? error.message : String(error);
+	const code = typeof error === 'object' && error !== null && 'code' in error
+		? String((error as NodeJS.ErrnoException).code)
+		: undefined;
+
+	if (code === 'ENOEXEC' || /\bENOEXEC\b/i.test(errorMessage)) {
+		const target = currentVsCodeTarget(options.platform, options.arch);
+		const binaryPath = options.binaryPath ?? 'the bundled observer binary';
+		return {
+			hint: getObserverStartupHint('wrong-platform'),
+			kind: 'wrong-platform',
+			message: `${binaryPath} cannot run on ${target} (${errorMessage}). ` +
+				'The installed extension package likely contains a binary built for a different operating system or CPU architecture. ' +
+				`Install the ${target} extension package or configure observability-studio.sharedObserverUrl.`,
+		};
+	}
+
+	if (code === 'EACCES' || /\bEACCES\b/i.test(errorMessage)) {
+		const binaryPath = options.binaryPath ?? 'the bundled observer binary';
+		return {
+			hint: getObserverStartupHint('not-executable'),
+			kind: 'not-executable',
+			message: `${binaryPath} is not executable (${errorMessage}). Reinstall the extension or restore execute permissions.`,
+		};
+	}
+
+	return {
+		hint: getObserverStartupHint('generic'),
+		kind: 'generic',
+		message: errorMessage,
+	};
+}

--- a/extension/src/test/build-vsix.test.ts
+++ b/extension/src/test/build-vsix.test.ts
@@ -2,23 +2,44 @@ import * as assert from 'node:assert/strict';
 import test from 'node:test';
 
 const {
+	buildObserverEnvironment,
 	buildVsceArgs,
 	normalizeReleaseVersion,
 	MARKETPLACE_BASE_CONTENT_URL,
 	MARKETPLACE_BASE_IMAGES_URL,
+	parseVsceTarget,
 	releaseTagFromEnvironment,
 	resolveReleaseVersion,
+	resolveVsceTarget,
+	vsceExecOptions,
 } = require('../../build-vsix.js') as {
+	buildObserverEnvironment: (env?: NodeJS.ProcessEnv, target?: string | null) => NodeJS.ProcessEnv;
 	buildVsceArgs: (options?: { releaseVersion?: string | null; extraArgs?: string[] }) => string[];
 	MARKETPLACE_BASE_CONTENT_URL: string;
 	MARKETPLACE_BASE_IMAGES_URL: string;
 	normalizeReleaseVersion: (value: string) => string;
+	parseVsceTarget: (extraArgs?: string[]) => string | null;
 	releaseTagFromEnvironment: (env?: NodeJS.ProcessEnv) => string;
 	resolveReleaseVersion: (options?: {
 		env?: NodeJS.ProcessEnv;
 		repoRoot?: string;
 		getExactTag?: (repoRoot?: string) => string;
 	}) => string | null;
+	resolveVsceTarget: (target?: string | null) => null | {
+		binaryName: string;
+		goarch: string;
+		goos: string;
+	};
+	vsceExecOptions: (options?: {
+		cwd?: string;
+		env?: NodeJS.ProcessEnv;
+	}) => {
+		cwd?: string;
+		encoding: string;
+		env?: NodeJS.ProcessEnv;
+		shell: boolean;
+		stdio: [string, string, string];
+	};
 };
 
 test('normalizeReleaseVersion strips tag prefixes and extracts the stable core from suffixed tags', () => {
@@ -97,6 +118,51 @@ test('resolveReleaseVersion returns null when there is no release tag', () => {
 		env: {},
 		getExactTag: () => '',
 	}), null);
+});
+
+test('parseVsceTarget extracts the explicit target argument', () => {
+	assert.equal(parseVsceTarget(['--target', 'darwin-arm64', '--no-dependencies']), 'darwin-arm64');
+	assert.equal(parseVsceTarget(['--target=linux-x64']), 'linux-x64');
+	assert.equal(parseVsceTarget(['--no-dependencies']), null);
+});
+
+test('resolveVsceTarget returns the Go build mapping for supported targets', () => {
+	assert.deepEqual(resolveVsceTarget('darwin-arm64'), {
+		binaryName: 'obstudio',
+		goarch: 'arm64',
+		goos: 'darwin',
+	});
+	assert.deepEqual(resolveVsceTarget('win32-x64'), {
+		binaryName: 'obstudio.exe',
+		goarch: 'amd64',
+		goos: 'windows',
+	});
+});
+
+test('resolveVsceTarget rejects unsupported targets', () => {
+	assert.throws(() => resolveVsceTarget('linux-arm64'), /Unsupported VS Code target/);
+});
+
+test('buildObserverEnvironment exports the cross-compile target for prepublish builds', () => {
+	const env = buildObserverEnvironment({ PATH: '/usr/bin' }, 'darwin-x64');
+	assert.equal(env.OBSTUDIO_GOOS, 'darwin');
+	assert.equal(env.OBSTUDIO_GOARCH, 'amd64');
+	assert.equal(env.OBSTUDIO_OBSERVER_BINARY_NAME, 'obstudio');
+	assert.equal(env.OBSTUDIO_VSCODE_TARGET, 'darwin-x64');
+	assert.equal(env.PATH, '/usr/bin');
+});
+
+test('vsceExecOptions enables shell execution on Windows cmd shims only', () => {
+	const options = vsceExecOptions({
+		cwd: '/tmp/extension',
+		env: { PATH: '/usr/bin' },
+	});
+
+	assert.equal(options.cwd, '/tmp/extension');
+	assert.equal(options.env?.PATH, '/usr/bin');
+	assert.equal(options.encoding, 'utf-8');
+	assert.deepEqual(options.stdio, ['ignore', 'pipe', 'pipe']);
+	assert.equal(options.shell, process.platform === 'win32');
 });
 
 test('buildVsceArgs adds release-version flags only when needed', () => {

--- a/extension/src/test/extension-integration.test.ts
+++ b/extension/src/test/extension-integration.test.ts
@@ -2,13 +2,19 @@ import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as http from 'node:http';
+import * as net from 'node:net';
+import * as os from 'node:os';
 import { execSync, execFileSync, spawn } from 'node:child_process';
 import test, { describe, it } from 'node:test';
+import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
+import { currentVsCodeTarget } from '../startup-errors';
 
 const extensionRoot = path.resolve(__dirname, '..', '..');
 const repoRoot = path.resolve(extensionRoot, '..');
+const nodeExecutable = process.execPath;
 
 interface TestContext {
+	ownsVsix?: boolean;
 	vsixFile?: string;
 }
 
@@ -26,6 +32,9 @@ type ExtensionPackage = {
 };
 
 function cleanup(context: TestContext): void {
+	if (context.ownsVsix === false) {
+		return;
+	}
 	if (context.vsixFile && fs.existsSync(context.vsixFile)) {
 		try {
 			fs.unlinkSync(context.vsixFile);
@@ -37,7 +46,11 @@ function cleanup(context: TestContext): void {
 
 /** Build VSIX once and return its path. Fails if @vscode/vsce is not installed locally. */
 function buildVsix(env: NodeJS.ProcessEnv = process.env): string {
-	const output = execSync('node build-vsix.js --no-dependencies', {
+	return buildVsixWithArgs([], env);
+}
+
+function buildVsixWithArgs(extraArgs: string[], env: NodeJS.ProcessEnv = process.env): string {
+	const output = execFileSync(nodeExecutable, ['build-vsix.js', '--no-dependencies', ...extraArgs], {
 		cwd: extensionRoot,
 		stdio: 'pipe',
 		timeout: 120_000,
@@ -50,13 +63,197 @@ function buildVsix(env: NodeJS.ProcessEnv = process.env): string {
 	return path.join(extensionRoot, vsixMatch[1]);
 }
 
+function resolvePrebuiltVsixFile(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const directPath = env.OBSTUDIO_PREBUILT_VSIX?.trim();
+	if (directPath) {
+		const candidate = path.isAbsolute(directPath)
+			? directPath
+			: path.resolve(extensionRoot, directPath);
+		assert.ok(fs.existsSync(candidate), `expected prebuilt VSIX at ${candidate}`);
+		return candidate;
+	}
+
+	const vsixDir = env.OBSTUDIO_PREBUILT_VSIX_DIR?.trim();
+	if (!vsixDir) {
+		return undefined;
+	}
+	const resolvedDir = path.isAbsolute(vsixDir)
+		? vsixDir
+		: path.resolve(extensionRoot, vsixDir);
+	assert.ok(fs.existsSync(resolvedDir), `expected prebuilt VSIX directory at ${resolvedDir}`);
+	const vsixFiles = fs.readdirSync(resolvedDir)
+		.filter((value) => value.endsWith('.vsix'))
+		.sort();
+	assert.equal(
+		vsixFiles.length,
+		1,
+		`expected exactly one prebuilt VSIX in ${resolvedDir}, found: ${vsixFiles.join(', ') || '(none)'}`,
+	);
+	return path.join(resolvedDir, vsixFiles[0]);
+}
+
+function currentVsixTarget(): string | undefined {
+	const target = currentVsCodeTarget();
+	return new Set(['darwin-arm64', 'darwin-x64', 'linux-x64', 'win32-x64']).has(target)
+		? target
+		: undefined;
+}
+
+function getPackagedObserverBinaryName(): string {
+	return process.platform === 'win32' ? 'obstudio.exe' : 'obstudio';
+}
+
+function getPackagedWeaverBinaryName(): string {
+	return process.platform === 'win32' ? 'weaver.exe' : 'weaver';
+}
+
+function findInstalledExtensionDir(extensionsDir: string): string {
+	const names = fs.readdirSync(extensionsDir);
+	const match = names.find((value) => value.startsWith('splunk.observability-studio-'));
+	assert.ok(match, `expected installed extension under ${extensionsDir}`);
+	return path.join(extensionsDir, match!);
+}
+
+async function getAvailablePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			if (address === null || typeof address === 'string') {
+				server.close(() => reject(new Error('Unable to allocate a test port.')));
+				return;
+			}
+			server.close((error) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(address.port);
+			});
+		});
+	});
+}
+
+async function terminateChild(child: ReturnType<typeof spawn>): Promise<void> {
+	if (child.exitCode !== null || child.killed) {
+		return;
+	}
+	child.kill();
+	await Promise.race([
+		new Promise<void>((resolve) => child.once('exit', () => resolve())),
+		new Promise<void>((resolve) => {
+			setTimeout(() => {
+				if (child.exitCode === null && !child.killed) {
+					child.kill('SIGKILL');
+				}
+				resolve();
+			}, 2_000);
+		}),
+	]);
+}
+
+async function waitFor<T>(
+	load: () => Promise<T>,
+	ready: (value: T) => boolean,
+	timeoutMs: number,
+): Promise<T> {
+	const deadline = Date.now() + timeoutMs;
+	let lastValue: T | undefined;
+	let lastError: unknown;
+
+	while (Date.now() < deadline) {
+		try {
+			lastValue = await load();
+			if (ready(lastValue)) {
+				return lastValue;
+			}
+			lastError = undefined;
+		} catch (error) {
+			lastError = error;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 200));
+	}
+
+	if (lastValue !== undefined) {
+		return lastValue;
+	}
+	if (lastError instanceof Error) {
+		throw lastError;
+	}
+	throw new Error('Timed out waiting for condition');
+}
+
+async function waitForHttpOrExit(url: string, child: ReturnType<typeof spawn>, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+
+	while (Date.now() < deadline) {
+		if (child.exitCode !== null || child.killed) {
+			throw new Error(`Observer exited before becoming ready at ${url}.`);
+		}
+
+		try {
+			await new Promise<void>((resolve, reject) => {
+				http.get(url, (response) => {
+					response.resume();
+					resolve();
+				}).on('error', reject);
+			});
+			return;
+		} catch (error) {
+			lastError = error;
+			await new Promise((resolve) => setTimeout(resolve, 200));
+		}
+	}
+
+	if (child.exitCode !== null || child.killed) {
+		throw new Error(`Observer exited before becoming ready at ${url}.`);
+	}
+	if (lastError instanceof Error) {
+		throw lastError;
+	}
+	throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function requestJson(url: string, options: {
+	body?: Buffer | string;
+	headers?: Record<string, string>;
+	method: 'DELETE' | 'GET' | 'POST';
+}): Promise<{ body: any; statusCode: number }> {
+	return new Promise((resolve, reject) => {
+		const request = http.request(url, {
+			method: options.method,
+			headers: options.headers,
+		}, (response) => {
+			let raw = '';
+			response.setEncoding('utf8');
+			response.on('data', (chunk) => {
+				raw += chunk;
+			});
+			response.on('end', () => {
+				const body = raw.length === 0 ? undefined : JSON.parse(raw);
+				resolve({
+					body,
+					statusCode: response.statusCode ?? 0,
+				});
+			});
+		});
+		request.on('error', reject);
+		if (options.body !== undefined) {
+			request.write(options.body);
+		}
+		request.end();
+	});
+}
+
 it('integration: buildObserverGo produces a binary', { timeout: 120_000 }, async (t) => {
 	const buildObserverPath = path.join(extensionRoot, 'build-observer.js');
 	assert.ok(fs.existsSync(buildObserverPath), 'build-observer.js should exist');
 
 	try {
 		// Run the build-observer.js script
-		execFileSync('node', [buildObserverPath], {
+		execFileSync(nodeExecutable, [buildObserverPath], {
 			cwd: extensionRoot,
 			stdio: 'pipe',
 			timeout: 120_000,
@@ -65,7 +262,7 @@ it('integration: buildObserverGo produces a binary', { timeout: 120_000 }, async
 		// Verify the binary was created
 		const binaryPath = path.join(extensionRoot, 'dist', 'observer', 'obstudio');
 		assert.ok(fs.existsSync(binaryPath), `Binary should exist at ${binaryPath}`);
-		const weaverPath = path.join(extensionRoot, 'dist', 'observer', 'weaver');
+		const weaverPath = path.join(extensionRoot, 'dist', 'observer', getPackagedWeaverBinaryName());
 		assert.ok(fs.existsSync(weaverPath), `Weaver runtime should exist at ${weaverPath}`);
 
 		// Verify it's executable
@@ -182,8 +379,8 @@ it('integration: VSIX contains observer binary', { timeout: 120_000 }, async () 
 			'VSIX should contain extension/dist/observer/obstudio binary'
 		);
 		assert.ok(
-			unzipOutput.includes('extension/dist/observer/weaver'),
-			'VSIX should contain extension/dist/observer/weaver runtime'
+			unzipOutput.includes(`extension/dist/observer/${getPackagedWeaverBinaryName()}`),
+			`VSIX should contain extension/dist/observer/${getPackagedWeaverBinaryName()} runtime`
 		);
 	} finally {
 		cleanup(context);
@@ -332,7 +529,7 @@ it('integration: binary serves client UI assets', { timeout: 180_000 }, async (t
 
 	const buildObserverPath = path.join(extensionRoot, 'build-observer.js');
 	try {
-		execFileSync('node', [buildObserverPath], {
+		execFileSync(nodeExecutable, [buildObserverPath], {
 			cwd: extensionRoot,
 			stdio: 'pipe',
 			timeout: 120_000,
@@ -405,7 +602,7 @@ it('integration: packaged binary enables validator when bundled weaver is presen
 	const binaryPath = path.join(extensionRoot, 'dist', 'observer', 'obstudio');
 	const buildObserverPath = path.join(extensionRoot, 'build-observer.js');
 	try {
-		execFileSync('node', [buildObserverPath], {
+		execFileSync(nodeExecutable, [buildObserverPath], {
 			cwd: extensionRoot,
 			stdio: 'pipe',
 			timeout: 120_000,
@@ -471,5 +668,190 @@ it('integration: packaged binary enables validator when bundled weaver is presen
 		assert.notEqual(summary.message, 'Validator unavailable', 'packaged binary should not report validator unavailable');
 	} finally {
 		child.kill();
+	}
+});
+
+it('integration: installed VSIX smoke test starts the packaged observer and accepts OTLP traces', { timeout: 240_000 }, async (t) => {
+	const target = currentVsixTarget();
+	if (!target) {
+		t.skip(`unsupported platform for VSIX smoke test: ${process.platform}/${process.arch}`);
+		return;
+	}
+
+	const context: TestContext = {};
+	let tempRoot = '';
+	let child: ReturnType<typeof spawn> | undefined;
+
+	try {
+		const prebuiltVsixFile = resolvePrebuiltVsixFile();
+		if (prebuiltVsixFile) {
+			context.ownsVsix = false;
+			context.vsixFile = prebuiltVsixFile;
+		} else {
+			try {
+				const vsixFile = buildVsixWithArgs(['--target', target]);
+				context.ownsVsix = true;
+				context.vsixFile = vsixFile;
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				if (
+					errorMessage.includes('go: command not found') ||
+					errorMessage.includes("'go' is not recognized")
+				) {
+					t.skip('Go toolchain not installed');
+					return;
+				}
+				throw error;
+			}
+		}
+
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-vsix-install-'));
+		const extensionsDir = path.join(tempRoot, 'extensions');
+		const userDataDir = path.join(tempRoot, 'user-data');
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		fs.mkdirSync(userDataDir, { recursive: true });
+
+		const vscodeExecutablePath = await downloadAndUnzipVSCode();
+		const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+		execFileSync(
+			cli,
+			[
+				...cliArgs,
+				'--install-extension',
+				context.vsixFile!,
+				'--extensions-dir',
+				extensionsDir,
+				'--user-data-dir',
+				userDataDir,
+				'--force',
+			],
+			{
+				encoding: 'utf-8',
+				shell: process.platform === 'win32',
+				stdio: 'pipe',
+				timeout: 120_000,
+			},
+		);
+
+		const installedExtensionDir = findInstalledExtensionDir(extensionsDir);
+		const binaryPath = path.join(
+			installedExtensionDir,
+			'dist',
+			'observer',
+			getPackagedObserverBinaryName(),
+		);
+		assert.ok(fs.existsSync(binaryPath), `installed observer binary should exist at ${binaryPath}`);
+		const weaverPath = path.join(
+			installedExtensionDir,
+			'dist',
+			'observer',
+			getPackagedWeaverBinaryName(),
+		);
+		assert.ok(fs.existsSync(weaverPath), `installed weaver runtime should exist at ${weaverPath}`);
+
+		const port = await getAvailablePort();
+		const otlpGrpcPort = await getAvailablePort();
+		const otlpHttpPort = await getAvailablePort();
+		const baseUrl = `http://127.0.0.1:${port}`;
+		const otlpHttpUrl = `http://127.0.0.1:${otlpHttpPort}`;
+
+		child = spawn(binaryPath, [], {
+			env: {
+				...process.env,
+				PORT: String(port),
+				OTLP_GRPC_PORT: String(otlpGrpcPort),
+				OTLP_HTTP_PORT: String(otlpHttpPort),
+			},
+			stdio: 'pipe',
+		});
+
+		await waitForHttpOrExit(`${baseUrl}/api/health`, child, 10_000);
+
+		const health = await requestJson(`${baseUrl}/api/health`, { method: 'GET' });
+		assert.equal(health.statusCode, 200);
+		assert.equal(health.body.kind, 'obstudio');
+		assert.equal(health.body.endpoints.otlpHttp, otlpHttpUrl);
+		assert.equal(health.body.endpoints.otlpGrpc, `127.0.0.1:${otlpGrpcPort}`);
+
+		const clearResponse = await requestJson(`${baseUrl}/api/data`, { method: 'DELETE' });
+		assert.equal(clearResponse.statusCode, 200);
+
+		const tracePayload = JSON.stringify({
+			resourceSpans: [
+				{
+					resource: {
+						attributes: [
+							{
+								key: 'service.name',
+								value: {
+									stringValue: 'vsix-smoke-test',
+								},
+							},
+						],
+					},
+					scopeSpans: [
+						{
+							scope: {
+								name: 'vsix-smoke',
+							},
+							spans: [
+								{
+									traceId: '0af7651916cd43dd8448eb211c80319c',
+									spanId: 'b7ad6b7169203331',
+									name: 'installed-vsix-span',
+									kind: 1,
+									startTimeUnixNano: 1000000000000000000,
+									endTimeUnixNano: 1000000001000000000,
+									status: {
+										code: 0,
+									},
+									attributes: [],
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+		const ingest = await requestJson(`${otlpHttpUrl}/v1/traces`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: tracePayload,
+		});
+		assert.equal(ingest.statusCode, 200);
+
+		const stats = await waitFor(
+			async () => {
+				const response = await requestJson(`${baseUrl}/api/query/stats`, { method: 'GET' });
+				assert.equal(response.statusCode, 200);
+				return response.body as {
+					spanCount?: number;
+					traceCount?: number;
+				};
+			},
+			(value) => value.spanCount === 1 && value.traceCount === 1,
+			10_000,
+		);
+		assert.equal(stats.spanCount, 1);
+		assert.equal(stats.traceCount, 1);
+
+		const traces = await requestJson(`${baseUrl}/api/query/traces?limit=5`, { method: 'GET' });
+		assert.equal(traces.statusCode, 200);
+		assert.ok(Array.isArray(traces.body), 'trace query should return an array');
+		assert.ok(
+			traces.body.some((trace: { serviceName?: string; traceId?: string }) =>
+				trace.traceId === '0af7651916cd43dd8448eb211c80319c' || trace.serviceName === 'vsix-smoke-test'),
+			'installed VSIX should expose the ingested OTLP trace through the REST query API',
+		);
+	} finally {
+		if (child) {
+			await terminateChild(child);
+		}
+		if (tempRoot) {
+			fs.rmSync(tempRoot, { force: true, recursive: true });
+		}
+		cleanup(context);
 	}
 });

--- a/extension/src/test/extension-vscode.test.ts
+++ b/extension/src/test/extension-vscode.test.ts
@@ -607,7 +607,10 @@ suite('VS Code Host', () => {
 					return typeof value.panelHtml === 'string'
 						&& value.panelHtml.includes('Observer could not start')
 						&& value.panelHtml.includes(`http://127.0.0.1:${conflictPort}`)
-						&& value.panelHtml.includes('observability-studio.managedObserverPort');
+						&& value.panelHtml.includes('not Splunk Observability Studio')
+						&& value.panelHtml.includes('observability-studio.managedObserverPort')
+						&& !value.panelHtml.includes('/api/health')
+						&& value.panelHtml.includes('after freeing the conflicting port');
 				},
 				20_000,
 			);
@@ -649,6 +652,42 @@ suite('VS Code Host', () => {
 		} finally {
 			await vscode.commands.executeCommand('observability-studio.stopObserver');
 			await config.update('managedObserverPort', undefined, vscode.ConfigurationTarget.Global);
+		}
+	});
+
+	test('configured shared observer hides raw health probe details when it is unreachable', async function () {
+		this.timeout(45_000);
+
+		await getExtension();
+		const unreachablePort = await getAvailablePort();
+		const config = vscode.workspace.getConfiguration('observability-studio');
+		const sharedMcpUrl = `http://127.0.0.1:${unreachablePort}/mcp`;
+
+		try {
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+			await config.update('sharedObserverUrl', sharedMcpUrl, vscode.ConfigurationTarget.Global);
+
+			await vscode.commands.executeCommand('observability-studio.openObserver');
+			const failedState = await waitFor(
+				() => Promise.resolve(vscode.commands.executeCommand<RuntimeState>('observability-studio.internal.getRuntimeState')),
+				(value) => {
+					if (!value || value.observerPort !== undefined || value.observerUrl !== undefined) {
+						return false;
+					}
+					return typeof value.panelHtml === 'string'
+						&& value.panelHtml.includes('Observer could not start')
+						&& value.panelHtml.includes(`http://127.0.0.1:${unreachablePort}`)
+						&& value.panelHtml.includes('could not reach the configured shared observer')
+						&& value.panelHtml.includes('observability-studio.sharedObserverUrl')
+						&& !value.panelHtml.includes('/api/health')
+						&& !value.panelHtml.includes('ECONNREFUSED');
+				},
+				30_000,
+			);
+			assert.equal(failedState.sharedMode, false);
+		} finally {
+			await vscode.commands.executeCommand('observability-studio.stopObserver');
+			await config.update('sharedObserverUrl', '', vscode.ConfigurationTarget.Global);
 		}
 	});
 

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -13,14 +13,21 @@ import {
 
 const extensionRoot = path.resolve(__dirname, '..', '..');
 const { getBuildPaths, resetObserverOutputDirs } = require('../../build-observer.js') as {
-	getBuildPaths: (extensionRoot?: string) => {
+	getBuildPaths: (extensionRoot?: string, env?: NodeJS.ProcessEnv) => {
 		observerRoot: string;
 		observerOutDir: string;
 		observerOutBinary: string;
+		target: {
+			binaryName: string;
+			goarch: string;
+			goos: string;
+		};
 	};
 	resetObserverOutputDirs: (paths: ReturnType<typeof getBuildPaths>) => void;
 };
-const weaverBinaryName = 'weaver';
+function hostWeaverBinaryName(): string {
+	return process.platform === 'win32' ? 'weaver.exe' : 'weaver';
+}
 
 function withTempExtensionRoot(run: (extensionRoot: string) => void) {
 	const extensionRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'obstudio-extension-'));
@@ -35,7 +42,7 @@ function withTempExtensionRoot(run: (extensionRoot: string) => void) {
 test('resolveBackend returns observer binary when it exists', () => {
 	withTempExtensionRoot((extensionRoot) => {
 		const binary = path.join(extensionRoot, 'dist', 'observer', 'obstudio');
-		const weaver = path.join(extensionRoot, 'dist', 'observer', 'weaver');
+		const weaver = path.join(extensionRoot, 'dist', 'observer', hostWeaverBinaryName());
 
 		fs.mkdirSync(path.dirname(binary), { recursive: true });
 		fs.writeFileSync(binary, '#!/bin/sh\n');
@@ -51,12 +58,41 @@ test('resolveBackend returns observer binary when it exists', () => {
 	});
 });
 
+test('resolveBackend picks a Windows weaver.exe runtime when present', () => {
+	withTempExtensionRoot((extensionRoot) => {
+		const binary = path.join(extensionRoot, 'dist', 'observer', 'obstudio.exe');
+		const weaver = path.join(extensionRoot, 'dist', 'observer', 'weaver.exe');
+
+		fs.mkdirSync(path.dirname(binary), { recursive: true });
+		fs.writeFileSync(binary, 'MZ');
+		fs.writeFileSync(weaver, 'MZ');
+
+		const backend = resolveBackend(extensionRoot);
+
+		assert.equal(backend.command, binary);
+		assert.equal(backend.env.WEAVER_PATH, weaver);
+	});
+});
+
 test('build output layout reserves the bundled weaver runtime path', () => {
 	withTempExtensionRoot((extensionRoot) => {
 		const paths = getBuildPaths(extensionRoot);
-		const expected = path.join(paths.observerOutDir, weaverBinaryName);
+		const expected = path.join(paths.observerOutDir, hostWeaverBinaryName());
 
 		assert.equal(expected.startsWith(paths.observerOutDir), true);
+	});
+});
+
+test('build output layout uses an .exe suffix for Windows targets', () => {
+	withTempExtensionRoot((extensionRoot) => {
+		const paths = getBuildPaths(extensionRoot, {
+			OBSTUDIO_GOARCH: 'amd64',
+			OBSTUDIO_GOOS: 'windows',
+		});
+
+		assert.equal(path.basename(paths.observerOutBinary), 'obstudio.exe');
+		assert.equal(paths.target.goos, 'windows');
+		assert.equal(paths.target.goarch, 'amd64');
 	});
 });
 

--- a/extension/src/test/startup-errors.test.ts
+++ b/extension/src/test/startup-errors.test.ts
@@ -1,0 +1,134 @@
+import * as assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	currentVsCodeTarget,
+	describeObserverStartupFailure,
+	getObserverProbeMismatchHint,
+	getObserverProbeUnavailableHint,
+	formatObserverProbeMismatchMessage,
+	formatObserverProbeUnavailableMessage,
+	formatPortConflictMessage,
+	getObserverStartupHint,
+} from '../startup-errors';
+
+test('currentVsCodeTarget maps supported runtime pairs to VS Code targets', () => {
+	assert.equal(currentVsCodeTarget('darwin', 'arm64'), 'darwin-arm64');
+	assert.equal(currentVsCodeTarget('darwin', 'x64'), 'darwin-x64');
+	assert.equal(currentVsCodeTarget('linux', 'x64'), 'linux-x64');
+	assert.equal(currentVsCodeTarget('win32', 'x64'), 'win32-x64');
+});
+
+test('formatPortConflictMessage names the managed UI setting for configurable ports', () => {
+	assert.equal(
+		formatPortConflictMessage({
+			owner: 'nginx (PID 42)',
+			port: 3000,
+			role: 'Observer UI',
+			settingName: 'managedObserverPort',
+		}),
+		'Observer UI port 3000 is already in use by "nginx (PID 42)". Stop the other process or change observability-studio.managedObserverPort.',
+	);
+});
+
+test('formatPortConflictMessage explains stale observer ownership for fixed OTLP ports', () => {
+	assert.equal(
+		formatPortConflictMessage({
+			owner: 'obstudio (PID 99)',
+			port: 4318,
+			role: 'OTLP/HTTP',
+		}),
+		'OTLP/HTTP port 4318 is already in use by "obstudio (PID 99)". Another Splunk Observability Studio instance or a stale observer process may still be running. Close the other VS Code window or terminate the stale observer process before restarting Splunk Observability Studio.',
+	);
+});
+
+test('formatObserverProbeMismatchMessage hides internal health endpoint details', () => {
+	assert.equal(
+		formatObserverProbeMismatchMessage('http://127.0.0.1:63575', 'managed-reuse'),
+		'the service already using http://127.0.0.1:63575 is not Splunk Observability Studio.',
+	);
+	assert.equal(
+		formatObserverProbeMismatchMessage('http://127.0.0.1:63575', 'shared-reuse'),
+		'the configured shared observer at http://127.0.0.1:63575 did not respond like Splunk Observability Studio. Verify observability-studio.sharedObserverUrl.',
+	);
+	assert.equal(
+		formatObserverProbeMismatchMessage('http://127.0.0.1:63575', 'startup-reuse'),
+		'a different service responded at http://127.0.0.1:63575 while Splunk Observability Studio was starting.',
+	);
+	assert.match(
+		getObserverProbeMismatchHint('managed-reuse'),
+		/freeing the conflicting port/i,
+	);
+	assert.match(
+		getObserverProbeMismatchHint('startup-reuse'),
+		/freeing the conflicting port/i,
+	);
+	assert.match(
+		getObserverProbeMismatchHint('shared-reuse'),
+		/observability-studio\.sharedObserverUrl/i,
+	);
+});
+
+test('formatObserverProbeUnavailableMessage hides raw probe transport details', () => {
+	assert.equal(
+		formatObserverProbeUnavailableMessage('http://127.0.0.1:63575', 'shared-reuse'),
+		'could not reach the configured shared observer at http://127.0.0.1:63575. Verify observability-studio.sharedObserverUrl and make sure Splunk Observability Studio is running there.',
+	);
+	assert.equal(
+		formatObserverProbeUnavailableMessage('http://127.0.0.1:63575', 'startup'),
+		'Splunk Observability Studio did not become ready at http://127.0.0.1:63575.',
+	);
+	assert.match(
+		getObserverProbeUnavailableHint('shared-reuse'),
+		/observability-studio\.sharedObserverUrl/i,
+	);
+	assert.match(
+		getObserverProbeUnavailableHint('startup'),
+		/output log/i,
+	);
+});
+
+test('describeObserverStartupFailure explains wrong-platform ENOEXEC failures', () => {
+	const failure = describeObserverStartupFailure(
+		Object.assign(new Error('spawn ENOEXEC'), { code: 'ENOEXEC' }),
+		{
+			arch: 'arm64',
+			binaryPath: '/tmp/obstudio',
+			platform: 'darwin',
+		},
+	);
+
+	assert.equal(failure.kind, 'wrong-platform');
+	assert.match(failure.message, /\/tmp\/obstudio cannot run on darwin-arm64/);
+	assert.match(failure.message, /different operating system or CPU architecture/);
+	assert.match(failure.message, /observability-studio\.sharedObserverUrl/);
+	assert.match(failure.hint, /platform-specific extension package/i);
+});
+
+test('describeObserverStartupFailure explains permission failures', () => {
+	const failure = describeObserverStartupFailure(
+		Object.assign(new Error('spawn EACCES'), { code: 'EACCES' }),
+		{ binaryPath: '/tmp/obstudio' },
+	);
+
+	assert.equal(
+		failure.message,
+		'/tmp/obstudio is not executable (spawn EACCES). Reinstall the extension or restore execute permissions.',
+	);
+	assert.equal(failure.kind, 'not-executable');
+});
+
+test('getObserverStartupHint returns guidance by failure kind', () => {
+	assert.match(
+		getObserverStartupHint('port-conflict'),
+		/freeing the conflicting port/i,
+	);
+	assert.match(
+		getObserverStartupHint('wrong-platform'),
+		/platform-specific extension package/i,
+	);
+	assert.match(
+		getObserverStartupHint('not-executable'),
+		/restore execute permissions/i,
+	);
+	assert.match(getObserverStartupHint('generic'), /output log/i);
+});

--- a/extension/src/test/webview-html.test.ts
+++ b/extension/src/test/webview-html.test.ts
@@ -7,6 +7,7 @@ import {
 	getObserverStoppedWebviewHtml,
 	getStatusBarUpdate,
 } from '../webview-html';
+import { getObserverStartupHint } from '../startup-errors';
 
 // --- getObserverWebviewHtml ---
 
@@ -63,6 +64,24 @@ describe('getObserverErrorWebviewHtml', () => {
 	it('includes restart hint', () => {
 		const html = getObserverErrorWebviewHtml('some error');
 		assert.ok(html.includes('Restart Observer'));
+		assert.ok(html.includes('output log'));
+	});
+
+	it('includes port-specific restart guidance for port conflicts', () => {
+		const html = getObserverErrorWebviewHtml(
+			'Observer UI port 3000 is already in use by "nginx (PID 42)".',
+			getObserverStartupHint('port-conflict'),
+		);
+		assert.ok(html.includes('freeing the conflicting port'));
+	});
+
+	it('includes platform guidance for ENOEXEC failures', () => {
+		const html = getObserverErrorWebviewHtml(
+			'binary cannot run on darwin-arm64 (spawn ENOEXEC).',
+			getObserverStartupHint('wrong-platform'),
+		);
+		assert.ok(html.includes('platform-specific extension package'));
+		assert.ok(html.includes('sharedObserverUrl'));
 	});
 
 	it('escapes HTML in error messages to prevent XSS', () => {

--- a/extension/src/webview-html.ts
+++ b/extension/src/webview-html.ts
@@ -1,6 +1,8 @@
 // Pure functions for generating webview HTML and escaping content.
 // Extracted from extension.ts so they can be unit-tested without VS Code APIs.
 
+import { getObserverStartupHint } from './startup-errors';
+
 export function escapeHtml(text: string): string {
 	return text
 		.replace(/&/g, '&amp;')
@@ -77,8 +79,12 @@ export function getObserverLoadingWebviewHtml(): string {
 </html>`;
 }
 
-export function getObserverErrorWebviewHtml(errorMessage: string): string {
+export function getObserverErrorWebviewHtml(
+	errorMessage: string,
+	startupHint: string = getObserverStartupHint('generic'),
+): string {
 	const escaped = escapeHtml(errorMessage);
+	const hint = escapeHtml(startupHint);
 
 	return `<!DOCTYPE html>
 <html lang="en">
@@ -129,9 +135,7 @@ export function getObserverErrorWebviewHtml(errorMessage: string): string {
 		<h2>Observer could not start</h2>
 		<div class="error-detail">${escaped}</div>
 		<p class="hint">
-			Use the Command Palette (Cmd+Shift+P) and run
-			<strong>Splunk Observability Studio: Restart Observer</strong> after
-			freeing the port.
+			${hint}
 		</p>
 	</div>
 </body>

--- a/observer/cmd/fetch-weaver/main.go
+++ b/observer/cmd/fetch-weaver/main.go
@@ -37,7 +37,7 @@ var supportedTargets = []target{
 	{goos: "darwin", goarch: "arm64", asset: "weaver-aarch64-apple-darwin.tar.xz", archiveBinaryName: "weaver", bundledBinaryName: "weaver"},
 	{goos: "darwin", goarch: "amd64", asset: "weaver-x86_64-apple-darwin.tar.xz", archiveBinaryName: "weaver", bundledBinaryName: "weaver"},
 	{goos: "linux", goarch: "amd64", asset: "weaver-x86_64-unknown-linux-gnu.tar.xz", archiveBinaryName: "weaver", bundledBinaryName: "weaver"},
-	{goos: "windows", goarch: "amd64", asset: "weaver-x86_64-pc-windows-msvc.zip", archiveBinaryName: "weaver.exe", bundledBinaryName: "weaver"},
+	{goos: "windows", goarch: "amd64", asset: "weaver-x86_64-pc-windows-msvc.zip", archiveBinaryName: "weaver.exe", bundledBinaryName: "weaver.exe"},
 }
 
 func main() {

--- a/observer/cmd/fetch-weaver/main_test.go
+++ b/observer/cmd/fetch-weaver/main_test.go
@@ -26,6 +26,21 @@ func TestFindTarget(t *testing.T) {
 	}
 }
 
+func TestFindTargetWindowsPreservesExeSuffix(t *testing.T) {
+	t.Parallel()
+
+	target, err := findTarget("windows", "amd64")
+	if err != nil {
+		t.Fatalf("findTarget returned error: %v", err)
+	}
+	if target.archiveBinaryName != "weaver.exe" {
+		t.Fatalf("unexpected archive binary name: %s", target.archiveBinaryName)
+	}
+	if target.bundledBinaryName != "weaver.exe" {
+		t.Fatalf("unexpected bundled binary name: %s", target.bundledBinaryName)
+	}
+}
+
 func TestFindTargetUnsupported(t *testing.T) {
 	t.Parallel()
 

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestClaudeCodeTargetUsesClaudeJSON(t *testing.T) {
@@ -779,4 +785,293 @@ func TestBuildSharedObserverStateNormalizesWildcardHost(t *testing.T) {
 	if state.MCPURL != "http://127.0.0.1:41234/mcp" {
 		t.Fatalf("MCPURL = %q, want %q", state.MCPURL, "http://127.0.0.1:41234/mcp")
 	}
+}
+
+func TestInstallSmokeInstallsBinaryAndAcceptsOTLP(t *testing.T) {
+	observerRoot := observerModuleRoot(t)
+	tempRoot := t.TempDir()
+	bundleDir := filepath.Join(tempRoot, "bundle")
+	homeDir := filepath.Join(tempRoot, "home")
+	binaryName := smokeBinaryName()
+	weaverName := installedWeaverName(filepath.Join(bundleDir, binaryName))
+	bundledBinary := filepath.Join(bundleDir, binaryName)
+	bundledWeaver := filepath.Join(bundleDir, weaverName)
+
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir bundle dir: %v", err)
+	}
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("mkdir home dir: %v", err)
+	}
+
+	build := exec.Command("go", "build", "-o", bundledBinary, "./cmd/obstudio")
+	build.Dir = observerRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build smoke obstudio binary: %v\n%s", err, strings.TrimSpace(string(output)))
+	}
+	if err := copyFile(bundledBinary, bundledWeaver); err != nil {
+		t.Fatalf("bundle sibling weaver runtime: %v", err)
+	}
+	if err := os.Chmod(bundledWeaver, 0o755); err != nil {
+		t.Fatalf("chmod sibling weaver runtime: %v", err)
+	}
+
+	install := exec.Command(bundledBinary, "install", "--target", "codex")
+	install.Env = append(os.Environ(), smokeHomeEnv(homeDir)...)
+	if output, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("run obstudio install smoke test: %v\n%s", err, strings.TrimSpace(string(output)))
+	}
+
+	installedDir := filepath.Join(homeDir, ".codex", "skills", "obstudio")
+	installedBinary := filepath.Join(installedDir, binaryName)
+	if _, err := os.Stat(installedBinary); err != nil {
+		t.Fatalf("expected installed binary at %s: %v", installedBinary, err)
+	}
+	if _, err := os.Stat(filepath.Join(installedDir, weaverName)); err != nil {
+		t.Fatalf("expected installed weaver runtime at %s: %v", filepath.Join(installedDir, weaverName), err)
+	}
+
+	configPath := filepath.Join(homeDir, ".codex", "config.toml")
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read generated codex config: %v", err)
+	}
+	configText := string(config)
+	for _, want := range []string{
+		codexManagedBlockStart,
+		"[mcp_servers.obstudio]",
+		fmt.Sprintf("command = %q", installedBinary),
+		"args = []",
+		codexManagedBlockEnd,
+	} {
+		if !strings.Contains(configText, want) {
+			t.Fatalf("expected generated codex config to contain %q, got:\n%s", want, configText)
+		}
+	}
+
+	observerPort := pickSmokePort(t)
+	otlpHTTPPort := pickSmokePort(t)
+	otlpGRPCPort := pickSmokePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", observerPort)
+	otlpHTTPURL := fmt.Sprintf("http://127.0.0.1:%d", otlpHTTPPort)
+
+	run := exec.Command(installedBinary)
+	runEnv := append(os.Environ(), smokeHomeEnv(homeDir)...)
+	runEnv = append(runEnv,
+		fmt.Sprintf("PORT=%d", observerPort),
+		fmt.Sprintf("OTLP_HTTP_PORT=%d", otlpHTTPPort),
+		fmt.Sprintf("OTLP_GRPC_PORT=%d", otlpGRPCPort),
+	)
+	run.Env = runEnv
+	var logs bytes.Buffer
+	run.Stdout = &logs
+	run.Stderr = &logs
+	if err := run.Start(); err != nil {
+		t.Fatalf("start installed obstudio binary: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- run.Wait()
+	}()
+	defer stopSmokeProcess(run, done)
+
+	client := &http.Client{Timeout: time.Second}
+	waitForSmokeHealth(t, client, baseURL+"/api/health", done, &logs, 10*time.Second)
+
+	var health struct {
+		Kind      string            `json:"kind"`
+		Endpoints map[string]string `json:"endpoints"`
+	}
+	if status := doSmokeJSONRequest(t, client, http.MethodGet, baseURL+"/api/health", "", nil, &health); status != http.StatusOK {
+		t.Fatalf("health endpoint returned %d", status)
+	}
+	if health.Kind != "obstudio" {
+		t.Fatalf("health kind = %q, want %q", health.Kind, "obstudio")
+	}
+	if got := health.Endpoints["otlpHttp"]; got != otlpHTTPURL {
+		t.Fatalf("health otlpHttp = %q, want %q", got, otlpHTTPURL)
+	}
+	if got := health.Endpoints["otlpGrpc"]; got != fmt.Sprintf("127.0.0.1:%d", otlpGRPCPort) {
+		t.Fatalf("health otlpGrpc = %q, want %q", got, fmt.Sprintf("127.0.0.1:%d", otlpGRPCPort))
+	}
+
+	if status := doSmokeJSONRequest(t, client, http.MethodDelete, baseURL+"/api/data", "", nil, nil); status != http.StatusOK {
+		t.Fatalf("clear data endpoint returned %d", status)
+	}
+
+	tracePayload := `{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"install-smoke-test"}}]},"scopeSpans":[{"scope":{"name":"install-smoke"},"spans":[{"traceId":"0af7651916cd43dd8448eb211c80319c","spanId":"b7ad6b7169203331","name":"installed-binary-span","kind":1,"startTimeUnixNano":1000000000000000000,"endTimeUnixNano":1000000001000000000,"status":{"code":0},"attributes":[]}]}]}]}`
+	if status := doSmokeJSONRequest(t, client, http.MethodPost, otlpHTTPURL+"/v1/traces", tracePayload, map[string]string{
+		"Content-Type": "application/json",
+	}, nil); status != http.StatusOK {
+		t.Fatalf("otlp ingest endpoint returned %d", status)
+	}
+
+	var stats struct {
+		SpanCount  int `json:"spanCount"`
+		TraceCount int `json:"traceCount"`
+	}
+	waitForSmokeStats(t, client, baseURL+"/api/query/stats", done, &logs, 10*time.Second, &stats)
+	if stats.SpanCount != 1 {
+		t.Fatalf("stats spanCount = %d, want 1", stats.SpanCount)
+	}
+	if stats.TraceCount != 1 {
+		t.Fatalf("stats traceCount = %d, want 1", stats.TraceCount)
+	}
+
+	var traces []struct {
+		ServiceName string `json:"serviceName"`
+		TraceID     string `json:"traceId"`
+	}
+	if status := doSmokeJSONRequest(t, client, http.MethodGet, baseURL+"/api/query/traces?limit=5", "", nil, &traces); status != http.StatusOK {
+		t.Fatalf("trace query endpoint returned %d", status)
+	}
+	found := false
+	for _, trace := range traces {
+		if trace.TraceID == "0af7651916cd43dd8448eb211c80319c" || trace.ServiceName == "install-smoke-test" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected ingested trace to be queryable, got %#v", traces)
+	}
+}
+
+func observerModuleRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve install_test.go path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func smokeBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "obstudio.exe"
+	}
+	return "obstudio"
+}
+
+func smokeHomeEnv(homeDir string) []string {
+	env := []string{
+		"HOME=" + homeDir,
+		"USERPROFILE=" + homeDir,
+	}
+	if runtime.GOOS == "windows" {
+		volume := filepath.VolumeName(homeDir)
+		if volume != "" {
+			env = append(env,
+				"HOMEDRIVE="+volume,
+				"HOMEPATH="+strings.TrimPrefix(homeDir, volume),
+			)
+		}
+	}
+	return env
+}
+
+func pickSmokePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("pick free port: %v", err)
+	}
+	defer listener.Close()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected TCP listener address, got %T", listener.Addr())
+	}
+	return addr.Port
+}
+
+func stopSmokeProcess(cmd *exec.Cmd, done <-chan error) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+func waitForSmokeHealth(t *testing.T, client *http.Client, url string, done <-chan error, logs *bytes.Buffer, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-done:
+			t.Fatalf("installed obstudio exited before health check succeeded: %v\n%s", err, strings.TrimSpace(logs.String()))
+		default:
+		}
+
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Fatalf("installed obstudio did not become healthy within %s\n%s", timeout, strings.TrimSpace(logs.String()))
+}
+
+func waitForSmokeStats(t *testing.T, client *http.Client, url string, done <-chan error, logs *bytes.Buffer, timeout time.Duration, stats *struct {
+	SpanCount  int `json:"spanCount"`
+	TraceCount int `json:"traceCount"`
+}) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-done:
+			t.Fatalf("installed obstudio exited before stats query succeeded: %v\n%s", err, strings.TrimSpace(logs.String()))
+		default:
+		}
+
+		if status := doSmokeJSONRequest(t, client, http.MethodGet, url, "", nil, stats); status == http.StatusOK && stats.SpanCount == 1 && stats.TraceCount == 1 {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Fatalf("installed obstudio did not report ingested stats within %s\n%s", timeout, strings.TrimSpace(logs.String()))
+}
+
+func doSmokeJSONRequest(t *testing.T, client *http.Client, method, url, body string, headers map[string]string, target any) int {
+	t.Helper()
+
+	var requestBody io.Reader
+	if body != "" {
+		requestBody = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, requestBody)
+	if err != nil {
+		t.Fatalf("build %s request %s: %v", method, url, err)
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+
+	if target == nil {
+		io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		t.Fatalf("decode %s %s response: %v", method, url, err)
+	}
+	return resp.StatusCode
 }


### PR DESCRIPTION
Build and publish platform-specific VSIX packages with matching `obstudio` and Weaver binaries, improve startup failure messages for wrong-platform packages and port conflicts, and add native smoke coverage for installed VSIXs and `obstudio install`.

Testing:
- `go test ./cmd/fetch-weaver -run Test -count=1`
- `go test ./cmd/obstudio -run TestInstallSmokeInstallsBinaryAndAcceptsOTLP -count=1`
- `npm run test:unit`
- `npm run test:integration:smoke`

Closes #94