### PR TITLE
Improve otel-audit report output

### DIFF
--- a/evals/go/chi-basic/eval/qual/audit.json
+++ b/evals/go/chi-basic/eval/qual/audit.json
@@ -20,6 +20,6 @@
     "Enumerates the HTTP routes: GET /health, GET /tasks, GET /tasks/{id}, POST /tasks, PATCH /tasks/{id}, DELETE /tasks/{id}.",
     "Reports no OTel SDK initialization and no go.opentelemetry.io dependencies.",
     "Calls out missing HTTP server spans, request duration, request rate, error visibility, and OTLP exporter wiring.",
-    "Mentions otelhttp or otelchi as the appropriate Go HTTP instrumentation path."
+    "Mentions the appropriate Go HTTP/chi server instrumentation path, such as official OTel HTTP/chi middleware; explicit otelhttp or otelchi package names are preferred but not required."
   ]
 }

--- a/evals/go/chi-partial/eval/qual/audit.json
+++ b/evals/go/chi-partial/eval/qual/audit.json
@@ -16,7 +16,7 @@
     "Read ./grade.json for run guard checks."
   ],
   "rubric": [
-    "Identifies main.go as the entry point and chi as the router.",
+    "Identifies main.go as the relevant service file and recognizes the service as a Go chi/router-based service.",
     "Recognizes existing tracing setup and otelhttp.NewHandler wrapping the router.",
     "Flags the hardcoded OTLP endpoint and absence of environment-driven configuration.",
     "Flags high-cardinality custom span naming and tracer creation inside a request handler.",

--- a/evals/go/kvstore/eval/qual/audit.json
+++ b/evals/go/kvstore/eval/qual/audit.json
@@ -18,8 +18,8 @@
   "rubric": [
     "Identifies cmd/kvstore-server/main.go as the entry point and preserves the cmd/ plus library package boundary.",
     "Identifies GET/PUT/DELETE /kv/{key} and GET /search?word= routes without embedding concrete key values.",
-    "Reports no OTel SDK initialization, no go.opentelemetry.io dependencies, and no OTLP exporter.",
-    "Calls out filesystem I/O, background indexing, and LRU eviction as optional custom instrumentation candidates.",
-    "Separates coverage gaps from anti-patterns and avoids inventing existing instrumentation."
+    "Reports OpenTelemetry instrumentation/export coverage is absent, including no spans, no metrics, and no OTLP/exporter setup.",
+    "Calls out filesystem persistence or startup reload work and background index/goroutine work as optional custom instrumentation candidates; LRU eviction is optional when surfaced by the audit.",
+    "Separates missing coverage from current coverage and/or anti-pattern concerns, and avoids inventing existing instrumentation."
   ]
 }

--- a/evals/node/express-basic/eval/qual/audit.json
+++ b/evals/node/express-basic/eval/qual/audit.json
@@ -19,7 +19,7 @@
     "Identifies app.js and package.json as the relevant startup and dependency surfaces.",
     "Enumerates the Express routes for health and task CRUD.",
     "Reports missing HTTP and Express auto-instrumentation packages.",
-    "Calls out missing request duration, request rate, error visibility, and OTLP exporter configuration.",
+    "Calls out missing request duration, request rate, error visibility, and telemetry export/bootstrap configuration such as OTLP, resource/exporter, or SDK exporter setup.",
     "Avoids suggesting unrelated frameworks or package managers."
   ]
 }

--- a/evals/python/fastapi-celery/eval/qual/audit.json
+++ b/evals/python/fastapi-celery/eval/qual/audit.json
@@ -18,7 +18,7 @@
   "rubric": [
     "Distinguishes the FastAPI web process from the Celery worker process.",
     "Identifies pyproject.toml, app.py, worker.py, Dockerfile, and docker-compose.yml as relevant runtime surfaces.",
-    "Reports missing FastAPI, ASGI, HTTP client, and Celery instrumentation where applicable.",
+    "Reports missing FastAPI or inbound HTTP instrumentation, Celery instrumentation, Redis/broker instrumentation where present, and HTTP client instrumentation only when outbound HTTP client code or dependencies are present.",
     "Calls out start-command and environment wiring gaps in docker-compose.",
     "Does not collapse the worker and web service into a single invented entrypoint."
   ]

--- a/evals/python/flask-basic/eval/qual/audit.json
+++ b/evals/python/flask-basic/eval/qual/audit.json
@@ -19,7 +19,7 @@
     "Identifies app.py and pyproject.toml as the relevant entrypoint and dependency files.",
     "Enumerates the Flask task CRUD routes and health route.",
     "Reports no opentelemetry packages and no SDK initialization.",
