### PR TITLE
Improve OTel audit and instrumentation skills

### DIFF
--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   use $otel-instrument instead.
 metadata:
   author: otel-studio
-  version: 0.6.0
+  version: 0.7.0
   category: observability
 ---
 
@@ -80,7 +80,9 @@ row.
 `@WithSpan` / `Span.current()` (Java).
 Record the span name and source file with line number.
 
-**Metrics inventory** -- build a list of every metric source:
+**Metrics inventory** -- build a list of every metric source. This includes
+both OpenTelemetry metrics and non-OTel custom application metrics that may be
+exported through an agent, bridge, legacy reporter, or sidecar.
 
 - Auto-instrumentation packages that emit metrics (check the "Signals" column).
 Enumerate every individual metric name the package produces -- one row per
@@ -98,7 +100,17 @@ list each individually.
 `meter.create_observable_gauge` (Python);
 `meter.createCounter`, `meter.createHistogram`,
 `meter.createObservableGauge` (Node.js).
-Record the metric name and source file with line number.
+- Custom application metric registrations, even when they do not use the OTel
+  Metrics API. Examples include Java `com.splunk.o11y.metrics.Metrics`,
+  Dropwizard/Codahale `Counter`, `Timer`, `Histogram`, `MetricRegistry`,
+  Micrometer `Counter`/`Timer`, Prometheus clients, StatsD clients, and
+  framework-specific metric helpers.
+Record the metric name, source file with line number, type, and export path.
+Use type values such as `auto`, `source OTel`, `custom app`, or `agent-exported`.
+For Java Dropwizard/Codahale/Splunk metrics, state when export is conditional on
+the Splunk/OpenTelemetry Java agent, Codahale reporter, or runtime config.
+Do not write "No metrics detected" when custom app metrics exist only because
+no source-level OTel `Meter` usage was found.
 
 **Logs inventory** -- build a list of OTel log integrations:
 
@@ -127,6 +139,72 @@ Status: `covered` / `partial` / `missing`.
 percentiles? (e.g. `http.server.request.duration` histogram, or span
 duration from auto-instrumentation.)
 Status: `covered` / `partial` / `missing`.
+
+**Gap priority and instrument handoff** -- classify every grouped gap before
+writing the report:
+
+- `required`: needed for baseline RED coverage, trace continuity, error
+  attribution, exporter/resource correctness, or removal of an OTel
+  anti-pattern that can break signals. Plain `$otel-instrument <service>`
+  should be able to fix these gaps by default.
+- `recommended`: useful deeper visibility, business metrics, optional log
+  export when trace-correlated stdout logs already exist, or client/cache
+  operational metrics beyond baseline RED. These are included when the user
+  asks `$otel-instrument fix all <service>`.
+- `deferred`: needs product/operator input, external infrastructure, secrets,
+  or a downstream ownership decision. Do not imply `$otel-instrument` will fix
+  it without clarification.
+
+If no `required` gaps remain, say that explicitly in `## Recommendation`.
+
+**Flow and gap synthesis** -- before writing the final report, synthesize the
+findings into a reader-first map:
+
+- **Signal Flow:** show the actual runtime topology as a component or edge map,
+  not a generic mental-model explanation and not a forced single request path.
+  Use concrete components discovered in the repo: runtime startup/export,
+  entry points, middleware/filters, controllers/handlers, service logic,
+  DAO/database calls, caches, queues, outbound clients, downstream services,
+  background workers, scheduled jobs, migration/maintenance runners, and
+  telemetry export.
+- Separate independent roots. Show synchronous request/RPC entry points,
+  message/queue consumers, scheduled/background services, maintenance runners,
+  and telemetry startup/export as separate branches when they are started by
+  different processes or lifecycle modules.
+- Do not place a component under an upstream branch unless the code proves that
+  it is invoked by that branch. For example, a Kafka/background process should
+  not appear under a Thrift/HTTP request branch just because it shares clients
+  or data stores.
+- Mark `[COVERED]` only for the exact component or edge where instrumentation
+  evidence exists. Coverage does not automatically flow through child data
+  stores, clients, queues, or helpers; mark those separately if evidence is
+  present, otherwise show the appropriate gap marker.
+- Include a `### Component Flow Map` under `## Signal Flow`. Prefer a compact
+  text flow with `[COVERED]` for covered edges and numbered gap markers like `[GAP1]`, `[GAP2]`, and `[GAP3]` over Mermaid when there are more than
+  four nodes or any edge needs explanation. Keep the map visually simple:
+  component names and markers only, no long edge labels. Use `[GAP1]` rather than `[G1]`; do not generate `[G1]`, `[G2]`, or `[G3]`.
+- Include a `### Map Legend` table immediately after the map when symbols are
+  used. Columns must be exactly `Symbol`, `Location`, `Meaning`,
+  `Signals Affected`. Use this table to explain coverage gaps, broken
+  propagation boundaries, missing metrics, missing log correlation, and missing
+  error recording.
+- Include a `### Step-by-Step Signal Coverage` table under `## Signal Flow`.
+  Use a normalized table with one row per flow step and signal type. Columns
+  must be exactly `Step`, `Component / Edge`, `Signal`, `Shows Today`,
+  `Missing Today`.
+  For each step, include rows for `Trace`, `Metric`, and `Log` when applicable.
+  Use `None detected` when that signal has no coverage for the step, and
+  `None identified` when no missing coverage is apparent. This table is
+  diagnostic: it shows where visibility stops in the flow, not the remediation
+  backlog.
+- **Gap:** convert the detailed gaps into an action-oriented table with
+  exactly these columns: `Priority`, `Area`, `Gap`, `User Impact`, `Fix`,
+  `Instrument Mode`. The `Priority` values must be `required`, `recommended`,
+  or `deferred`. Use `Instrument Mode` values `default`, `fix all`, or
+  `manual decision`. The `Fix` column is the target remediation and must not be
+  presented as current behavior.
+  Deduplicate and group related flow blind spots into remediation themes so the
+  `## Gap` table does not repeat the flow table one row at a time.
 
 **Anti-patterns** -- flag any of these:
 
@@ -159,11 +237,14 @@ Use this template for `.observe/otel.md`:
 
 **Language:** {language} | **Framework:** {framework} | **Date:** {YYYY-MM-DD}
 
