### PR TITLE
Replace macos-13 with macos-15-intel for darwin-x64 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             label: linux-x64
           - os: windows-latest
             label: win32-x64
-          - os: macos-13
+          - os: macos-15-intel
             label: darwin-x64
           - os: macos-14
             label: darwin-arm64
@@ -105,7 +105,7 @@ jobs:
             label: linux-x64
           - os: windows-latest
             label: win32-x64
-          - os: macos-13
+          - os: macos-15-intel
             label: darwin-x64
           - os: macos-14
             label: darwin-arm64
@@ -150,7 +150,7 @@ jobs:
             label: linux-x64
           - os: windows-latest
             label: win32-x64
-          - os: macos-13
+          - os: macos-15-intel
             label: darwin-x64
           - os: macos-14
             label: darwin-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             target: linux-x64
           - os: windows-latest
             target: win32-x64
-          - os: macos-13
+          - os: macos-15-intel
             target: darwin-x64
           - os: macos-14
             target: darwin-arm64


### PR DESCRIPTION
Summary:
- replace `macos-13` with `macos-15-intel` for the `darwin-x64` lane in CI observer smoke, extension VSIX, and extension smoke jobs
- replace `macos-13` with `macos-15-intel` for the `darwin-x64` release VSIX build
- keep `darwin-x64` publishing and CI coverage intact while leaving the other platform lanes unchanged

Reason:
- `darwin-x64` remains a supported VS Code target for this extension, so dropping it from CI or release would regress Intel macOS coverage
- `macos-13` is no longer the right GitHub-hosted runner target for Intel macOS, and those jobs were the ones getting stuck in queue
- moving the Intel lane to `macos-15-intel` preserves native Intel validation and release packaging on a supported runner image

Testing:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml"); puts "workflow YAML ok"'`
- built and installed a local `0.0.7` VSIX on desktop, then verified the packaged observer returned `200` from `/api/health`, accepted OTLP traces, and returned the ingested trace via `/api/query/traces`