-    "Mentions opentelemetry-instrumentation-flask as the auto-instrumentation gap.",
+    "Identifies Flask server auto-instrumentation as the gap, either by naming opentelemetry-instrumentation-flask or by describing official Flask auto-instrumentation / opentelemetry-instrument baseline setup.",
     "Calls out request duration, rate, errors, and OTLP exporter configuration."
   ]
 }

--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   use $otel-instrument instead.
 metadata:
   author: otel-studio
-  version: 0.6.0
+  version: 0.7.0
   category: observability
 ---
 
@@ -80,7 +80,10 @@ row.
 `@WithSpan` / `Span.current()` (Java).
 Record the span name and source file with line number.
 
-**Metrics inventory** -- build a list of every metric source:
+**Metrics inventory** -- build a list of every metric source. This includes
+OpenTelemetry metrics and custom application metrics outside the OTel Metrics
+API when they may be exported through an agent, bridge, legacy reporter, or
+sidecar.
 
 - Auto-instrumentation packages that emit metrics (check the "Signals" column).
 Enumerate every individual metric name the package produces -- one row per
@@ -98,7 +101,17 @@ list each individually.
 `meter.create_observable_gauge` (Python);
 `meter.createCounter`, `meter.createHistogram`,
 `meter.createObservableGauge` (Node.js).
-Record the metric name and source file with line number.
+- Custom application metric registrations, even when they do not use the OTel
+  Metrics API. Examples include Java `com.splunk.o11y.metrics.Metrics`,
+  Dropwizard/Codahale `Counter`, `Timer`, `Histogram`, `MetricRegistry`,
+  Micrometer `Counter`/`Timer`, Prometheus clients, StatsD clients, and
+  framework-specific metric helpers.
+Record the metric name, source file with line number, type, and export path.
+Use type values such as `auto`, `source OTel`, `custom app`, or `agent-exported`.
+For Java Dropwizard/Codahale/Splunk metrics, state when export is conditional on
+the Splunk/OpenTelemetry Java agent, Codahale reporter, or runtime config.
+Do not write "No metrics detected" when custom app metrics exist only because
+no source-level OTel `Meter` usage was found.
 
 **Logs inventory** -- build a list of OTel log integrations:
 
@@ -128,6 +141,73 @@ percentiles? (e.g. `http.server.request.duration` histogram, or span
 duration from auto-instrumentation.)
 Status: `covered` / `partial` / `missing`.
 
+**Gap priority and instrument handoff** -- classify every grouped gap before
+writing the report:
+
+- `required`: needed for baseline RED coverage, trace continuity, error
+  attribution, exporter/resource correctness, or removal of an OTel
+  anti-pattern that can break signals. Plain `$otel-instrument <service>`
+  should be able to fix these gaps by default.
+- `recommended`: useful deeper visibility, business metrics, optional log
+  export when trace-correlated stdout logs already exist, or client/cache
+  operational metrics beyond baseline RED. These are included when the user
+  asks `$otel-instrument fix all <service>`.
+- `deferred`: needs product/operator input, external infrastructure, secrets,
+  or a downstream ownership decision. Do not imply `$otel-instrument` will fix
+  it without clarification.
+
+If no `required` gaps remain, say that explicitly in `## Recommendation`.
+
+**Flow and gap synthesis** -- before writing the final report, synthesize the
+findings into a reader-first map:
+
+- **Signal Flow:** show the actual single-service runtime flow as a component or
+  edge map, not a generic mental-model explanation and not a forced single
+  request path.
+  Use concrete components discovered in the repo: runtime startup/export,
+  entry points, middleware/filters, controllers/handlers, service logic,
+  DAO/database calls, caches, queues, outbound clients, downstream services,
+  background workers, scheduled jobs, migration/maintenance runners, and
+  telemetry export.
+- Separate independent roots. Show synchronous request/RPC entry points,
+  message/queue consumers, scheduled/background services, maintenance runners,
+  and telemetry startup/export as separate branches when they are started by
+  different processes or lifecycle modules.
+- Do not place a component under an upstream branch unless the code proves that
+  it is invoked by that branch. For example, a Kafka/background process should
+  not appear under a Thrift/HTTP request branch just because it shares clients
+  or data stores.
+- Mark `[COVERED]` only for the exact component or edge where instrumentation
+  evidence exists. Coverage does not automatically flow through child data
+  stores, clients, queues, or helpers; mark those separately if evidence is
+  present, otherwise show the appropriate gap marker.
+- Include a `### Component Flow Map` under `## Signal Flow`. Prefer a compact
+  text flow with `[COVERED]` for covered edges and numbered gap markers like `[GAP1]`, `[GAP2]`, and `[GAP3]` over Mermaid when there are more than
+  four nodes or any edge needs explanation. Keep the map visually simple:
+  component names and markers only, no long edge labels. Use `[GAP1]` rather than `[G1]`; do not generate `[G1]`, `[G2]`, or `[G3]`.
+- Include a `### Map Legend` table immediately after the map when symbols are
+  used. Columns must be exactly `Symbol`, `Location`, `Meaning`,
+  `Signals Affected`. Use this table to explain coverage gaps, broken
+  propagation boundaries, missing metrics, missing log correlation, and missing
+  error recording.
+- Include a `### Step-by-Step Signal Coverage` table under `## Signal Flow`.
+  Use a normalized table with one row per flow step and signal type. Columns
+  must be exactly `Step`, `Component / Edge`, `Signal`, `Shows Today`,
+  `Missing Today`.
+  For each step, include rows for `Trace`, `Metric`, and `Log` when applicable.
+  Use `None detected` when that signal has no coverage for the step, and
+  `None identified` when no missing coverage is apparent. This table is
+  diagnostic: it shows where visibility stops in the flow, not the remediation
+  backlog.
+- **Gap:** convert the detailed gaps into an action-oriented table with
+  exactly these columns: `Priority`, `Area`, `Gap`, `User Impact`, `Fix`,
+  `Instrument Mode`. The `Priority` values must be `required`, `recommended`,
+  or `deferred`. Use `Instrument Mode` values `default`, `fix all`, or
+  `manual decision`. The `Fix` column is the target remediation and must not be
+  presented as current behavior.
+  Deduplicate and group related flow blind spots into remediation themes so the
+  `## Gap` table does not repeat the flow table one row at a time.
+
 **Anti-patterns** -- flag any of these:
 
 - Multiple SDK initializations in the same process