-## Evidence
-- Manifest: {path}
-- Entry point: {path}
-- Route source: {path(s)}
-- Runtime/startup: {path(s) or "none detected"}
+## Audit Evidence
+
+| Check | Finding | Source |
+|-------|---------|--------|
+| Manifest | {dependency and build evidence} | {path} |
+| Entry point | {process entry point} | {path} |
+| Route source | {route/controller files inspected} | {path(s)} |
+| Runtime/startup | {startup surface and telemetry config} | {path(s) or "none detected"} |
 
 ## Routes
 
@@ -174,6 +255,57 @@ Use this template for `.observe/otel.md`:
 | POST | /tasks |
 | GET | /tasks/{id} |
 | ... | ... |
+
+## Signal Flow
+
+Use this section to show the component flow first, then the signal coverage for
+each step. The user should be able to point at a node or edge and understand
+what traces, metrics, and logs can explain today, and what remains invisible.
+
+### Component Flow Map
+
+```text
+Inbound request
+  |
+  v
+[Router / controller] [COVERED]
+  |-- [COVERED] [Repository / database]
+  |-- [GAP1] [Downstream service]
+  `-- [GAP2] [Telemetry export]
+```
+
+### Map Legend
+
+| Symbol | Location | Meaning | Signals Affected |
+|--------|----------|---------|------------------|
+| COVERED | Router / controller -> Repository / database | Trace context and enough RED signal coverage were detected | Trace, Metric, Log |
+| GAP1 | Router / controller -> Downstream service | Propagation: downstream visibility is incomplete | Trace |
+| GAP2 | Service -> Telemetry export | Export config: resource or exporter configuration is inconsistent | Trace, Metric, Log |
+
+### Step-by-Step Signal Coverage
+
+| Step | Component / Edge | Signal | Shows Today | Missing Today |
+|------|------------------|--------|-------------|---------------|
+| 1 | Client -> Router / controller | Trace | GET /tasks server span from otelhttp | Missing in non-instrumented startup path |
+| 1 | Client -> Router / controller | Metric | Request rate and duration from http.server.request.duration | None identified |
+| 1 | Client -> Router / controller | Log | Request log with trace_id/span_id | None identified |
+| 2 | Handler -> Repository / client | Trace | tasks.lookup custom span | Missing recordException on failures |
+| 2 | Handler -> Repository / client | Metric | db.client.operation.duration | None identified |
+| 2 | Handler -> Repository / client | Log | Repository error log with trace_id/span_id | None identified |
+| ... | ... | ... | ... | ... |
+
+## Gap
+
+Highest-impact fixes derived from the flow map. Group related blind spots so
+this is a prioritized remediation backlog, not a second signal inventory.
+
+| Priority | Area | Gap | User Impact | Fix | Instrument Mode |
+|----------|------|-----|-------------|-----|-----------------|
+| required | Startup | Java agent/env setup only appears in one startup path | Local runs can miss HTTP, DB, and client spans | Standardize startup with OTel enabled for every runtime | default |
+| required | Errors | Custom spans do not record exceptions | Failed operations are hard to find from traces | Set span status and record exceptions on failure paths | default |
+| recommended | Logs | OTel log export is not configured, but trace-correlated stdout logs exist | Logs can be correlated but may not appear as OTel log signals | Add a supported OTel log bridge/exporter only if log signals are required | fix all |
+| deferred | Downstream owner | External service does not publish telemetry | Cross-service traces stop outside this repo | Coordinate downstream instrumentation with the owning team | manual decision |
+| ... | ... | ... | ... | ... | ... |
 
 ## Current Instrumentation
 
@@ -195,18 +327,24 @@ If no span sources are found, write: "No spans detected."
 ### Metrics
 
 List every individual metric name -- one row per metric. Never group auto-
-instrumented metrics with vague labels like "(+ related)" or parenthetical
-summaries.
+instrumented or custom application metrics with vague labels like "(+ related)"
+or parenthetical summaries.
 
-| Name | Source | Type |
-|------|--------|------|
-| http.server.request.duration | otelhttp | auto |
-| http.server.active_requests | otelhttp | auto |
-| http.server.request.size | otelhttp | auto |
-| http.server.response.size | otelhttp | auto |
-| orders.processed.count | orders/metrics.go:15 | custom |
+| Name | Source | Type | Export Path |
+|------|--------|------|-------------|
+| http.server.request.duration | otelhttp | auto | OTel SDK/exporter |
+| http.server.active_requests | otelhttp | auto | OTel SDK/exporter |
+| http.server.request.size | otelhttp | auto | OTel SDK/exporter |
+| http.server.response.size | otelhttp | auto | OTel SDK/exporter |
+| orders.processed.count | orders/metrics.go:15 | source OTel | OTel SDK/exporter |
+| orders.queue.depth | orders/worker.go:88 | custom app | Prometheus scrape |
+| service.query.timer | QueryManager.java:120 | custom app | Dropwizard/Codahale; may be exported by Java agent or legacy reporter when enabled |
 
-If no metric sources are found, write: "No metrics detected."
+If custom application metrics exist but no source-level OTel `Meter`
+instruments are found, list the custom metrics and add a short note:
+"No source-level custom OpenTelemetry `Meter` instruments were detected."
+Only write "No metrics detected." when no OTel, auto-instrumented, or custom
+application metric sources are found.
 
 ### Logs
 
@@ -234,12 +372,6 @@ Status values:
   exist but no histogram for percentile breakdown).
 - **missing** -- no data source provides this signal.
 
-## Gaps
-- {remaining non-RED gaps: missing auto-instrumentation packages, missing
-  context propagation, missing OTLP exporter configuration, missing
-  service.name resource, etc.}
-- If no gaps remain, write: "No additional gaps detected."
-
 ## Anti-Patterns
 - {any issues found, or "None detected"}
 
@@ -249,12 +381,75 @@ Status values:
   $otel-instrument for custom business metrics"}
 
 ---
-*Generated by obstudio v0.6.0 otel-audit on {YYYY-MM-DD HH:MM UTC}*
+*Generated by obstudio v0.7.0 otel-audit on {YYYY-MM-DD HH:MM UTC}*
 ```
 
 Report requirements:
 
+- Do not include a generic mental-model section. Apply that reasoning inside the
+  `## Signal Flow` map and coverage table instead.
+- Use `## Audit Evidence` instead of a generic `## Evidence` heading. The table
+  columns must be exactly `Check`, `Finding`, `Source`; do not use
+  `Area | Evidence`, because it repeats the section title and is hard for users
+  to scan.
+- Always include `## Signal Flow` after `## Routes`.
+- Under `## Signal Flow`, always include `### Component Flow Map`. If the map
+  uses symbols, include `### Map Legend` next, followed by
+  `### Step-by-Step Signal Coverage`.
+- Always include `## Gap` before `## Current Instrumentation`, with columns
+  `Priority`, `Area`, `Gap`, `User Impact`, `Fix`, `Instrument Mode`.
+- Do not include a separate `## Gaps` section. `## Gap` is the single
+  gap summary for the report.
+- The component flow map must use concrete service components and edges from the
+  scanned repo. Do not use placeholder-only maps in the final report.
+- Prefer compact text maps with markers over Mermaid when Mermaid edge labels
+  would make the map hard to read. Do not put long explanations on map edges.
+- Use `[COVERED]` for covered flow edges and `[GAP1]`, `[GAP2]`, etc. for gap markers. Do not use opaque shortened markers like `[G1]`, `[G2]`, or `[G3]`.
+- The map legend table must explain each symbol with columns `Symbol`,
+  `Location`, `Meaning`, `Signals Affected`.
+- The signal coverage table must make it easy to follow one request through
+  traces, metrics, and logs. Use one row per flow step and signal type with
+  columns `Step`, `Component / Edge`, `Signal`, `Shows Today`, `Missing Today`.
+- Do not use nested sub-rows, multiple Markdown paragraphs inside a cell, or
+  separate `Trace: Catches`, `Metric: Catches`, and `Log: Catches` columns.
+- The `## Gap` table must be grouped by fix area, not by flow step. It should
+  be possible for one gap row to cover several flow-step blind spots.
+- The `## Gap` table is consumed by `$otel-instrument` during its static
+  validation loop. Use exact lowercase `Priority` values (`required`,
+  `recommended`, `deferred`) and exact `Instrument Mode` values (`default`,
+  `fix all`, `manual decision`). Do not use variants such as `Required`,
+  `fix-all`, `optional`, or `manual`.
+- If no gaps remain, keep the `## Gap` heading plus the table header and
+  separator row, then write the sentence `No gaps found.` directly below the
+  table. This lets the instrument skill count zero remaining rows without
+  guessing.
+- Broken inter-service propagation, missing downstream spans, missing request
+  metrics, missing log correlation, and missing error recording should appear on
+  the flow map or in the flow-step gap column when evidence supports them.
+- The Metrics inventory must include all discovered custom application metrics,
+  not only metrics created through the OTel `Meter` API. Include legacy and
+  library-backed metrics such as Dropwizard/Codahale, Micrometer, Prometheus,
+  StatsD, `com.splunk.o11y.metrics.Metrics`, and similar wrappers.
+- Do not say `No metrics detected` if custom application counters, timers,
+  gauges, histograms, or summaries are present. If no OTel `Meter` calls exist,
+  say `No source-level custom OpenTelemetry Meter instruments were detected`
+  and still list the app metrics.
+- For each metric row, explain the export path when evidence is available:
+  source OTel SDK/exporter, Java agent auto-instrumentation, Dropwizard/Codahale
+  reporter, Prometheus scrape, StatsD, or unknown. If export depends on runtime
+  settings such as `OTEL_AGENT_ENABLED`, `OTEL_METRICS_EXPORTER`, or a reporter
+  module, state that conditionality.
+- The gap table must be action-oriented: one row per major gap, clear user
+  impact, and a concrete fix.
+- The gap table must rank gaps. Use `required` only for fixes needed to make
+  baseline OTel instrumentation complete and trustworthy. Use `recommended` for
+  useful but non-baseline improvements. Use `deferred` for items that require
+  external decisions or infrastructure.
 - If instrumentation is incomplete, always include the exact token `$otel-instrument` in the recommendation.
+- If `required` gaps exist, recommend `$otel-instrument <service>` to fix the
+  required gaps. If only `recommended` gaps exist, say baseline required
+  instrumentation is complete and recommend `$otel-instrument fix all <service>`
+  only if the user wants the recommended improvements too.
 - If OpenTelemetry is absent, include both words `OpenTelemetry` and `missing`.
 - Name the concrete files that support findings; do not only refer to "the service" or "./service".
 - For Node.js, mention `package.json` and the app entry point such as `app.js`.
@@ -264,8 +459,10 @@ Report requirements:
 - For Go multi-package services, name the process entry point such as `cmd/kvstore-server/main.go` and relevant library files. If filesystem persistence, background indexing, or LRU eviction exists, call those out explicitly.
 
 **Chat summary:** After writing `.observe/otel.md`, present a brief summary in
-chat that includes: RED signal statuses, count of gaps found, and the
-recommendation line. End with: `Full report: .observe/otel.md`.
+chat that includes: RED signal statuses, count of gaps found by priority using
+the exact labels `Required gaps: N`, `Recommended gaps: N`, and
+`Deferred gaps: N`, plus the recommendation line. End with:
+`Full report: .observe/otel.md`.
 
 ### Step 4 -- Verify Telemetry (optional)
 

--- a/skills/otel-instrument/SKILL.md
+++ b/skills/otel-instrument/SKILL.md
@@ -6,10 +6,12 @@ description: >-
   asks to "add OTel", "add tracing", "add metrics", "implement observability",
   "wire up telemetry", "instrument this service", or asks to add a specific
   custom signal like "add a metric to track queue depth", "add a span for
-  payment processing", "track error rate for X".
+  payment processing", "track error rate for X", or asks to fix required
+  observability gaps from an audit. Runs a static audit validation loop after
+  instrumentation. Use "fix all" requests to include recommended audit gaps too.
 metadata:
   author: otel-studio
-  version: 0.1.0
+  version: 0.1.1
   category: observability
 ---
 
@@ -21,6 +23,32 @@ Prefer the application's current runtime shape. If the project already uses Dock
 
 ## Workflow
 