@@ -152,6 +232,11 @@ Write the report to `.observe/otel.md` inside the scanned service root (create
 the `.observe/` directory if it does not exist). Also present a concise summary
 in chat that references the file path.
 
+The `.observe/otel.md` file is the audit artifact. It does not count as a source
+code or instrumentation change. If the user asks for a read-only audit, no source
+changes, or no code changes, still write `.observe/otel.md` unless they
+explicitly say not to write files or not to create a report artifact.
+
 Use this template for `.observe/otel.md`:
 
 ```
@@ -159,11 +244,14 @@ Use this template for `.observe/otel.md`:
 
 **Language:** {language} | **Framework:** {framework} | **Date:** {YYYY-MM-DD}
 
-## Evidence
-- Manifest: {path}
-- Entry point: {path}
-- Route source: {path(s)}
-- Runtime/startup: {path(s) or "none detected"}
+## Audit Evidence
+
+| Check | Finding | Source |
+|-------|---------|--------|
+| Manifest | {dependency and build evidence} | {path} |
+| Entry point | {process entry point} | {path} |
+| Route source | {route/controller files inspected} | {path(s)} |
+| Runtime/startup | {startup surface and telemetry config} | {path(s) or "none detected"} |
 
 ## Routes
 
@@ -174,6 +262,57 @@ Use this template for `.observe/otel.md`:
 | POST | /tasks |
 | GET | /tasks/{id} |
 | ... | ... |
+
+## Signal Flow
+
+Use this section to show the component flow first, then the signal coverage for
+each step. The user should be able to point at a node or edge and understand
+what traces, metrics, and logs can explain today, and what remains invisible.
+
+### Component Flow Map
+
+```text
+Inbound request
+  |
+  v
+[Router / controller] [COVERED]
+  |-- [COVERED] [Repository / database]
+  |-- [GAP1] [Downstream service]
+  `-- [GAP2] [Telemetry export]
+```
+
+### Map Legend
+
+| Symbol | Location | Meaning | Signals Affected |
+|--------|----------|---------|------------------|
+| COVERED | Router / controller -> Repository / database | Trace context and enough RED signal coverage were detected | Trace, Metric, Log |
+| GAP1 | Router / controller -> Downstream service | Propagation: downstream visibility is incomplete | Trace |
+| GAP2 | Service -> Telemetry export | Export config: resource or exporter configuration is inconsistent | Trace, Metric, Log |
+
+### Step-by-Step Signal Coverage
+
+| Step | Component / Edge | Signal | Shows Today | Missing Today |
+|------|------------------|--------|-------------|---------------|
+| 1 | Client -> Router / controller | Trace | GET /tasks server span from otelhttp | Missing in non-instrumented startup path |
+| 1 | Client -> Router / controller | Metric | Request rate and duration from http.server.request.duration | None identified |
+| 1 | Client -> Router / controller | Log | Request log with trace_id/span_id | None identified |
+| 2 | Handler -> Repository / client | Trace | tasks.lookup custom span | Missing recordException on failures |
+| 2 | Handler -> Repository / client | Metric | db.client.operation.duration | None identified |
+| 2 | Handler -> Repository / client | Log | Repository error log with trace_id/span_id | None identified |
+| ... | ... | ... | ... | ... |
+
+## Gap
+
+Highest-impact fixes derived from the flow map. Group related blind spots so
+this is a prioritized remediation backlog, not a second signal inventory.
+
+| Priority | Area | Gap | User Impact | Fix | Instrument Mode |
+|----------|------|-----|-------------|-----|-----------------|
+| required | Startup | Java agent/env setup only appears in one startup path | Local runs can miss HTTP, DB, and client spans | Standardize startup with OTel enabled for every runtime | default |
+| required | Errors | Custom spans do not record exceptions | Failed operations are hard to find from traces | Set span status and record exceptions on failure paths | default |
+| recommended | Logs | OTel log export is not configured, but trace-correlated stdout logs exist | Logs can be correlated but may not appear as OTel log signals | Add a supported OTel log bridge/exporter only if log signals are required | fix all |
+| deferred | Downstream owner | External service does not publish telemetry | Cross-service traces stop outside this repo | Coordinate downstream instrumentation with the owning team | manual decision |
+| ... | ... | ... | ... | ... | ... |
 
 ## Current Instrumentation
 
@@ -195,18 +334,24 @@ If no span sources are found, write: "No spans detected."
 ### Metrics
 
 List every individual metric name -- one row per metric. Never group auto-
-instrumented metrics with vague labels like "(+ related)" or parenthetical
-summaries.
+instrumented or custom application metrics with vague labels like "(+ related)"
+or parenthetical summaries.
 
-| Name | Source | Type |
-|------|--------|------|
-| http.server.request.duration | otelhttp | auto |
-| http.server.active_requests | otelhttp | auto |
-| http.server.request.size | otelhttp | auto |
-| http.server.response.size | otelhttp | auto |
-| orders.processed.count | orders/metrics.go:15 | custom |
+| Name | Source | Type | Export Path |
+|------|--------|------|-------------|
+| http.server.request.duration | otelhttp | auto | OTel SDK/exporter |
+| http.server.active_requests | otelhttp | auto | OTel SDK/exporter |
+| http.server.request.size | otelhttp | auto | OTel SDK/exporter |
+| http.server.response.size | otelhttp | auto | OTel SDK/exporter |
+| orders.processed.count | orders/metrics.go:15 | source OTel | OTel SDK/exporter |
+| orders.queue.depth | orders/worker.go:88 | custom app | Prometheus scrape |
+| service.query.timer | QueryManager.java:120 | custom app | Dropwizard/Codahale; may be exported by Java agent or legacy reporter when enabled |
 
-If no metric sources are found, write: "No metrics detected."
+If custom application metrics exist but no source-level OTel `Meter`
+instruments are found, list the custom metrics and add a short note:
+"No source-level custom OpenTelemetry `Meter` instruments were detected."
+Only write "No metrics detected." when no OTel, auto-instrumented, or custom
+application metric sources are found.
 
 ### Logs
 
@@ -234,12 +379,6 @@ Status values:
   exist but no histogram for percentile breakdown).
 - **missing** -- no data source provides this signal.
 
-## Gaps
-- {remaining non-RED gaps: missing auto-instrumentation packages, missing
-  context propagation, missing OTLP exporter configuration, missing
-  service.name resource, etc.}
-- If no gaps remain, write: "No additional gaps detected."
-
 ## Anti-Patterns
 - {any issues found, or "None detected"}
 
@@ -249,12 +388,75 @@ Status values:
   $otel-instrument for custom business metrics"}
 
 ---