+### Remediation Modes
+
+Before preflight, classify the user's request:
+
+- `required`: default mode for `$otel-instrument <service>` and requests to
+  "instrument", "add OTel", or "fix the audit". Fix all repo-local gaps needed
+  for baseline RED coverage, trace continuity, error attribution,
+  exporter/resource correctness, and OTel anti-pattern removal.
+- `fix all`: use when the user says `fix all`, `all gaps`, or equivalent. Fix
+  everything from `required` plus repo-local `recommended` audit gaps such as
+  useful business/client/cache metrics or OTel log export when requested by the
+  audit. Do not implement `deferred` gaps without a focused user decision.
+- `targeted`: use when the user asks for one named span, metric, log bridge, or
+  propagation fix. Keep the change scoped to that signal unless it depends on
+  missing baseline OTel setup.
+
+If `.observe/otel.md` exists, read its `## Gap` table first. Honor
+`Priority` (`required`, `recommended`, `deferred`) and `Instrument Mode`
+(`default`, `fix all`, `manual decision`) when present. If the report uses an
+older unranked gap table, infer the priority using the rules above and state
+that inference in the working summary.
+
+Plain `$otel-instrument <service>` should finish all `required` gaps in one
+go. It should not stop after auto-instrumentation if required custom
+spans/metrics/error recording are needed to close the required gaps.
+
 ### 1. Preflight
 
 Before editing anything, ground the plan with repo evidence:
@@ -28,7 +56,42 @@ Before editing anything, ground the plan with repo evidence:
 - Confirm the language and framework from actual dependency or source files
 - Confirm the target process from the repo's real start surface: `docker-compose.yml`, Kubernetes manifests, `package.json` scripts, `Makefile`, `Procfile`, PM2 configs, Supervisor configs, systemd units, launchd plists, PowerShell scripts, or a plain shell command
 - Confirm existing telemetry indicators or record `none found`
+- Build an **existing trace wiring inventory** before adding any tracer,
+  provider, SDK initialization, dependency, or DI binding:
+  - Runtime/agent: `-javaagent`, `JAVA_TOOL_OPTIONS`, `OTEL_*` env vars,
+    preload flags, sidecars, collectors, launcher scripts, Docker/Kubernetes
+    startup.
+  - SDK/provider setup: `OpenTelemetrySdk`, `TracerProvider`,
+    `MeterProvider`, `NodeSDK`, `TracerProvider(...)`, `otel.SetTracerProvider`,
+    `trace.set_tracer_provider`, `GlobalOpenTelemetry`, or equivalent.
+  - Tracer acquisition: `getTracer`, `trace.get_tracer`, `otel.Tracer`,
+    `trace.getTracer`, constructor-injected `Tracer`, framework `@Bean`,
+    Guice `@Provides`, Spring beans, Micronaut factories, or DI modules.
+  - Existing custom spans: `spanBuilder`, `tracer.Start`,
+    `start_as_current_span`, `startActiveSpan`, `Span.current`, span status,
+    `recordException`, MDC/log correlation, and propagation inject/extract.
+  - Existing propagation: `traceparent`, W3C propagators, HTTP client/header
+    injection, message header propagation, framework interceptors.
+- Classify the current setup as one of:
+  - `auto-only`: agent/preload/framework auto-instrumentation exists, no custom spans.
+  - `custom-with-provider`: custom spans exist and the tracer/provider binding is visible.
+  - `custom-provider-external`: custom spans exist, but the binding likely comes from an
+    external module/runtime not defined in this repo.
+  - `missing`: no usable OTel runtime or tracer/provider path found.
+- Use this language-specific discovery matrix while building the inventory:
+
+  | Language | Existing implementation discovery |
+  |----------|-----------------------------------|
+  | Python | Search `pyproject.toml`, `requirements.txt`, and startup files for `opentelemetry-*`, `trace.set_tracer_provider`, `TracerProvider`, `MeterProvider`, `OTLPSpanExporter`, `OTLPMetricExporter`, `trace.get_tracer`, `FastAPIInstrumentor`, `FlaskInstrumentor`, `CeleryInstrumentor`, `RequestsInstrumentor`, `LoggingInstrumentor`, and any imported `otel_setup.py`, `telemetry.py`, or `instrumentation.py`. Reuse that setup module; do not create a second provider. |
+  | Node.js | Search `package.json`, preload commands, and startup files for `@opentelemetry/*`, `NodeSDK`, `registerInstrumentations`, `provider.register`, `trace.getTracer`, `metrics.getMeter`, `diag.setLogger`, `OTLPTraceExporter`, `OTLPMetricExporter`, `--require`, `--import`, and framework instrumentation packages. Extend the existing preload/setup file and respect the installed SDK option names. |
+  | Go | Search `go.mod` and process entry points for `go.opentelemetry.io/otel`, `otel.SetTracerProvider`, `otel.SetMeterProvider`, `otel.SetTextMapPropagator`, `otel.Tracer`, `otel.Meter`, `sdktrace.NewTracerProvider`, `sdkmetric.NewMeterProvider`, `otlptrace`, `otlpmetric`, `otelhttp`, `otelgrpc`, and shutdown hooks. Reuse the existing provider and propagator; do not add another provider in a package init path. |
+  | Java | Search Maven/Gradle files, startup scripts, and DI/framework modules for `-javaagent`, `JAVA_TOOL_OPTIONS`, `OTEL_*`, `opentelemetry-*`, `micronaut-tracing-opentelemetry`, `GlobalOpenTelemetry`, `OpenTelemetrySdk`, `SdkTracerProvider`, constructor-injected `Tracer`, Guice `@Provides`, Spring `@Bean`, Micronaut `@Factory`, and external bootstrap modules named in the injector. Use the existing binding or agent-backed global provider. |
+  | .NET | Search `.csproj`, `Program.cs`, `Startup.cs`, host builder code, and launch profiles for `OpenTelemetry`, `AddOpenTelemetry`, `WithTracing`, `WithMetrics`, `AddAspNetCoreInstrumentation`, `AddHttpClientInstrumentation`, `AddOtlpExporter`, `ActivitySource`, `Meter`, `OTEL_*`, and resource builder setup. Extend the existing service collection wiring instead of adding a parallel provider. |
 - Confirm the planned `service.name` source and `deployment.environment` source