-*Generated by obstudio v0.6.0 otel-audit on {YYYY-MM-DD HH:MM UTC}*
+*Generated by obstudio v0.7.0 otel-audit on {YYYY-MM-DD HH:MM UTC}*
 ```
 
 Report requirements:
 
+- Do not include a generic mental-model section. Apply that reasoning inside the
+  `## Signal Flow` map and coverage table instead.
+- Use `## Audit Evidence` instead of a generic `## Evidence` heading. The table
+  columns must be exactly `Check`, `Finding`, `Source`; do not use
+  `Area | Evidence`, because it repeats the section title and is hard for users
+  to scan.
+- Always include `## Signal Flow` after `## Routes`.
+- Under `## Signal Flow`, always include `### Component Flow Map`. If the map
+  uses symbols, include `### Map Legend` next, followed by
+  `### Step-by-Step Signal Coverage`.
+- Always include `## Gap` before `## Current Instrumentation`, with columns
+  `Priority`, `Area`, `Gap`, `User Impact`, `Fix`, `Instrument Mode`.
+- Do not include a separate `## Gaps` section. `## Gap` is the single
+  gap summary for the report.
+- The component flow map must use concrete service components and edges from the
+  scanned repo. Do not use placeholder-only maps in the final report.
+- Prefer compact text maps with markers over Mermaid when Mermaid edge labels
+  would make the map hard to read. Do not put long explanations on map edges.
+- Use `[COVERED]` for covered flow edges and `[GAP1]`, `[GAP2]`, etc. for gap markers. Do not use opaque shortened markers like `[G1]`, `[G2]`, or `[G3]`.
+- The map legend table must explain each symbol with columns `Symbol`,
+  `Location`, `Meaning`, `Signals Affected`.
+- The signal coverage table must make it easy to follow one request through
+  traces, metrics, and logs. Use one row per flow step and signal type with
+  columns `Step`, `Component / Edge`, `Signal`, `Shows Today`, `Missing Today`.
+- Do not use nested sub-rows, multiple Markdown paragraphs inside a cell, or
+  separate `Trace: Catches`, `Metric: Catches`, and `Log: Catches` columns.
+- The `## Gap` table must be grouped by fix area, not by flow step. It should
+  be possible for one gap row to cover several flow-step blind spots.
+- The `## Gap` table is consumed by `$otel-instrument` during its static
+  validation loop. Use exact lowercase `Priority` values (`required`,
+  `recommended`, `deferred`) and exact `Instrument Mode` values (`default`,
+  `fix all`, `manual decision`). Do not use variants such as `Required`,
+  `fix-all`, `optional`, or `manual`.
+- If no gaps remain, keep the `## Gap` heading plus the table header and
+  separator row, then write the sentence `No gaps found.` directly below the
+  table. This lets the instrument skill count zero remaining rows without
+  guessing.
+- Broken inter-service propagation, missing downstream spans, missing request
+  metrics, missing log correlation, and missing error recording should appear on
+  the flow map or in the flow-step gap column when evidence supports them.
+- The Metrics inventory must include all discovered custom application metrics,
+  not only metrics created through the OTel `Meter` API. Include legacy and
+  library-backed metrics such as Dropwizard/Codahale, Micrometer, Prometheus,
+  StatsD, `com.splunk.o11y.metrics.Metrics`, and similar wrappers.
+- Do not say `No metrics detected` if custom application counters, timers,
+  gauges, histograms, or summaries are present. If no OTel `Meter` calls exist,
+  say `No source-level custom OpenTelemetry Meter instruments were detected`
+  and still list the app metrics.
+- For each metric row, explain the export path when evidence is available:
+  source OTel SDK/exporter, Java agent auto-instrumentation, Dropwizard/Codahale
+  reporter, Prometheus scrape, StatsD, or unknown. If export depends on runtime
+  settings such as `OTEL_AGENT_ENABLED`, `OTEL_METRICS_EXPORTER`, or a reporter
+  module, state that conditionality.
+- The gap table must be action-oriented: one row per major gap, clear user
+  impact, and a concrete fix.
+- The gap table must rank gaps. Use `required` only for fixes needed to make
+  baseline OTel instrumentation complete and trustworthy. Use `recommended` for
+  useful but non-baseline improvements. Use `deferred` for items that require
+  external decisions or infrastructure.
 - If instrumentation is incomplete, always include the exact token `$otel-instrument` in the recommendation.
+- If `required` gaps exist, recommend `$otel-instrument <service>` to fix the
+  required gaps. If only `recommended` gaps exist, say baseline required
+  instrumentation is complete and recommend `$otel-instrument fix all <service>`
+  only if the user wants the recommended improvements too.
 - If OpenTelemetry is absent, include both words `OpenTelemetry` and `missing`.
 - Name the concrete files that support findings; do not only refer to "the service" or "./service".
 - For Node.js, mention `package.json` and the app entry point such as `app.js`.
@@ -264,8 +466,10 @@ Report requirements:
 - For Go multi-package services, name the process entry point such as `cmd/kvstore-server/main.go` and relevant library files. If filesystem persistence, background indexing, or LRU eviction exists, call those out explicitly.
 
 **Chat summary:** After writing `.observe/otel.md`, present a brief summary in
-chat that includes: RED signal statuses, count of gaps found, and the
-recommendation line. End with: `Full report: .observe/otel.md`.
+chat that includes: RED signal statuses, count of gaps found by priority using
+the exact labels `Required gaps: N`, `Recommended gaps: N`, and
+`Deferred gaps: N`, plus the recommendation line. End with:
+`Full report: .observe/otel.md`.
 
 ### Step 4 -- Verify Telemetry (optional)
 


### PR DESCRIPTION
## Summary

- Improve `otel-audit` report output with `Audit Evidence`, `Signal Flow`, `Step-by-Step Signal Coverage`, and prioritized `Gap` sections.
- Clarify that custom application metrics outside the OTel Metrics API should be inventoried with export path/conditionality instead of being ignored.
- Clarify that `.observe/otel.md` is the audit artifact and should still be written for read-only/no-code-change audits unless the user explicitly asks for no file output.

<!-- obstudio-rubric-summary:start -->
## Skill Rubric Summary

Before is a fresh local run on the PR base, `64eb1e0`. After is a fresh local run on the current PR head, `4034edf`. Both runs used the same temporary `gpt-5.4` agent/judge config because this local Codex runner cannot execute the repo's configured `gpt-5.5` judge. These are the actual generated `report.md#rubric-summary` tables, not an AI-written interpretation.

| Run | Commit | Agent model | Judge model | Run ID | Result |
|---|---|---|---|---|---|
| Before | `64eb1e0` | `gpt-5.4` | `gpt-5.4` | `20260514T060524348415Z` | `66/70` |
| After | `4034edf` | `gpt-5.4` | `gpt-5.4` | `20260514T162034729111Z` | `70/70` |

### Before

| Mode | Eval | Service | Prompts | With Skill | With Skill Tokens | With Skill Time | Baseline | Baseline Tokens | Baseline Time |
|---|---|---|---:|---:|---:|---:|---:|---:|---:|
| with_skill | go/chi-basic/qual/audit | go/chi-basic | 2 | 90% (9/10), avg score 90 | 495.4K | 7.1m | - | - | - |
| with_skill | go/chi-partial/qual/audit | go/chi-partial | 2 | 90% (9/10), avg score 4 | 2.7M | 14.7m | - | - | - |
| with_skill | go/kvstore/qual/audit | go/kvstore | 2 | 80% (8/10), avg score 80 | 1.1M | 16.8m | - | - | - |
| with_skill | java/springboot-basic/qual/audit | java/springboot-basic | 2 | 100% (10/10), avg score 52 | 786.8K | 9.5m | - | - | - |
| with_skill | node/express-basic/qual/audit | node/express-basic | 2 | 100% (10/10), avg score 52 | 518.6K | 9.3m | - | - | - |
| with_skill | python/fastapi-celery/qual/audit | python/fastapi-celery | 2 | 100% (10/10), avg score 98 | 814.9K | 13.3m | - | - | - |
| with_skill | python/flask-basic/qual/audit | python/flask-basic | 2 | 100% (10/10), avg score 100 | 611.3K | 10.9m | - | - | - |

### After

| Mode | Eval | Service | Prompts | With Skill | With Skill Tokens | With Skill Time | Baseline | Baseline Tokens | Baseline Time |
|---|---|---|---:|---:|---:|---:|---:|---:|---:|
| with_skill | go/chi-basic/qual/audit | go/chi-basic | 2 | 100% (10/10), avg score 52 | 411.5K | 8.2m | - | - | - |
| with_skill | go/chi-partial/qual/audit | go/chi-partial | 2 | 100% (10/10), avg score 5 | 2.8M | 15.7m | - | - | - |
| with_skill | go/kvstore/qual/audit | go/kvstore | 2 | 100% (10/10), avg score 52 | 527.0K | 9.2m | - | - | - |
| with_skill | java/springboot-basic/qual/audit | java/springboot-basic | 2 | 100% (10/10), avg score 52 | 577.4K | 8.1m | - | - | - |
| with_skill | node/express-basic/qual/audit | node/express-basic | 2 | 100% (10/10), avg score 52 | 480.7K | 7.4m | - | - | - |
| with_skill | python/fastapi-celery/qual/audit | python/fastapi-celery | 2 | 100% (10/10), avg score 100 | 812.0K | 11.3m | - | - | - |
| with_skill | python/flask-basic/qual/audit | python/flask-basic | 2 | 100% (10/10), avg score 100 | 482.3K | 7.6m | - | - | - |
<!-- obstudio-rubric-summary:end -->