+- If an audit report exists, classify the remediation backlog:
+  - required gaps to fix in default mode
+  - recommended gaps to fix only in `fix all` mode
+  - deferred gaps that need a manual decision
 - Distinguish between application repos and tooling repos such as CLIs, MCP servers, workers, libraries, installers, and build tools. Instrument the executable path users or operators actually run today. Do not invent a web app, Docker path, or entrypoint that is not present.
 - If the repo has multiple runnable surfaces, instrument the one the user actually cares about; otherwise ask which one matters
 - If the repo is primarily tooling or library code and no runnable surface is obvious, stop and ask instead of inventing an app shell
@@ -41,6 +104,9 @@ Do not proceed until you can state all of these clearly:
 - `service.name`
 - environment dimension
 - incremental addition vs new scaffold
+- trace source of truth: existing provider/binding to reuse, or evidence that one is missing
+- remediation mode and the gap priorities it will change, when an audit report
+  or gap request is present
 
 ### Fast Path: Targeted Custom Signal
 
@@ -51,7 +117,8 @@ preflight scan finds OTel SDK already initialized:
 1. Skip Steps 2-3 (dependencies and auto-instrumentation are already present).
 2. Go directly to Step 4 (Custom Instrumentation) with the user's request as context.
 3. Add only the requested signal — do not re-scaffold or re-wire existing setup.
-4. Proceed to Step 5 (build check).
+4. Proceed to Step 5 (Static Audit Validation Loop), then Step 6 if the user
+   wants a build check.
 
 If the preflight scan finds no OTel SDK, tell the user auto-instrumentation
 needs to be set up first and continue with the full workflow (Steps 2-3).
@@ -86,6 +153,24 @@ Apply auto-instrumentation first, then add manual spans for key business operati
 - Use only official OpenTelemetry packages (`go.opentelemetry.io/otel`, `go.opentelemetry.io/contrib`, `@opentelemetry/*`, `opentelemetry-*`). Do not use community or third-party OTel wrappers. The only exceptions are library-maintained integrations where no official package exists (e.g. `go-redis/redisotel`, `XSAM/otelsql`).
 - Do not initialize the SDK more than once per process.
 - Find any existing OTel setup before adding new code. Extend it.
+- Reuse the existing trace source of truth. If custom spans already obtain a
+  tracer through DI, framework beans, globals, or an agent-backed global
+  provider, add spans through that path instead of creating a second provider or
+  a new binding.
+- Do not add a new dependency, SDK initializer, tracer provider, meter provider,
+  or DI `Tracer` binding unless the inventory proves it is absent and required
+  for the requested signal. If dependency manifests already contain the OTel APIs
+  you are using, do not add duplicate dependencies.
+- For DI-based apps, search every module/factory plus external bootstrap modules
+  named in the injector. If a constructor already accepts `Tracer` and the app
+  builds/starts, assume a binding may already be provided externally. Add a
+  fallback binding only after proving injector startup fails without it.
+- If a fallback `Tracer` binding is truly needed, place it in an
+  observability-owned module/factory such as `OtelModule`, `TelemetryModule`, or
+  `ObservabilityConfig`, not in an unrelated persistence/client/business module.
+  The fallback should bridge to the existing global/runtime provider
+  (`GlobalOpenTelemetry.getTracer(...)` in Java agent setups) and must not
+  initialize a second SDK.
 - Place OTel initialization code in a separate file.
 - Minimize changes to existing code. Do not move functions between files.
 - Do not create spans for trivial helpers. Only span real diagnostic boundaries.
@@ -134,18 +219,41 @@ Go:
 Java:
 - Use the Java agent for Spring Boot unless custom business spans are explicitly requested.
 - Avoid adding SDK dependencies to `pom.xml` for basic Spring Boot coverage.
+- Before adding Java dependencies or a `Tracer` provider, inspect existing
+  `pom.xml`/Gradle files, Java agent startup, DI modules, framework factories,
+  and current constructor-injected `Tracer` usage. Existing OTel dependencies or
+  constructor-injected custom spans mean tracing was already partially present.
+- Prefer `GlobalOpenTelemetry` only as a bridge to the Java agent's global
+  provider. Do not call `OpenTelemetrySdk.builder()` or install another
+  provider in an agent-instrumented app unless the repo already uses that
+  pattern and there is one provider per process.
+- For Guice/Micronaut/Spring DI, do not add `@Provides Tracer` or `@Bean Tracer`
+  by default. First verify no existing binding is supplied by the app, framework,
+  or external bootstrap module. If one is required, add it to the OTel/Telemetry
+  module and mention in the final response why it was needed.
 - Wire the agent through the existing startup surface, `JAVA_TOOL_OPTIONS`, or a documented run command.
 - In the final response, explicitly mention `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, HTTP server spans, and `http.server.request.duration`.
 
 ### 4. Custom Instrumentation
 
-After auto-instrumentation is wired up, prompt the user:
+After auto-instrumentation is wired up, use the remediation mode:
+
+- In `required` mode, add custom spans, metrics, propagation, error recording,
+  or log correlation only when they are necessary to close `required` gaps.
+  Do not prompt before making these required fixes.
+- In `fix all` mode, add both `required` and repo-local `recommended` custom
+  signals. Skip `deferred` gaps and report the decision needed.
+- In `targeted` mode, add only the requested signal and any baseline OTel setup
+  required for that signal to work.
+- If there is no audit report, no ranked gap request, and no targeted signal,
+  then prompt the user:
 
 > Auto-instrumentation is configured. Would you like me to add custom spans or metrics for your business logic?
 
 Then wait for the user's answer.
 
-- **If no**: proceed to the build check (Step 5).
+- **If no**: proceed to the static audit validation loop (Step 5), then the
+  optional build check (Step 6).
 - **If yes**: analyze the codebase for high-value custom instrumentation points:
   - Error handling paths that catch and handle exceptions
   - Key business operations (payments, orders, user registration, etc.)
@@ -155,7 +263,45 @@ Then wait for the user's answer.
   - Suggest specific spans and metrics with names, attributes, and rationale
   - Apply after user approval
 
-### 5. Verify (Optional Build Check)
+For gap-driven work, prefer closing every selected gap completely over leaving
+half-wired instrumentation. If a selected gap cannot be fixed safely in this
+repo, leave the code unchanged for that gap and report the blocker clearly.
+
+### 5. Static Audit Validation Loop
+
+After instrumentation edits, run the static audit workflow against the same
+service before optional build/start verification. This loop is mandatory for
+`required` and `fix all` remediation modes, and optional for narrowly
+`targeted` requests.
+
+Loop rules:
+
+1. Run the audit read-only and write/update `.observe/otel.md`.
+2. Count selected remaining gaps from the `## Gap` table:
+   - `required` mode succeeds when `Priority=required` gap count is `0`.
+   - `fix all` mode succeeds when `Priority=required` plus repo-local
+     `Priority=recommended` / `Instrument Mode=fix all` gap count is `0`.
+   - `targeted` mode succeeds when the named requested signal is present and no
+     new required gap was introduced.
+3. If selected gaps remain and can be fixed repo-locally, make another
+   remediation pass and rerun the audit.
+4. Run at most three static audit passes after the first code edit. Do not
+   loop forever.
+5. Do not run install, build, test, startup, Docker/Compose, curl, Observer, or
+   runtime telemetry validation commands as part of this static audit loop.
+   Those remain part of optional Step 6 verification.
+6. If a selected gap cannot be fixed safely in this repo, stop retrying that
+   gap, leave `.observe/otel.md` with the latest audit result, and report the
+   blocker with the exact gap row.
+7. If an audit report is missing, malformed, or does not include the required
+   `Priority` / `Instrument Mode` columns, rerun the audit once. If it is still
+   not parseable, report that the validation loop could not classify remaining
+   gaps and continue to optional Step 6.
+
+The final `.observe/otel.md` must reflect the last static audit pass, not the
+initial preflight report.
+
+### 6. Verify (Optional Build Check)
 
 Verification is optional. Do not run install, build, test, startup,
 Docker/Compose, curl, siege, Observer, or telemetry validation commands unless