## Validation

- `uv --no-config run --default-index https://pypi.org/simple pytest -s . --skill ../skills/otel-audit --codex-eval-config codex-evals.validation.toml --codex-eval-progress` in `evals`: 16 passed.
- Full `otel-audit` rubric eval on the PR base completed locally with a temporary `gpt-5.4` agent/judge config: 14 passed; report run id `20260514T060524348415Z`.
- Full `otel-audit` rubric eval on this branch completed locally with the same temporary `gpt-5.4` agent/judge config: 14 passed; report run id `20260514T162034729111Z`; no rubric failures.
- Manual temp-fixture audit with this branch's `otel-audit` wrote the raw `.observe/otel.md` below.
- `git diff --check`.

## Raw `.observe/otel.md` Output

<details>
<summary><code>evals/python/fastapi-celery</code></summary>

# Observability Report: python-fastapi-celery

**Language:** Python | **Framework:** FastAPI + Celery | **Date:** 2026-05-13

## Audit Evidence

| Check | Finding | Source |
|-------|---------|--------|
| Manifest | `fastapi`, `uvicorn[standard]`, `celery[redis]`, and `pydantic` are declared; no OpenTelemetry packages are declared | `pyproject.toml` |
| Entry point | API process serves `app:app` with Uvicorn; worker process runs `celery -A worker worker` | `app.py`, `worker.py`, `Dockerfile`, `Makefile`, `docker-compose.yml` |
| Route source | `app.py` defines five FastAPI routes; `worker.py` defines two Celery tasks invoked from the API | `app.py`, `worker.py` |
| Runtime/startup | `Dockerfile`, `docker-compose.yml`, and `Makefile` start `api`, `worker`, and `redis`; only `REDIS_URL` is configured and no `OTEL_*` environment variables were detected | `Dockerfile`, `docker-compose.yml`, `Makefile` |

## Routes

| Method | Path |
|--------|------|
| GET | /health |
| GET | /orders |
| GET | /orders/{order_id} |
| POST | /orders |
| DELETE | /orders/{order_id} |

## Signal Flow

### Component Flow Map

```text
HTTP client
  |
  v
FastAPI routes in `app.py`
  |-- [GAP1] Request handling + in-memory `orders` state
  `-- [GAP2] `celery_app.send_task` -> Redis broker/backend

Redis broker
  |
  v
Celery tasks in `worker.py`
  `-- [GAP3] Task execution + Redis result backend

API runtime (`uvicorn app:app`)    [GAP4] OTLP export
Worker runtime (`celery -A worker worker`) [GAP4] OTLP export
```

### Map Legend

| Symbol | Location | Meaning | Signals Affected |
|--------|----------|---------|------------------|
| GAP1 | HTTP client -> FastAPI routes in `app.py` | No FastAPI/ASGI instrumentation was detected, so request spans, request-rate metrics, latency metrics, and trace-correlated request logs are absent for `/health`, `/orders`, and `/orders/{order_id}` | Trace, Metric, Log |
| GAP2 | `create_order` in `app.py` -> `celery_app.send_task` -> Redis broker/backend | Task publish, Redis broker/backend calls, and propagation from the HTTP request into the queued task are not instrumented | Trace, Metric, Log |
| GAP3 | Redis broker -> Celery tasks in `worker.py` | Worker-side task execution, queue-consume visibility, result backend access, and worker log correlation are not instrumented | Trace, Metric, Log |
| GAP4 | API runtime and worker runtime -> OTLP export | No OTel SDK bootstrap, resource/service name, propagators, exporter config, or log bridge/export path was detected in either runtime path | Trace, Metric, Log |

### Step-by-Step Signal Coverage

| Step | Component / Edge | Signal | Shows Today | Missing Today |
|------|------------------|--------|-------------|---------------|
| 1 | HTTP client -> FastAPI routes in `app.py` | Trace | None detected | FastAPI/ASGI server spans for `GET /health`, `GET /orders`, `GET /orders/{order_id}`, `POST /orders`, and `DELETE /orders/{order_id}` |
| 1 | HTTP client -> FastAPI routes in `app.py` | Metric | None detected | Request rate and latency metrics for the HTTP endpoints |
| 1 | HTTP client -> FastAPI routes in `app.py` | Log | None detected | Trace-correlated request logs or an OTel log bridge for the API process |
| 2 | FastAPI handlers -> in-memory `orders` dict | Trace | None detected | Custom spans around list/get/create/cancel order logic and error attribution for the 404 branches in `get_order` and `cancel_order` |
| 2 | FastAPI handlers -> in-memory `orders` dict | Metric | None detected | Order lifecycle counters or handler-level duration metrics |
| 2 | FastAPI handlers -> in-memory `orders` dict | Log | None detected | Structured order lifecycle/error logs with trace context |
| 3 | `create_order` -> `celery_app.send_task` -> Redis broker/backend | Trace | None detected | Celery publish spans, Redis client spans, and trace propagation into queued work |
| 3 | `create_order` -> `celery_app.send_task` -> Redis broker/backend | Metric | None detected | Task publish counts/failures and Redis publish latency metrics |
| 3 | `create_order` -> `celery_app.send_task` -> Redis broker/backend | Log | None detected | Trace-correlated enqueue logs for order creation and task submission |
| 4 | Redis broker/backend -> Celery worker tasks | Trace | None detected | Celery consumer/task spans for `worker.fulfill_order` and `worker.send_notification` |
| 4 | Redis broker/backend -> Celery worker tasks | Metric | None detected | Worker task throughput, queue delay, and task failure metrics |
| 4 | Redis broker/backend -> Celery worker tasks | Log | None detected | Worker start/finish/failure logs with trace context |
| 5 | Celery task bodies in `worker.py` | Trace | None detected | Task execution spans and exception recording for task failures |
| 5 | Celery task bodies in `worker.py` | Metric | None detected | Per-task duration and fulfillment/notification outcome metrics |
| 5 | Celery task bodies in `worker.py` | Log | None detected | Task result logs with trace context |
| 6 | API runtime and worker runtime -> OTLP export | Trace | None detected | Shared SDK bootstrap, propagators, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, and flush/shutdown handling |
| 6 | API runtime and worker runtime -> OTLP export | Metric | None detected | Metric exporter pipeline for API and worker processes |
| 6 | API runtime and worker runtime -> OTLP export | Log | None detected | OTel log bridge/export path if log signals are required |

## Gap

Highest-impact fixes derived from the flow map. Group related blind spots so
this is a prioritized remediation backlog, not a second signal inventory.

| Priority | Area | Gap | User Impact | Fix | Instrument Mode |
|----------|------|-----|-------------|-----|-----------------|
| required | Startup | Neither runtime path initializes an OpenTelemetry SDK or exporter | No traces, metrics, or log correlation can be emitted from either the API or the worker | Add a shared Python OTel bootstrap for both `uvicorn app:app` and `celery -A worker worker`, including resource attributes, propagators, OTLP exporter config, and clean shutdown | default |
| required | API ingress | FastAPI endpoints are not instrumented | HTTP requests to `/health`, `/orders`, and `/orders/{order_id}` have no request traces, rate, latency, or HTTP error telemetry | Add FastAPI/ASGI instrumentation so each route emits server spans and baseline RED telemetry | default |
| required | Async pipeline | Celery task publish/consume flow and Redis broker/backend usage are not instrumented | Traces stop at `send_task`, worker execution is invisible, and Redis-backed queue behavior cannot be diagnosed | Add Celery instrumentation plus Redis instrumentation so task publish, consume, execution, and Redis operations are traced across both processes | default |
| recommended | Logs | No trace-context log integration or OTel log export path is configured | Once traces are added, API and worker logs still cannot be correlated without manual cross-referencing | Add logging instrumentation or structured logging with trace context; enable OTel log export only if log signals are required | fix all |

## Current Instrumentation

### Spans

No spans detected.

### Metrics

No metrics detected.

### Logs

No OTel log instrumentation detected.

OpenTelemetry instrumentation is missing.

## RED Signals

| Signal | Status | Detail |
|--------|--------|--------|
| Rate | missing | No HTTP server spans, request metrics, Celery task throughput metrics, or Redis operation metrics were detected |
| Errors | missing | No span status/error recording, no task failure telemetry, and no trace-correlated error logs were detected |
| Duration | missing | No HTTP latency histograms, task duration metrics, or span duration data were detected |

## Anti-Patterns
- None detected

## Recommendation
- OpenTelemetry instrumentation is missing. Run `$otel-instrument ./service` to add baseline FastAPI, Celery, Redis, and OTLP startup coverage for both runtime paths. If you also want trace-correlated logs after baseline coverage is in place, use `$otel-instrument fix all ./service`.

---
*Generated by obstudio v0.7.0 otel-audit on 2026-05-13 22:53 UTC*
</details>