@@ -173,7 +319,7 @@ the user asks for verification or approves it after being asked.
 7. If verification fails, fix issues caused by the instrumentation and report
    anything outside scope.
 
-### 6. Enable Debugging in VS Code
+### 7. Enable Debugging in VS Code
 
 This step is REQUIRED whenever `.vscode/launch.json` exists.
 
@@ -184,13 +330,19 @@ This step is REQUIRED whenever `.vscode/launch.json` exists.
    - `OTEL_BSP_SCHEDULE_DELAY=100`
 3. After editing, report which configuration was updated, the file path, and whether the env vars were added or already present.
 4. If `.vscode/launch.json` exists and you do not update it, stop and explain why.
-5. If `.vscode/launch.json` does not exist, explicitly report: `No .vscode/launch.json found; Step 6 skipped.`
+5. If `.vscode/launch.json` does not exist, explicitly report: `No .vscode/launch.json found; Step 7 skipped.`
 
-### 7. Finalize
+### 8. Finalize
 
 - In the final response, separate file changes from verified outcomes
 - If verification is partial, say exactly what is working and what is still missing instead of reporting full success
 - Always include the service-name configuration, OTLP endpoint configuration, and which automatic spans/metrics are expected from the instrumentation.
+- When working from audit gaps, include the remediation mode (`required` or
+  `fix all`), required gaps fixed, recommended gaps fixed or intentionally
+  skipped, and deferred gaps that need a manual decision.
+- Include the static audit validation-loop outcome: number of audit passes,
+  selected gap count remaining, and any gap rows blocked by manual decisions or
+  external ownership.
 
 ## Credential Safety
 


### PR DESCRIPTION
## Summary

- Expand `otel-audit` reports with signal-flow maps, gap priorities, custom application metric inventory, and clearer instrumentation handoff fields.
- Improve `otel-instrument` preflight and remediation rules for existing OTel wiring, especially Java agent startup, `GlobalOpenTelemetry`, DI tracer bindings, and duplicate SDK/provider avoidance.
- Keep the change scoped to the two OTel skill instruction files.

## Eval Evidence

All evals below used existing fixtures under `evals/`. I compared the skill from `origin/main` against this PR's current skill. The local Codex CLI rejected the repo default `gpt-5.5`, so these runs used `gpt-5.4` for agent runs, and the instrumentation judge run used a temporary config with `agent = "gpt-5.4"` and `judge = "gpt-5.4"`.

### Bottom line

- Runtime telemetry pass rate did **not** improve on the checked Docker runtime eval: both origin-main and current skill passed the same Observer trace/metric checks for `python/fastapi-celery`.
- Instrumentation rubric percentage did **not** improve on `go/chi-partial`: both passed all 5/5 rubric checks.
- The measured improvement is in audit and handoff quality: the current skill produces more structured discovery, signal-flow mapping, required/recommended gap prioritization, and clearer implementation guidance on the more complex eval fixture.

### Complex audit before/after: `python/fastapi-celery`

I selected `python/fastapi-celery` because it has multiple runtime surfaces: a FastAPI API process, a Celery worker process, Redis broker/backend wiring, Dockerfile, Compose, and Makefile startup paths.

Command shape:

```bash
uv --no-config run --default-index https://pypi.org/simple pytest -s \
  python/fastapi-celery/eval/qual/audit.json -k direct \
  --skill <before-or-after-otel-audit> \
  --codex-eval-kind rubric --no-rubric --model gpt-5.4 --codex-eval-progress
```

| Skill | Result | Audit report difference |
| --- | --- | --- |
| `origin/main` `otel-audit@0.6.0` | Passed; run `20260511T200937524977Z`; 188.0s | Correctly found empty OTel coverage, separated FastAPI from Celery, flagged missing FastAPI/ASGI, Celery, Redis, startup/env wiring, error attribution, and log correlation. Report was concise and mostly finding-list oriented. |
| Current `otel-audit@0.7.0` | Passed; run `20260511T201251364551Z`; 188.8s | Found the same required gaps, but produced a more implementation-ready report: discovery table, explicit FastAPI route inventory, startup/process surfaces, signal-flow map, prioritized gap table with `required` vs `recommended`, and a clear note that no outbound HTTP client dependency was detected. |

Current-skill audit report excerpt from `python/fastapi-celery`:

```text
Read-only audit of ./service: OpenTelemetry instrumentation is missing across the FastAPI API, Celery worker, and Redis queue path.
Rate: missing. Errors: missing. Duration: missing.

Signal Flow
Client -> uvicorn/FastAPI app -> FastAPI routes /health, /orders, /orders/{order_id} [GAP1]
POST /orders -> celery_app.send_task("worker.fulfill_order") [GAP2]
Redis broker/backend -> Celery tasks worker.fulfill_order, worker.send_notification [GAP2]
API startup / worker startup / telemetry export [GAP4]

Priority   Area            Gap
required   Startup/export  No OTel SDK, exporter, service.name, or telemetry bootstrap is present in API or worker startup
required   FastAPI/ASGI    fastapi is present but there is no opentelemetry-instrumentation-fastapi usage
required   Celery          send_task in the API and task consumers in the worker are uninstrumented
required   Redis           Redis is the Celery broker and backend, but there is no Redis instrumentation
recommended Logs           No trace-context injection or OTel log bridge is configured
```

### Docker runtime eval before/after: `python/fastapi-celery`

Command shape:

```bash
uv --no-config run --default-index https://pypi.org/simple pytest -s \
  python/fastapi-celery/eval/runtime/instrument.json -k runtime-preserving \
  --skill <before-or-after-otel-instrument> \
  --codex-eval-kind runtime --model gpt-5.4 --codex-eval-progress
```

| Skill | Runtime result | Observer check evidence | Runtime telemetry delta |
| --- | --- | --- | --- |
| `origin/main` `otel-instrument@0.1.0` | Passed; run `20260511T211217600694Z`; 462.0s | Traces matched `GET /health`, `GET /orders`, `POST /orders`; metrics matched `http.server.request.duration` or `http.server.duration` | Baseline passes. |
| Current `otel-instrument@0.1.1` | Passed; run `20260511T200003523037Z`; 563.9s | Traces matched `GET /health`, `GET /orders`, `POST /orders`; metrics matched `http.server.request.duration` or `http.server.duration` | No measured improvement on this runtime eval. |

The Docker runtime eval only checks FastAPI HTTP spans and HTTP server duration metrics. It does not currently assert Celery task spans, Redis spans, or trace continuity across the queue boundary, so this run cannot prove a runtime improvement for those signals.

### Instrumentation rubric eval: `go/chi-partial`

Command shape:

```bash
uv --no-config run --default-index https://pypi.org/simple pytest -s \
  go/chi-partial/eval/qual/instrument.json -k runtime-preserving \
  --skill <before-or-after-otel-instrument> \
  --codex-eval-kind rubric --codex-eval-config /tmp/obstudio-codex-evals-gpt54.toml \
  --codex-eval-progress
```

| Skill | Eval result | Judge result | Compile check | Output notes |
| --- | --- | --- | --- | --- |
| `origin/main` `otel-instrument@0.1.0` | Passed | `overall_pass: true`, all 5 rubric checks passed | `go test -mod=mod ./...` passed | Added `service/otel.go`, preserved chi routes and `otelhttp.NewHandler`, added `MeterProvider`, env-driven OTLP config, global propagator, provider shutdown, and removed hot-path/high-cardinality custom span usage. |
| Current `otel-instrument@0.1.1` | Passed | `overall_pass: true`, all 5 rubric checks passed | `go test -mod=mod ./...` passed | Produced the same core fixes plus a richer post-remediation audit artifact, `.env.example`, route enrichment via `otelhttp.WithSpanNameFormatter` and chi route labeling, signal-specific OTLP endpoint handling, and graceful HTTP server shutdown. |

## Attached Evidence Files

<details>
<summary><code>audit-origin-main-python-fastapi-celery.md</code></summary>

````markdown
Used `otel-audit` in read-only mode. I did not create `.observe/otel.md` because you asked not to modify files.

**Findings**
1. OpenTelemetry instrumentation is missing. There are no OTel dependencies in [service/pyproject.toml](service/pyproject.toml:6), no SDK/setup code in [service/app.py](service/app.py:1) or [service/worker.py](service/worker.py:1), and no `OTEL_*` runtime config in [service/Dockerfile](service/Dockerfile:13), [service/docker-compose.yml](service/docker-compose.yml:7), or [service/Makefile](service/Makefile:6).
2. The FastAPI request path is uninstrumented. The API exposes `GET /health`, `GET /orders`, `GET /orders/{order_id}`, `POST /orders`, and `DELETE /orders/{order_id}` in [service/app.py](service/app.py:19), [service/app.py](service/app.py:24), [service/app.py](service/app.py:29), [service/app.py](service/app.py:37), and [service/app.py](service/app.py:52), but there is no FastAPI/ASGI instrumentation, so HTTP spans and request RED coverage are absent.
3. The Celery/Redis boundary is uninstrumented. `create_order()` publishes `worker.fulfill_order` via Celery in [service/app.py](service/app.py:48), and the worker uses Redis-backed broker/backend plus two tasks in [service/worker.py](service/worker.py:6), [service/worker.py](service/worker.py:12), and [service/worker.py](service/worker.py:18). There is no `opentelemetry-instrumentation-celery` or `...-redis`, so trace propagation stops at enqueue/consume. `task_track_started` in [service/worker.py](service/worker.py:9) is Celery state tracking, not OTel telemetry.
4. Error attribution and log correlation are missing. API 404 paths in [service/app.py](service/app.py:33) and [service/app.py](service/app.py:55), plus any worker failures, would not produce span status, recorded exceptions, or logs with `trace_id` / `span_id`.

**Status**
- Rate: `missing`
- Errors: `missing`
- Duration: `missing`
- Required gaps: 4
- Recommended gaps: 2
- Deferred gaps: 0

Current instrumentation is effectively empty: no spans detected, no metrics detected, and no OTel log instrumentation detected. Anti-patterns: none detected; the problem is absence, not partial misconfiguration.

Recommendation: run `$otel-instrument ./service` to add shared SDK/exporter/resource setup plus FastAPI, Celery, and Redis coverage. If you also want trace-correlated logs and business metrics such as order throughput, fulfillment latency, or queue depth, use `$otel-instrument fix all ./service`.
````
</details>

<details>
<summary><code>audit-current-python-fastapi-celery.md</code></summary>

````markdown
**Summary**
Read-only audit of `./service`: `OpenTelemetry` instrumentation is missing across the FastAPI API, Celery worker, and Redis queue path.

`Rate`: missing. `Errors`: missing. `Duration`: missing.  
`Required gaps: 4`  
`Recommended gaps: 1`  
`Deferred gaps: 0`  
Recommendation: run `$otel-instrument ./service` to add baseline SDK/export, FastAPI spans, Celery producer/consumer spans, Redis spans, and optional log correlation.

I did not create `.observe/otel.md` because you asked for a no-modify scan.

**Audit Evidence**

| Check | Finding | Source |
|---|---|---|
| Manifest | `fastapi`, `uvicorn`, `celery[redis]`, `pydantic`; Redis is implied by `celery[redis]` and runtime `REDIS_URL` | [pyproject.toml](service/pyproject.toml:1), [docker-compose.yml](service/docker-compose.yml:11) |
| Entry point | FastAPI app is created in `app.py`; Celery app and tasks are created in `worker.py` | [app.py](service/app.py:9), [worker.py](service/worker.py:8) |
| Route source | All HTTP routes are declared directly in `app.py` | [app.py](service/app.py:19) |
| Runtime/startup | API starts via `uvicorn`; worker starts via `celery -A worker worker`; no `OTEL_*` env vars or `opentelemetry-instrument` wrapper are present in any startup path | [Dockerfile](service/Dockerfile:13), [docker-compose.yml](service/docker-compose.yml:18), [Makefile](service/Makefile:7) |

**Routes**

| Method | Path |
|---|---|
| GET | `/health` |
| GET | `/orders` |
| GET | `/orders/{order_id}` |
| POST | `/orders` |
| DELETE | `/orders/{order_id}` |

**Signal Flow**
```text
Client
  -> FastAPI routes `/health`, `/orders`, `/orders/{order_id}` [GAP1]
     -> in-memory `orders` dict [GAP1]
     -> `celery_app.send_task("worker.fulfill_order")` [GAP2]
        -> Redis broker/backend [GAP3]
           -> Celery tasks `worker.fulfill_order`, `worker.send_notification` [GAP2]

API startup / worker startup / telemetry export [GAP4]
```

| Priority | Area | Gap | User Impact | Fix | Instrument Mode |
|---|---|---|---|---|---|
| required | Startup/export | No OTel SDK, exporter, `service.name`, or telemetry bootstrap is present in API or worker startup | No traces, metrics, or correlated logs leave either process | Add OTel SDK/export setup and enable it in the `uvicorn` and `celery` startup paths | default |
| required | FastAPI/ASGI | `fastapi` is present but there is no `opentelemetry-instrumentation-fastapi` usage | No route spans or HTTP RED data for `/health` and `/orders*` | Instrument the FastAPI app for inbound HTTP spans | default |
| required | Celery | `send_task` in the API and task consumers in the worker are uninstrumented | Traces stop at enqueue; task execution is invisible | Add `opentelemetry-instrumentation-celery` to producer and worker processes | default |
| required | Redis | Redis is the Celery broker and backend, but there is no Redis instrumentation | Queue handoff and backend operations are invisible | Add `opentelemetry-instrumentation-redis` for broker/backend visibility | default |
| recommended | Logs | No trace-context injection or OTel log bridge is configured | If logs are needed, they cannot be joined cleanly to traces | Add `opentelemetry-instrumentation-logging` or equivalent trace field injection | fix all |

**Current Instrumentation**
No spans detected.  
No metrics detected.  
No OTel log instrumentation detected.  
`worker.py` sets `task_track_started = True` in [worker.py](service/worker.py:9), but that is Celery task state, not trace/metric/log coverage.  
OpenTelemetry instrumentation is missing.

No outbound HTTP client dependency was detected, so I did not flag an HTTP client instrumentation gap.
````
</details>

<details>
<summary><code>runtime-origin-main-python-fastapi-celery-grade.json</code></summary>

```json
{
  "checks": [
    {
      "id": "final-message-present",
      "description": "Run produced a non-empty final response.",
      "passed": true,
      "evidence": "Final message present",
      "category": "sanity",
      "skipped": false
    },
    {
      "id": "skills-loaded",
      "description": "Loaded side exposes repo skill entries through .agents/skills.",
      "passed": true,
      "evidence": "Loaded skills: otel-instrument",
      "category": "sanity",
      "skipped": false
    },
    {
      "id": "observer-runtime-telemetry",
      "description": "Docker runtime emits FastAPI traces to a running Observer.",
      "passed": true,
      "evidence": "traces matched span_names: GET /health, GET /orders, POST /orders; metrics matched one of contains_any: http.server.request.duration, http.server.duration",
      "category": "runtime",
      "skipped": false
    }
  ]
}
```
</details>

<details>
<summary><code>runtime-current-python-fastapi-celery-grade.json</code></summary>

```json
{
  "checks": [
    {
      "id": "final-message-present",
      "description": "Run produced a non-empty final response.",
      "passed": true,
      "evidence": "Final message present",
      "category": "sanity",
      "skipped": false
    },
    {
      "id": "skills-loaded",
      "description": "Loaded side exposes repo skill entries through .agents/skills.",
      "passed": true,
      "evidence": "Loaded skills: otel-instrument",
      "category": "sanity",
      "skipped": false
    },
    {
      "id": "observer-runtime-telemetry",
      "description": "Docker runtime emits FastAPI traces to a running Observer.",
      "passed": true,
      "evidence": "traces matched span_names: GET /health, GET /orders, POST /orders; metrics matched one of contains_any: http.server.request.duration, http.server.duration",
      "category": "runtime",
      "skipped": false
    }
  ]
}
```
</details>

## Validation

- Ran `git diff --check`.
- Ran audit before/after on `evals/go/chi-partial`.
- Ran audit before/after on `evals/python/fastapi-celery` and attached the complex-fixture reports above.
- Ran Docker-backed runtime eval before/after on `evals/python/fastapi-celery`; both passed the same Observer traces and metrics checks.
- Ran instrumentation rubric eval before/after on `evals/go/chi-partial`; both passed all rubric checks.
- Ran `go test -mod=mod ./...` in both generated `go/chi-partial` instrumentation outputs.
