### PR TITLE
Add Java Kafka eval fixtures

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -223,3 +223,17 @@ baseline side.
 | `evals/go/chi-partial/` | Chi with partial OTel | `go run .` |
 | `evals/go/kvstore/` | Chi + package tests | `make test` |
 | `evals/java/springboot-basic/` | Spring Boot | `mvn spring-boot:run` |
+| `evals/java/kafka-producer-consumer/` | Plain Kafka producer + consumer | `mvn test` |
+| `evals/java/kafka-batch-consumer/` | Plain Kafka batch consumer | `mvn test` |
+| `evals/java/kafka-listener-container/` | Kafka listener container | `mvn test` |
+| `evals/java/kafka-streams/` | Kafka Streams with Guice wiring | `mvn test` |
+
+The Java Kafka fixtures use broker-free unit or topology tests as eval commands.
+Running the services with `mvn exec:java` or `mvn spring-boot:run` requires a
+Kafka broker and is documented in each fixture README. See those fixture READMEs
+for eval intent, required environment variables, and the Java-agent versus
+manual-SDK boundary.
+
+Kafka coverage is organized by processing pattern rather than by every
+framework combination: direct producer/consumer, batch consumer, listener
+container, and Kafka Streams.

--- a/evals/java/kafka-batch-consumer/README.md
+++ b/evals/java/kafka-batch-consumer/README.md
@@ -1,0 +1,23 @@
+# Kafka Batch Consumer Eval Fixture
+
+This fixture covers a plain Java Kafka batch consumer that processes
+`ConsumerRecords` from `poll()` as a unit and commits offsets after each batch.
+
+## Runtime
+
+```bash
+mvn test
+
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
+PAYMENTS_TOPIC=payments \
+mvn exec:java
+```
+
+`mvn test` is broker-free and verifies the batch processor. `mvn exec:java`
+requires a running Kafka broker.
+
+The service intentionally contains no OpenTelemetry SDK, Java agent startup
+configuration, OTLP exporter wiring, or custom `Tracer` usage. Instrumentation
+responses should prefer the OpenTelemetry Java agent for Kafka consumer spans
+and treat batch-size, failed-record, high-value-payment, and batch-duration
+metrics as optional custom signals unless explicitly requested.

--- a/evals/java/kafka-batch-consumer/eval/qual/audit.json
+++ b/evals/java/kafka-batch-consumer/eval/qual/audit.json
@@ -1,0 +1,26 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Scan the plain Java Kafka batch consumer service in ./service for observability gaps. Do not modify files."
+    },
+    {
+      "id": "readiness-review",
+      "task": "Produce an observability readiness review for the plain Java Kafka batch consumer service in ./service. Identify existing telemetry, missing OpenTelemetry coverage, batch-processing risks, and the next instrumentation step. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies BatchConsumerApplication.java as the entry point and BatchConsumerConfig.java as the startup/runtime configuration surface.",
+    "Identifies PaymentBatchConsumer.java as the KafkaConsumer poll loop that processes ConsumerRecords as batches and commits offsets with commitSync().",
+    "Identifies PaymentBatchProcessor.java as the batch aggregation logic and names the payments topic.",
+    "Reports no OpenTelemetry SDK setup, Java agent startup, OTLP exporter configuration, or custom Tracer usage.",
+    "Calls out missing Kafka consumer spans, batch size, valid/failed record counts, high-value-payment counts, batch duration, commit error, and consumer lag/offset visibility.",
+    "Recommends the OpenTelemetry Java agent as the primary Kafka consumer instrumentation path and treats batch metrics as optional custom signals."
+  ]
+}

--- a/evals/java/kafka-batch-consumer/eval/qual/instrument.json
+++ b/evals/java/kafka-batch-consumer/eval/qual/instrument.json
@@ -1,0 +1,25 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Add OpenTelemetry instrumentation to the plain Java Kafka batch consumer service in ./service. Preserve the ConsumerRecords batch-processing and commitSync behavior. Prefer Java agent auto-instrumentation for Kafka clients; do not add custom spans or metrics unless explicitly required."
+    },
+    {
+      "id": "runtime-preserving",
+      "task": "Instrument the plain Java Kafka batch consumer service in ./service while preserving the existing Maven runtime, Kafka topic, batch-poll loop, and offset commit behavior. Prefer the OpenTelemetry Java agent, include fast local metric export settings for development use, and avoid unnecessary application code changes."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Performs a Java trace wiring inventory covering Maven dependencies, JAVA_TOOL_OPTIONS or -javaagent startup, OTEL_* configuration, Kafka consumer batch code, and existing Tracer usage, then classifies the pre-change fixture as missing based on evidence.",
+    "Preserves BatchConsumerApplication.java, PaymentBatchConsumer.java, PaymentBatchProcessor.java, the payments topic, batch-poll loop, and commitSync behavior.",
+    "Uses or recommends the OpenTelemetry Java agent in the existing Maven/Java startup path with OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_METRIC_EXPORT_INTERVAL=1000, and OTEL_METRIC_EXPORT_TIMEOUT=500.",
+    "Does not add OpenTelemetrySdk, a duplicate provider, broad manual tracing, or custom Tracer creation when no custom spans are requested.",
+    "Mentions that Kafka consumer spans come from the Java agent and treats batch size, failed-record count, commit latency, and high-value-payment metrics as optional business instrumentation unless explicitly requested."
+  ]
+}

--- a/evals/java/kafka-batch-consumer/pom.xml
+++ b/evals/java/kafka-batch-consumer/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>kafka-batch-consumer</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>kafka-batch-consumer</name>
+    <description>Plain Kafka batch consumer service for OTel skill evaluation</description>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.17.2</jackson.version>
+        <junit.version>5.10.3</junit.version>
+        <kafka.version>3.8.1</kafka.version>
+        <slf4j.version>2.0.16</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <mainClass>com.example.kafkabatch.BatchConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/BatchConsumerApplication.java
+++ b/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/BatchConsumerApplication.java
@@ -1,0 +1,20 @@
+package com.example.kafkabatch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public final class BatchConsumerApplication {
+
+    private BatchConsumerApplication() {
+    }
+
+    public static void main(String[] args) {
+        BatchConsumerConfig config = BatchConsumerConfig.fromEnvironment();
+        PaymentBatchProcessor processor = new PaymentBatchProcessor(new ObjectMapper());
+
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(config.consumerProperties());
+        try (PaymentBatchConsumer batchConsumer = new PaymentBatchConsumer(consumer, config.paymentsTopic(), processor)) {
+            batchConsumer.runForever();
+        }
+    }
+}

--- a/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/BatchConsumerConfig.java
+++ b/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/BatchConsumerConfig.java
@@ -1,0 +1,29 @@
+package com.example.kafkabatch;
+
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+public record BatchConsumerConfig(String bootstrapServers, String paymentsTopic, String consumerGroup) {
+
+    public static BatchConsumerConfig fromEnvironment() {
+        Map<String, String> env = System.getenv();
+        return new BatchConsumerConfig(
+                env.getOrDefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
+                env.getOrDefault("PAYMENTS_TOPIC", "payments"),
+                env.getOrDefault("KAFKA_CONSUMER_GROUP", "payment-batch-worker"));
+    }
+
+    public Properties consumerProperties() {
+        Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "500");
+        return properties;
+    }
+}

--- a/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/BatchResult.java
+++ b/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/BatchResult.java
@@ -1,0 +1,4 @@
+package com.example.kafkabatch;
+
+public record BatchResult(int totalRecords, int validRecords, int failedRecords, int highValuePayments, double totalAmount) {
+}

--- a/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/PaymentBatchConsumer.java
+++ b/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/PaymentBatchConsumer.java
@@ -1,0 +1,55 @@
+package com.example.kafkabatch;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class PaymentBatchConsumer implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(PaymentBatchConsumer.class);
+
+    private final KafkaConsumer<String, String> consumer;
+    private final String paymentsTopic;
+    private final PaymentBatchProcessor processor;
+
+    public PaymentBatchConsumer(
+            KafkaConsumer<String, String> consumer,
+            String paymentsTopic,
+            PaymentBatchProcessor processor) {
+        this.consumer = consumer;
+        this.paymentsTopic = paymentsTopic;
+        this.processor = processor;
+    }
+
+    public void runForever() {
+        consumer.subscribe(List.of(paymentsTopic));
+        while (!Thread.currentThread().isInterrupted()) {
+            pollBatch(Duration.ofSeconds(1));
+        }
+    }
+
+    public BatchResult pollBatch(Duration timeout) {
+        ConsumerRecords<String, String> records = consumer.poll(timeout);
+        List<String> payloads = new ArrayList<>();
+        for (ConsumerRecord<String, String> record : records) {
+            payloads.add(record.value());
+        }
+
+        BatchResult result = processor.process(payloads);
+        if (!payloads.isEmpty()) {
+            consumer.commitSync();
+            logger.info("Processed payment batch: {}", result);
+        }
+        return result;
+    }
+
+    @Override
+    public void close() {
+        consumer.close();
+    }
+}

--- a/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/PaymentBatchProcessor.java
+++ b/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/PaymentBatchProcessor.java
@@ -1,0 +1,49 @@
+package com.example.kafkabatch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+
+public final class PaymentBatchProcessor {
+
+    private static final double HIGH_VALUE_THRESHOLD = 5_000.0;
+
+    private final ObjectMapper objectMapper;
+
+    public PaymentBatchProcessor(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public BatchResult process(List<String> payloads) {
+        int valid = 0;
+        int failed = 0;
+        int highValue = 0;
+        double totalAmount = 0.0;
+
+        for (String payload : payloads) {
+            PaymentEvent payment = parse(payload);
+            if (payment == null) {
+                failed++;
+                continue;
+            }
+            valid++;
+            totalAmount += payment.amount();
+            if (payment.amount() >= HIGH_VALUE_THRESHOLD) {
+                highValue++;
+            }
+        }
+
+        return new BatchResult(payloads.size(), valid, failed, highValue, totalAmount);
+    }
+
+    private PaymentEvent parse(String payload) {
+        if (payload == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(payload, PaymentEvent.class);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+}

--- a/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/PaymentEvent.java
+++ b/evals/java/kafka-batch-consumer/src/main/java/com/example/kafkabatch/PaymentEvent.java
@@ -1,0 +1,4 @@
+package com.example.kafkabatch;
+
+public record PaymentEvent(String paymentId, String accountId, double amount, String currency) {
+}

--- a/evals/java/kafka-batch-consumer/src/test/java/com/example/kafkabatch/PaymentBatchProcessorTest.java
+++ b/evals/java/kafka-batch-consumer/src/test/java/com/example/kafkabatch/PaymentBatchProcessorTest.java
@@ -1,0 +1,31 @@
+package com.example.kafkabatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class PaymentBatchProcessorTest {
+
+    private final PaymentBatchProcessor processor = new PaymentBatchProcessor(new ObjectMapper());
+
+    @Test
+    void summarizesValidFailedAndHighValuePayments() {
+        BatchResult result = processor.process(Arrays.asList(
+                """
+                {"paymentId":"payment-1","accountId":"acct-1","amount":25.0,"currency":"USD"}
+                """,
+                """
+                {"paymentId":"payment-2","accountId":"acct-2","amount":7500.0,"currency":"USD"}
+                """,
+                "{not-json",
+                null));
+
+        assertEquals(4, result.totalRecords());
+        assertEquals(2, result.validRecords());
+        assertEquals(2, result.failedRecords());
+        assertEquals(1, result.highValuePayments());
+        assertEquals(7525.0, result.totalAmount());
+    }
+}

--- a/evals/java/kafka-listener-container/README.md
+++ b/evals/java/kafka-listener-container/README.md
@@ -1,0 +1,24 @@
+# Kafka Listener Container Eval Fixture
+
+This fixture covers container-managed Kafka consumers implemented with Spring
+Kafka `@KafkaListener`. It is intentionally separate from the plain Kafka
+`Consumer.poll()` fixtures because listener containers change the startup and
+configuration surfaces an instrumentation agent should preserve.
+
+## Runtime
+
+```bash
+mvn test
+
+SPRING_KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
+ALERTS_TOPIC=alerts \
+mvn spring-boot:run
+```
+
+`mvn test` is broker-free and calls the listener directly. `mvn spring-boot:run`
+requires a running Kafka broker.
+
+The service intentionally contains no OpenTelemetry SDK, Java agent startup
+configuration, OTLP exporter wiring, or custom `Tracer` usage. Instrumentation
+responses should prefer the OpenTelemetry Java agent for Kafka listener client
+spans and avoid replacing Spring Kafka listener container behavior.

--- a/evals/java/kafka-listener-container/eval/qual/audit.json
+++ b/evals/java/kafka-listener-container/eval/qual/audit.json
@@ -1,0 +1,26 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Scan the Java Kafka listener-container service in ./service for observability gaps. Do not modify files."
+    },
+    {
+      "id": "readiness-review",
+      "task": "Produce an observability readiness review for the Java Kafka listener-container service in ./service. Identify existing telemetry, missing OpenTelemetry coverage, Spring Kafka listener-container risks, and the next instrumentation step. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies KafkaListenerContainerApplication.java as the Spring Boot entry point and application.properties as the Spring Kafka listener-container configuration surface.",
+    "Identifies AlertListener.java and its @KafkaListener method as the Kafka listener entry point, including the alerts topic and alerts-worker group.",
+    "Identifies AlertService.java as the business processing logic for paging-required alerts.",
+    "Reports no OpenTelemetry SDK setup, Java agent startup, OTLP exporter configuration, or custom Tracer usage.",
+    "Calls out missing Kafka listener spans, malformed/null payload visibility, processed alert counts, critical alert counts, listener error visibility, and consumer lag/offset visibility.",
+    "Recommends the OpenTelemetry Java agent as the primary Spring Kafka instrumentation path and avoids replacing listener container behavior with manual Kafka clients."
+  ]
+}

--- a/evals/java/kafka-listener-container/eval/qual/instrument.json
+++ b/evals/java/kafka-listener-container/eval/qual/instrument.json
@@ -1,0 +1,25 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Add OpenTelemetry instrumentation to the Java Kafka listener-container service in ./service. Preserve the Spring Boot runtime and @KafkaListener container behavior. Prefer Java agent auto-instrumentation for Kafka clients; do not add custom spans or metrics unless explicitly required."
+    },
+    {
+      "id": "runtime-preserving",
+      "task": "Instrument the Java Kafka listener-container service in ./service while preserving the existing Maven runtime, Spring Kafka listener annotations, topic configuration, and listener container behavior. Prefer the OpenTelemetry Java agent, include fast local metric export settings for development use, and avoid unnecessary application code changes."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Performs a Java trace wiring inventory covering Maven dependencies, JAVA_TOOL_OPTIONS or -javaagent startup, OTEL_* configuration, Spring Kafka listener configuration, and existing Tracer usage, then classifies the pre-change fixture as missing based on evidence.",
+    "Preserves KafkaListenerContainerApplication.java, AlertListener.java, AlertService.java, application.properties, the alerts topic, and @KafkaListener behavior.",
+    "Uses or recommends the OpenTelemetry Java agent in the existing Maven/Spring Boot startup path with OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_METRIC_EXPORT_INTERVAL=1000, and OTEL_METRIC_EXPORT_TIMEOUT=500.",
+    "Does not add OpenTelemetrySdk, a duplicate provider, broad manual tracing, custom Tracer creation, or replacement KafkaConsumer loops when no custom spans are requested.",
+    "Mentions that Kafka consumer spans from Spring Kafka listener containers come from the Java agent and treats processed alert counts or malformed-payload counters as optional business instrumentation unless explicitly requested."
+  ]
+}

--- a/evals/java/kafka-listener-container/pom.xml
+++ b/evals/java/kafka-listener-container/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.4</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>kafka-listener-container</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>kafka-listener-container</name>
+    <description>Kafka listener-container service with Spring Kafka for OTel skill evaluation</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertEvent.java
+++ b/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertEvent.java
@@ -1,0 +1,4 @@
+package com.example.kafkalistener;
+
+public record AlertEvent(String alertId, String entityId, String severity, String message) {
+}

--- a/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertListener.java
+++ b/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertListener.java
@@ -1,0 +1,35 @@
+package com.example.kafkalistener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AlertListener {
+
+    private final AlertService service;
+    private final ObjectMapper objectMapper;
+
+    public AlertListener(AlertService service, ObjectMapper objectMapper) {
+        this.service = service;
+        this.objectMapper = objectMapper;
+    }
+
+    @KafkaListener(topics = "${alerts.topic:alerts}", groupId = "${alerts.group:alerts-worker}")
+    public void onAlert(String payload) {
+        parse(payload).ifPresent(service::process);
+    }
+
+    Optional<AlertEvent> parse(String payload) {
+        if (payload == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(payload, AlertEvent.class));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertService.java
+++ b/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertService.java
@@ -1,0 +1,23 @@
+package com.example.kafkalistener;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AlertService {
+
+    private final List<AlertSummary> processed = Collections.synchronizedList(new ArrayList<>());
+
+    public AlertSummary process(AlertEvent event) {
+        boolean pagingRequired = "CRITICAL".equalsIgnoreCase(event.severity());
+        AlertSummary summary = new AlertSummary(event.alertId(), event.entityId(), pagingRequired);
+        processed.add(summary);
+        return summary;
+    }
+
+    public List<AlertSummary> processed() {
+        return List.copyOf(processed);
+    }
+}

--- a/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertSummary.java
+++ b/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/AlertSummary.java
@@ -1,0 +1,4 @@
+package com.example.kafkalistener;
+
+public record AlertSummary(String alertId, String entityId, boolean pagingRequired) {
+}

--- a/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/KafkaListenerContainerApplication.java
+++ b/evals/java/kafka-listener-container/src/main/java/com/example/kafkalistener/KafkaListenerContainerApplication.java
@@ -1,0 +1,14 @@
+package com.example.kafkalistener;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@EnableKafka
+@SpringBootApplication
+public class KafkaListenerContainerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(KafkaListenerContainerApplication.class, args);
+    }
+}

--- a/evals/java/kafka-listener-container/src/main/resources/application.properties
+++ b/evals/java/kafka-listener-container/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.kafka.bootstrap-servers=${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+alerts.topic=${ALERTS_TOPIC:alerts}
+alerts.group=${ALERTS_GROUP:alerts-worker}

--- a/evals/java/kafka-listener-container/src/test/java/com/example/kafkalistener/AlertListenerTest.java
+++ b/evals/java/kafka-listener-container/src/test/java/com/example/kafkalistener/AlertListenerTest.java
@@ -1,0 +1,38 @@
+package com.example.kafkalistener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class AlertListenerTest {
+
+    @Test
+    void processesCriticalAlertPayload() {
+        AlertService service = new AlertService();
+        AlertListener listener = new AlertListener(service, new ObjectMapper());
+
+        listener.onAlert("""
+                {
+                  "alertId": "alert-1",
+                  "entityId": "entity-1",
+                  "severity": "CRITICAL",
+                  "message": "latency high"
+                }
+                """);
+
+        assertEquals(1, service.processed().size());
+        assertTrue(service.processed().getFirst().pagingRequired());
+    }
+
+    @Test
+    void dropsMalformedAlertPayload() {
+        AlertService service = new AlertService();
+        AlertListener listener = new AlertListener(service, new ObjectMapper());
+
+        listener.onAlert("{not-json");
+
+        assertTrue(service.processed().isEmpty());
+    }
+}

--- a/evals/java/kafka-producer-consumer/README.md
+++ b/evals/java/kafka-producer-consumer/README.md
@@ -1,0 +1,24 @@
+# Plain Kafka Producer/Consumer Eval Fixture
+
+This fixture covers direct Java Kafka client usage without Guice, Spring, or
+Kafka Streams.
+
+## Runtime
+
+```bash
+mvn test
+
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
+ORDERS_TOPIC=orders \
+SHIPMENTS_TOPIC=shipments \
+mvn exec:java
+```
+
+`mvn test` is broker-free and verifies the message handling logic. `mvn
+exec:java` requires a running Kafka broker.
+
+The service intentionally contains no OpenTelemetry SDK, Java agent startup
+configuration, OTLP exporter wiring, or custom `Tracer` usage. Instrumentation
+responses should prefer the OpenTelemetry Java agent for producer and consumer
+client spans, with custom business metrics such as shipment commands produced
+treated as optional unless explicitly requested.

--- a/evals/java/kafka-producer-consumer/eval/qual/audit.json
+++ b/evals/java/kafka-producer-consumer/eval/qual/audit.json
@@ -1,0 +1,26 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Scan the plain Java Kafka producer/consumer service in ./service for observability gaps. Do not modify files."
+    },
+    {
+      "id": "readiness-review",
+      "task": "Produce an observability readiness review for the plain Java Kafka producer/consumer service in ./service. Identify existing telemetry, missing OpenTelemetry coverage, producer/consumer risks, and the next instrumentation step. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies ProducerConsumerApplication.java as the entry point and KafkaClientConfig.java as the startup/runtime configuration surface.",
+    "Identifies OrderConsumer.java as the KafkaConsumer poll loop and ShipmentProducer.java as the KafkaProducer send path.",
+    "Names the orders and shipments topics and distinguishes consumed records from produced shipment commands.",
+    "Reports no OpenTelemetry SDK setup, Java agent startup, OTLP exporter configuration, or custom Tracer usage.",
+    "Calls out missing Kafka producer/consumer spans, shipment command counts, malformed/null order visibility, consumer lag/offset visibility, and producer send error visibility.",
+    "Recommends the OpenTelemetry Java agent as the primary Kafka producer/consumer instrumentation path and treats business metrics as optional custom signals."
+  ]
+}

--- a/evals/java/kafka-producer-consumer/eval/qual/instrument.json
+++ b/evals/java/kafka-producer-consumer/eval/qual/instrument.json
@@ -1,0 +1,25 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Add OpenTelemetry instrumentation to the plain Java Kafka producer/consumer service in ./service. Preserve the direct KafkaProducer and KafkaConsumer runtime shape. Prefer Java agent auto-instrumentation for Kafka clients; do not add custom spans or metrics unless explicitly required."
+    },
+    {
+      "id": "runtime-preserving",
+      "task": "Instrument the plain Java Kafka producer/consumer service in ./service while preserving the existing Maven runtime, Kafka topics, and poll/send behavior. Prefer the OpenTelemetry Java agent, include fast local metric export settings for development use, and avoid unnecessary application code changes."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Performs a Java trace wiring inventory covering Maven dependencies, JAVA_TOOL_OPTIONS or -javaagent startup, OTEL_* configuration, Kafka producer/consumer code, and existing Tracer usage, then classifies the pre-change fixture as missing based on evidence.",
+    "Preserves ProducerConsumerApplication.java, OrderConsumer.java, ShipmentProducer.java, and the orders to shipments topic flow.",
+    "Uses or recommends the OpenTelemetry Java agent in the existing Maven/Java startup path with OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_METRIC_EXPORT_INTERVAL=1000, and OTEL_METRIC_EXPORT_TIMEOUT=500.",
+    "Does not add OpenTelemetrySdk, a duplicate provider, broad manual tracing, or custom Tracer creation when no custom spans are requested.",
+    "Mentions that Kafka producer and consumer spans come from the Java agent and treats shipment command counts or malformed-order counters as optional business instrumentation unless explicitly requested."
+  ]
+}

--- a/evals/java/kafka-producer-consumer/pom.xml
+++ b/evals/java/kafka-producer-consumer/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>kafka-producer-consumer</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>kafka-producer-consumer</name>
+    <description>Plain Kafka producer and consumer service for OTel skill evaluation</description>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.17.2</jackson.version>
+        <junit.version>5.10.3</junit.version>
+        <kafka.version>3.8.1</kafka.version>
+        <slf4j.version>2.0.16</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <mainClass>com.example.kafka.ProducerConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/KafkaClientConfig.java
+++ b/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/KafkaClientConfig.java
@@ -1,0 +1,48 @@
+package com.example.kafka;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+public record KafkaClientConfig(
+        String bootstrapServers,
+        String ordersTopic,
+        String shipmentsTopic,
+        String consumerGroup) {
+
+    public static KafkaClientConfig fromEnvironment() {
+        Map<String, String> env = System.getenv();
+        return new KafkaClientConfig(
+                env.getOrDefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
+                env.getOrDefault("ORDERS_TOPIC", "orders"),
+                env.getOrDefault("SHIPMENTS_TOPIC", "shipments"),
+                env.getOrDefault("KAFKA_CONSUMER_GROUP", "shipment-worker"));
+    }
+
+    public Properties producerProperties() {
+        Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.ACKS_CONFIG, "all");
+        return properties;
+    }
+
+    public Properties consumerProperties() {
+        Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return properties;
+    }
+
+    public List<String> orderTopicSubscription() {
+        return List.of(ordersTopic);
+    }
+}

--- a/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/OrderConsumer.java
+++ b/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/OrderConsumer.java
@@ -1,0 +1,55 @@
+package com.example.kafka;
+
+import java.time.Duration;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public final class OrderConsumer implements AutoCloseable {
+
+    private final KafkaConsumer<String, String> consumer;
+    private final String ordersTopic;
+    private final OrderMessageHandler handler;
+    private final ShipmentProducer producer;
+
+    public OrderConsumer(
+            KafkaConsumer<String, String> consumer,
+            String ordersTopic,
+            OrderMessageHandler handler,
+            ShipmentProducer producer) {
+        this.consumer = consumer;
+        this.ordersTopic = ordersTopic;
+        this.handler = handler;
+        this.producer = producer;
+    }
+
+    public void runForever() {
+        consumer.subscribe(java.util.List.of(ordersTopic));
+        while (!Thread.currentThread().isInterrupted()) {
+            pollOnce(Duration.ofMillis(500));
+        }
+    }
+
+    public int pollOnce(Duration timeout) {
+        ConsumerRecords<String, String> records = consumer.poll(timeout);
+        int produced = 0;
+        for (ConsumerRecord<String, String> record : records) {
+            produced += handleRecord(record);
+        }
+        return produced;
+    }
+
+    private int handleRecord(ConsumerRecord<String, String> record) {
+        return handler.toShipmentCommand(record.value())
+                .map(command -> {
+                    producer.send(command, handler.toJson(command));
+                    return 1;
+                })
+                .orElse(0);
+    }
+
+    @Override
+    public void close() {
+        consumer.close();
+    }
+}

--- a/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/OrderEvent.java
+++ b/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/OrderEvent.java
@@ -1,0 +1,4 @@
+package com.example.kafka;
+
+public record OrderEvent(String orderId, String customerId, String region, int itemCount) {
+}

--- a/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/OrderMessageHandler.java
+++ b/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/OrderMessageHandler.java
@@ -1,0 +1,46 @@
+package com.example.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+
+public final class OrderMessageHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public OrderMessageHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Optional<ShipmentCommand> toShipmentCommand(String payload) {
+        if (payload == null) {
+            return Optional.empty();
+        }
+        try {
+            OrderEvent order = objectMapper.readValue(payload, OrderEvent.class);
+            return Optional.of(new ShipmentCommand(
+                    order.orderId(),
+                    order.customerId(),
+                    warehouseFor(order.region()),
+                    order.itemCount()));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+
+    public String toJson(ShipmentCommand command) {
+        try {
+            return objectMapper.writeValueAsString(command);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialize shipment command " + command.orderId(), e);
+        }
+    }
+
+    private String warehouseFor(String region) {
+        return switch (region) {
+            case "us-east" -> "warehouse-a";
+            case "eu" -> "warehouse-eu";
+            default -> "warehouse-west";
+        };
+    }
+}

--- a/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/ProducerConsumerApplication.java
+++ b/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/ProducerConsumerApplication.java
@@ -1,0 +1,31 @@
+package com.example.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+public final class ProducerConsumerApplication {
+
+    private ProducerConsumerApplication() {
+    }
+
+    public static void main(String[] args) {
+        KafkaClientConfig config = KafkaClientConfig.fromEnvironment();
+        OrderMessageHandler handler = new OrderMessageHandler(new ObjectMapper());
+
+        KafkaProducer<String, String> producer = new KafkaProducer<>(config.producerProperties());
+        KafkaConsumer<String, String> consumer;
+        try {
+            consumer = new KafkaConsumer<>(config.consumerProperties());
+        } catch (RuntimeException | Error e) {
+            producer.close(Duration.ofSeconds(5));
+            throw e;
+        }
+
+        try (ShipmentProducer shipmentProducer = new ShipmentProducer(producer, config.shipmentsTopic());
+                OrderConsumer orderConsumer = new OrderConsumer(consumer, config.ordersTopic(), handler, shipmentProducer)) {
+            orderConsumer.runForever();
+        }
+    }
+}

--- a/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/ShipmentCommand.java
+++ b/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/ShipmentCommand.java
@@ -1,0 +1,4 @@
+package com.example.kafka;
+
+public record ShipmentCommand(String orderId, String customerId, String warehouse, int itemCount) {
+}

--- a/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/ShipmentProducer.java
+++ b/evals/java/kafka-producer-consumer/src/main/java/com/example/kafka/ShipmentProducer.java
@@ -1,0 +1,25 @@
+package com.example.kafka;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+public final class ShipmentProducer implements AutoCloseable {
+
+    private final KafkaProducer<String, String> producer;
+    private final String topic;
+
+    public ShipmentProducer(KafkaProducer<String, String> producer, String topic) {
+        this.producer = producer;
+        this.topic = topic;
+    }
+
+    public void send(ShipmentCommand command, String payload) {
+        producer.send(new ProducerRecord<>(topic, command.orderId(), payload));
+    }
+
+    @Override
+    public void close() {
+        producer.flush();
+        producer.close();
+    }
+}

--- a/evals/java/kafka-producer-consumer/src/test/java/com/example/kafka/OrderMessageHandlerTest.java
+++ b/evals/java/kafka-producer-consumer/src/test/java/com/example/kafka/OrderMessageHandlerTest.java
@@ -1,0 +1,39 @@
+package com.example.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OrderMessageHandlerTest {
+
+    private final OrderMessageHandler handler = new OrderMessageHandler(new ObjectMapper());
+
+    @Test
+    void buildsShipmentCommandForValidOrder() {
+        Optional<ShipmentCommand> command = handler.toShipmentCommand("""
+                {
+                  "orderId": "order-1",
+                  "customerId": "customer-1",
+                  "region": "us-east",
+                  "itemCount": 3
+                }
+                """);
+
+        assertTrue(command.isPresent());
+        assertEquals("warehouse-a", command.get().warehouse());
+        assertEquals(3, command.get().itemCount());
+    }
+
+    @Test
+    void dropsMalformedOrders() {
+        assertTrue(handler.toShipmentCommand("{not-json").isEmpty());
+    }
+
+    @Test
+    void dropsNullOrders() {
+        assertTrue(handler.toShipmentCommand(null).isEmpty());
+    }
+}

--- a/evals/java/kafka-streams/README.md
+++ b/evals/java/kafka-streams/README.md
@@ -1,0 +1,44 @@
+# Kafka Streams Eval Fixture
+
+This fixture is a small order stream processor used by the OTel skill evals.
+It uses Guice for application wiring and Kafka Streams for stream-processing.
+
+## Runtime
+
+```bash
+mvn test
+
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
+KAFKA_APPLICATION_ID=order-risk-stream \
+ORDERS_TOPIC=orders \
+ENRICHED_ORDERS_TOPIC=orders.enriched \
+FRAUD_ALERTS_TOPIC=orders.fraud-alerts \
+mvn exec:java
+```
+
+This fixture does not define a fat-jar or shaded-jar build. Use
+`mvn exec:java` for local live runs, with a Kafka broker available at
+`KAFKA_BOOTSTRAP_SERVERS`.
+
+The service intentionally contains no OpenTelemetry SDK, Java agent startup
+configuration, OTLP exporter wiring, or Guice `Tracer` binding.
+
+## Eval Intent
+
+The audit and instrumentation evals share one boundary: use the OpenTelemetry
+Java agent as the primary Kafka Streams instrumentation path, and do not add a
+manual SDK, duplicate provider, or Guice `Tracer` binding unless the task
+explicitly asks for custom spans or metrics.
+
+`OrderEventParser` intentionally drops malformed and null order records without
+logging, metrics, or spans. Audit responses should identify that failed-parse
+visibility gap. Instrumentation responses should treat a failed-parse counter or
+record-processing latency metric as optional business instrumentation unless the
+prompt explicitly requests custom signals.
+
+`OrderEventParser.toJson()` throws on serialization failure and is not a silent
+failure gap; the intentional silent failure is limited to `parse()`.
+
+Instrumentation responses that add or recommend Java agent runtime settings
+should include fast local metric export settings such as
+`OTEL_METRIC_EXPORT_INTERVAL=1000` and `OTEL_METRIC_EXPORT_TIMEOUT=500`.

--- a/evals/java/kafka-streams/eval/qual/audit.json
+++ b/evals/java/kafka-streams/eval/qual/audit.json
@@ -1,0 +1,27 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Scan the Java Kafka Streams service in ./service for observability gaps. Do not modify files."
+    },
+    {
+      "id": "readiness-review",
+      "task": "Produce an observability readiness review for the Java Kafka Streams service in ./service. Identify existing telemetry, missing OpenTelemetry coverage, stream-processing risks, existing Guice wiring, and the next instrumentation step. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies KafkaStreamsApplication.java as the process entry point and StreamProcessingModule.java as the Guice module that provides KafkaStreams.",
+    "Identifies OrderStreamTopology.java as the Kafka Streams topology and names the orders, orders.enriched, and orders.fraud-alerts topics.",
+    "Reports no OpenTelemetry SDK setup, Java agent startup, OTLP exporter configuration, or Guice Tracer binding.",
+    "Calls out missing Kafka producer/consumer traces plus record-processing, failed-parse, high-risk-alert, error, and latency visibility.",
+    "Calls out that OrderEventParser.parse() drops null records with no log, metric, or span, making null-record events invisible at runtime.",
+    "Calls out that OrderEventParser.parse() swallows malformed JSON with no log, metric, or span, making parse failures invisible at runtime.",
+    "Recommends the OpenTelemetry Java agent as the primary Kafka Streams instrumentation path and limits custom spans or metrics to explicit business signal needs."
+  ]
+}

--- a/evals/java/kafka-streams/eval/qual/instrument.json
+++ b/evals/java/kafka-streams/eval/qual/instrument.json
@@ -1,0 +1,26 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Add OpenTelemetry instrumentation to the Java Kafka Streams service in ./service. Preserve the Kafka topology and existing Guice module structure. Prefer Java agent auto-instrumentation for Kafka clients; do not create a second SDK or Guice Tracer binding unless custom spans are explicitly required."
+    },
+    {
+      "id": "runtime-preserving",
+      "task": "Instrument the Java Kafka Streams service in ./service while preserving the existing Maven runtime, Guice injector, and Kafka topic behavior. Prefer the OpenTelemetry Java agent for Kafka Streams coverage, include fast local metric export settings for development use, and avoid unnecessary application code changes."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Performs a Java trace wiring inventory covering Maven dependencies, JAVA_TOOL_OPTIONS or -javaagent startup, OTEL_* configuration, Guice modules, and existing Tracer usage, then classifies the pre-change fixture as missing based on evidence.",
+    "Preserves KafkaStreamsApplication.java, StreamProcessingModule.java, OrderStreamTopology.java, and the orders to orders.enriched plus orders.fraud-alerts topic flow.",
+    "Uses or recommends the OpenTelemetry Java agent in the existing Maven/Java startup path with OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_METRIC_EXPORT_INTERVAL=1000, and OTEL_METRIC_EXPORT_TIMEOUT=500.",
+    "Does not add OpenTelemetrySdk, a duplicate provider, broad manual tracing, or a Guice @Provides Tracer binding when no custom spans are requested.",
+    "Mentions that Kafka producer/consumer spans, including clients used internally by Kafka Streams, come from the Java agent and treats custom record-processing spans or metrics as optional business instrumentation rather than required auto-instrumentation when custom signals are not explicitly requested.",
+    "Acknowledges that OrderEventParser.parse() drops null and malformed records with no telemetry, and treats a failed-parse counter as optional business instrumentation unless explicitly requested."
+  ]
+}

--- a/evals/java/kafka-streams/pom.xml
+++ b/evals/java/kafka-streams/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>kafka-streams</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>kafka-streams</name>
+    <description>Kafka Streams order processor with Guice wiring for OTel skill evaluation</description>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <guice.version>7.0.0</guice.version>
+        <jackson.version>2.17.2</jackson.version>
+        <junit.version>5.10.3</junit.version>
+        <kafka.version>3.8.1</kafka.version>
+        <slf4j.version>2.0.16</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams-test-utils</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <mainClass>com.example.streaming.KafkaStreamsApplication</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/EnrichedOrder.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/EnrichedOrder.java
@@ -1,0 +1,11 @@
+package com.example.streaming;
+
+public record EnrichedOrder(
+        String orderId,
+        String customerId,
+        double amount,
+        String region,
+        String status,
+        boolean highRisk,
+        String riskReason) {
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/KafkaStreamsApplication.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/KafkaStreamsApplication.java
@@ -1,0 +1,19 @@
+package com.example.streaming;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public final class KafkaStreamsApplication {
+
+    private KafkaStreamsApplication() {
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        Injector injector = Guice.createInjector(new StreamProcessingModule());
+        OrderStreamService service = injector.getInstance(OrderStreamService.class);
+        Runtime.getRuntime().addShutdownHook(new Thread(service::close, "streams-shutdown"));
+
+        service.start();
+        Thread.currentThread().join();
+    }
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderEvent.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderEvent.java
@@ -1,0 +1,9 @@
+package com.example.streaming;
+
+public record OrderEvent(
+        String orderId,
+        String customerId,
+        double amount,
+        String region,
+        String status) {
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderEventParser.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderEventParser.java
@@ -1,0 +1,35 @@
+package com.example.streaming;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import java.util.Optional;
+
+public final class OrderEventParser {
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public OrderEventParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Optional<OrderEvent> parse(String payload) {
+        if (payload == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(payload, OrderEvent.class));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+
+    public String toJson(EnrichedOrder order) {
+        try {
+            return objectMapper.writeValueAsString(order);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialize enriched order " + order.orderId(), e);
+        }
+    }
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderStreamService.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderStreamService.java
@@ -1,0 +1,35 @@
+package com.example.streaming;
+
+import com.google.inject.Inject;
+import java.time.Duration;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class OrderStreamService implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(OrderStreamService.class);
+
+    private final KafkaStreams streams;
+
+    @Inject
+    public OrderStreamService(KafkaStreams streams) {
+        this.streams = streams;
+    }
+
+    public void start() {
+        streams.setUncaughtExceptionHandler(exception -> {
+            logger.error("Kafka Streams thread failed", exception);
+            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+        });
+        streams.start();
+        logger.info("Order stream processor started");
+    }
+
+    @Override
+    public void close() {
+        streams.close(Duration.ofSeconds(10));
+        logger.info("Order stream processor stopped");
+    }
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderStreamTopology.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/OrderStreamTopology.java
@@ -1,0 +1,48 @@
+package com.example.streaming;
+
+import com.google.inject.Inject;
+import java.util.List;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+
+public final class OrderStreamTopology {
+
+    private final OrderEventParser parser;
+    private final RiskScorer riskScorer;
+    private final StreamConfig config;
+
+    @Inject
+    public OrderStreamTopology(OrderEventParser parser, RiskScorer riskScorer, StreamConfig config) {
+        this.parser = parser;
+        this.riskScorer = riskScorer;
+        this.config = config;
+    }
+
+    public Topology build() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> rawOrders = builder.stream(
+                config.ordersTopic(),
+                Consumed.with(Serdes.String(), Serdes.String()));
+
+        KStream<String, EnrichedOrder> enrichedOrders = rawOrders.flatMapValues(payload ->
+                parser.parse(payload)
+                        .map(riskScorer::enrich)
+                        .map(List::of)
+                        .orElseGet(List::of));
+
+        enrichedOrders
+                .mapValues(parser::toJson)
+                .to(config.enrichedOrdersTopic(), Produced.with(Serdes.String(), Serdes.String()));
+
+        enrichedOrders
+                .filter((key, order) -> order.highRisk())
+                .mapValues(parser::toJson)
+                .to(config.fraudAlertsTopic(), Produced.with(Serdes.String(), Serdes.String()));
+
+        return builder.build();
+    }
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/RiskScorer.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/RiskScorer.java
@@ -1,0 +1,32 @@
+package com.example.streaming;
+
+public final class RiskScorer {
+
+    private static final double HIGH_VALUE_THRESHOLD = 10_000.0;
+
+    public EnrichedOrder enrich(OrderEvent event) {
+        boolean highRisk = isHighRisk(event);
+        return new EnrichedOrder(
+                event.orderId(),
+                event.customerId(),
+                event.amount(),
+                event.region(),
+                event.status(),
+                highRisk,
+                highRisk ? riskReason(event) : "none");
+    }
+
+    private boolean isHighRisk(OrderEvent event) {
+        return event.amount() >= HIGH_VALUE_THRESHOLD || "MANUAL_REVIEW".equalsIgnoreCase(event.status());
+    }
+
+    private String riskReason(OrderEvent event) {
+        if (event.amount() >= HIGH_VALUE_THRESHOLD) {
+            return "high-value-order";
+        }
+        if ("MANUAL_REVIEW".equalsIgnoreCase(event.status())) {
+            return "manual-review-status";
+        }
+        return "none";
+    }
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/StreamConfig.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/StreamConfig.java
@@ -1,0 +1,36 @@
+package com.example.streaming;
+
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+
+public record StreamConfig(
+        String bootstrapServers,
+        String applicationId,
+        String ordersTopic,
+        String enrichedOrdersTopic,
+        String fraudAlertsTopic) {
+
+    public static StreamConfig fromEnvironment() {
+        Map<String, String> env = System.getenv();
+        return new StreamConfig(
+                env.getOrDefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
+                env.getOrDefault("KAFKA_APPLICATION_ID", "order-risk-stream"),
+                env.getOrDefault("ORDERS_TOPIC", "orders"),
+                env.getOrDefault("ENRICHED_ORDERS_TOPIC", "orders.enriched"),
+                env.getOrDefault("FRAUD_ALERTS_TOPIC", "orders.fraud-alerts"));
+    }
+
+    public Properties toKafkaProperties() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE);
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return properties;
+    }
+}

--- a/evals/java/kafka-streams/src/main/java/com/example/streaming/StreamProcessingModule.java
+++ b/evals/java/kafka-streams/src/main/java/com/example/streaming/StreamProcessingModule.java
@@ -1,0 +1,31 @@
+package com.example.streaming;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import org.apache.kafka.streams.KafkaStreams;
+
+public final class StreamProcessingModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(StreamConfig.class).toInstance(StreamConfig.fromEnvironment());
+        bind(OrderEventParser.class).in(Singleton.class);
+        bind(RiskScorer.class).in(Singleton.class);
+        bind(OrderStreamTopology.class).in(Singleton.class);
+        bind(OrderStreamService.class).in(Singleton.class);
+    }
+
+    @Provides
+    @Singleton
+    ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Provides
+    @Singleton
+    KafkaStreams kafkaStreams(StreamConfig config, OrderStreamTopology topology) {
+        return new KafkaStreams(topology.build(), config.toKafkaProperties());
+    }
+}

--- a/evals/java/kafka-streams/src/main/resources/simplelogger.properties
+++ b/evals/java/kafka-streams/src/main/resources/simplelogger.properties
@@ -1,0 +1,3 @@
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.showThreadName=true

--- a/evals/java/kafka-streams/src/test/java/com/example/streaming/OrderStreamTopologyTest.java
+++ b/evals/java/kafka-streams/src/test/java/com/example/streaming/OrderStreamTopologyTest.java
@@ -1,0 +1,184 @@
+package com.example.streaming;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Properties;
+import java.util.UUID;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.jupiter.api.Test;
+
+class OrderStreamTopologyTest {
+
+    private static final String HIGH_VALUE_ORDER = """
+            {
+              "orderId": "order-100",
+              "customerId": "customer-22",
+              "amount": 12500.0,
+              "region": "us-west",
+              "status": "SUBMITTED"
+            }
+            """;
+
+    private static final String NORMAL_ORDER = """
+            {
+              "orderId": "order-101",
+              "customerId": "customer-23",
+              "amount": 125.0,
+              "region": "us-west",
+              "status": "SUBMITTED"
+            }
+            """;
+
+    private static final String MANUAL_REVIEW_ORDER = """
+            {
+              "orderId": "order-102",
+              "customerId": "customer-24",
+              "amount": 75.0,
+              "region": "us-east",
+              "status": "MANUAL_REVIEW"
+            }
+            """;
+
+    @Test
+    void routesHighRiskOrdersToEnrichedAndFraudTopics() {
+        StreamConfig config = testConfig();
+        OrderStreamTopology topology = new OrderStreamTopology(
+                new OrderEventParser(new ObjectMapper()),
+                new RiskScorer(),
+                config);
+
+        try (TopologyTestDriver driver = new TopologyTestDriver(topology.build(), testProperties(config))) {
+            TestInputTopic<String, String> orders = inputTopic(driver, config);
+            TestOutputTopic<String, String> enriched = outputTopic(driver, config.enrichedOrdersTopic());
+            TestOutputTopic<String, String> fraud = outputTopic(driver, config.fraudAlertsTopic());
+
+            orders.pipeInput("order-100", HIGH_VALUE_ORDER);
+
+            assertFalse(enriched.isEmpty(), "expected enriched output");
+            assertFalse(fraud.isEmpty(), "expected fraud output");
+            String enrichedPayload = enriched.readValue();
+            String fraudPayload = fraud.readValue();
+            assertTrue(enrichedPayload.contains("\"orderId\":\"order-100\""));
+            assertTrue(fraudPayload.contains("\"highRisk\":true"));
+            assertTrue(fraudPayload.contains("\"riskReason\":\"high-value-order\""));
+        }
+    }
+
+    @Test
+    void routesNormalOrdersOnlyToEnrichedTopic() {
+        StreamConfig config = testConfig();
+        OrderStreamTopology topology = new OrderStreamTopology(
+                new OrderEventParser(new ObjectMapper()),
+                new RiskScorer(),
+                config);
+
+        try (TopologyTestDriver driver = new TopologyTestDriver(topology.build(), testProperties(config))) {
+            TestInputTopic<String, String> orders = inputTopic(driver, config);
+            TestOutputTopic<String, String> enriched = outputTopic(driver, config.enrichedOrdersTopic());
+            TestOutputTopic<String, String> fraud = outputTopic(driver, config.fraudAlertsTopic());
+
+            orders.pipeInput("order-101", NORMAL_ORDER);
+
+            assertFalse(enriched.isEmpty(), "expected enriched output");
+            String enrichedPayload = enriched.readValue();
+            assertTrue(enrichedPayload.contains("\"orderId\":\"order-101\""));
+            assertTrue(enrichedPayload.contains("\"highRisk\":false"));
+            assertTrue(fraud.isEmpty());
+        }
+    }
+
+    @Test
+    void routesManualReviewOrdersToFraudTopic() {
+        StreamConfig config = testConfig();
+        OrderStreamTopology topology = new OrderStreamTopology(
+                new OrderEventParser(new ObjectMapper()),
+                new RiskScorer(),
+                config);
+
+        try (TopologyTestDriver driver = new TopologyTestDriver(topology.build(), testProperties(config))) {
+            TestInputTopic<String, String> orders = inputTopic(driver, config);
+            TestOutputTopic<String, String> enriched = outputTopic(driver, config.enrichedOrdersTopic());
+            TestOutputTopic<String, String> fraud = outputTopic(driver, config.fraudAlertsTopic());
+
+            orders.pipeInput("order-102", MANUAL_REVIEW_ORDER);
+
+            assertFalse(enriched.isEmpty(), "expected enriched output");
+            assertFalse(fraud.isEmpty(), "expected fraud output");
+            String enrichedPayload = enriched.readValue();
+            String fraudPayload = fraud.readValue();
+            assertTrue(enrichedPayload.contains("\"orderId\":\"order-102\""));
+            assertTrue(fraudPayload.contains("\"highRisk\":true"));
+            assertTrue(fraudPayload.contains("\"riskReason\":\"manual-review-status\""));
+        }
+    }
+
+    @Test
+    void dropsMalformedOrderEvents() {
+        StreamConfig config = testConfig();
+        OrderStreamTopology topology = new OrderStreamTopology(
+                new OrderEventParser(new ObjectMapper()),
+                new RiskScorer(),
+                config);
+
+        try (TopologyTestDriver driver = new TopologyTestDriver(topology.build(), testProperties(config))) {
+            TestInputTopic<String, String> orders = inputTopic(driver, config);
+            TestOutputTopic<String, String> enriched = outputTopic(driver, config.enrichedOrdersTopic());
+            TestOutputTopic<String, String> fraud = outputTopic(driver, config.fraudAlertsTopic());
+
+            orders.pipeInput("bad-order", "{not-json");
+
+            assertTrue(enriched.isEmpty());
+            assertTrue(fraud.isEmpty());
+        }
+    }
+
+    @Test
+    void dropsNullOrderEvents() {
+        StreamConfig config = testConfig();
+        OrderStreamTopology topology = new OrderStreamTopology(
+                new OrderEventParser(new ObjectMapper()),
+                new RiskScorer(),
+                config);
+
+        try (TopologyTestDriver driver = new TopologyTestDriver(topology.build(), testProperties(config))) {
+            TestInputTopic<String, String> orders = inputTopic(driver, config);
+            TestOutputTopic<String, String> enriched = outputTopic(driver, config.enrichedOrdersTopic());
+            TestOutputTopic<String, String> fraud = outputTopic(driver, config.fraudAlertsTopic());
+
+            orders.pipeInput("deleted-order", (String) null);
+
+            assertTrue(enriched.isEmpty());
+            assertTrue(fraud.isEmpty());
+        }
+    }
+
+    private static StreamConfig testConfig() {
+        return new StreamConfig(
+                "dummy:9092",
+                "order-risk-stream-test",
+                "orders",
+                "orders.enriched",
+                "orders.fraud-alerts");
+    }
+
+    private static Properties testProperties(StreamConfig config) {
+        Properties properties = config.toKafkaProperties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, config.applicationId() + "-" + UUID.randomUUID());
+        return properties;
+    }
+
+    private static TestInputTopic<String, String> inputTopic(TopologyTestDriver driver, StreamConfig config) {
+        return driver.createInputTopic(config.ordersTopic(), new StringSerializer(), new StringSerializer());
+    }
+
+    private static TestOutputTopic<String, String> outputTopic(TopologyTestDriver driver, String topic) {
+        return driver.createOutputTopic(topic, new StringDeserializer(), new StringDeserializer());
+    }
+}

--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -261,6 +261,17 @@ Report requirements:
 - For Python, mention `pyproject.toml` or `requirements.txt`, the app file such as `app.py`, and runtime files such as `Dockerfile` or `docker-compose.yml` when present.
 - For FastAPI/Celery services, mention the web app, worker file, Dockerfile, compose commands, FastAPI/ASGI coverage, Celery instrumentation, Redis instrumentation if Redis is present, and HTTP client instrumentation only when an HTTP client dependency is detected.
 - For Java/Spring Boot, mention the Spring Boot entry point such as `TasksApplication.java`, controller files such as `TaskController.java`, and the Java agent recommendation.
+- For Java/Kafka services, mention the main entry point, runtime configuration,
+  producer/consumer classes that wrap `KafkaProducer` or `KafkaConsumer`, batch
+  poll loops that handle `ConsumerRecords`, listener-container classes or
+  methods such as `@KafkaListener`, and Kafka Streams lifecycle/topology code
+  that constructs `KafkaStreams`, `Topology`, `StreamsBuilder`, `KStream`, or
+  `KTable`.
+- For Java/Kafka services, name topics, consumer groups, poll/send/listener or
+  topology behavior, offset commit behavior, uncaught exception handling, Java
+  agent coverage for Kafka clients, and missing business signals such as
+  processed records, failed parses, high-risk alerts, processing errors,
+  consumer lag/offset visibility, and record-processing latency.
 - For Go multi-package services, name the process entry point such as `cmd/kvstore-server/main.go` and relevant library files. If filesystem persistence, background indexing, or LRU eviction exists, call those out explicitly.
 
 **Chat summary:** After writing `.observe/otel.md`, present a brief summary in
@@ -379,7 +390,8 @@ appear in the project.
 The OpenTelemetry Java agent auto-instruments without code changes:
 - Spring MVC (REST controllers), Spring WebFlux, Spring Data (JPA, JDBC)
 - RestTemplate and WebClient (outbound HTTP)
-- Kafka, RabbitMQ, gRPC
+- Kafka producers/consumers (including clients used internally by Kafka Streams)
+- RabbitMQ, gRPC
 - Servlet containers (Tomcat, Jetty, Undertow)
 - JDBC drivers
 

--- a/skills/otel-instrument/references/languages/java.md
+++ b/skills/otel-instrument/references/languages/java.md
@@ -124,15 +124,41 @@ The Java agent auto-instruments:
 - Spring WebFlux (reactive endpoints)
 - Spring Data (JPA, JDBC)
 - RestTemplate and WebClient (outbound HTTP)
-- Kafka, RabbitMQ, gRPC
+- Kafka producers/consumers (including clients used internally by Kafka Streams)
+- RabbitMQ, gRPC
 - Servlet containers (Tomcat, Jetty, Undertow)
 - JDBC drivers
 
 No code changes needed for basic coverage.
-In final user-facing output, state that Spring MVC and the servlet container
-will emit HTTP server spans and request duration metrics through the agent.
-Also name the service identity and exporter settings, for example
-`OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT`.
+In final user-facing output, name only the frameworks and clients actually
+detected in the project. For Spring MVC or servlet apps, state that HTTP server
+spans and request duration metrics will come through the agent. For Kafka or
+Kafka Streams apps, state that producer, consumer, and stream client spans will
+come through the agent. Also name the service identity and exporter settings,
+for example `OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+### Kafka Processing Patterns
+
+For Java Kafka services, preserve the current processing pattern instead of
+rewriting the application to fit instrumentation. Do not convert one Kafka
+processing model into another just to add telemetry:
+
+- Plain producer/consumer services: keep `KafkaProducer.send()` and
+  `KafkaConsumer.poll()` startup behavior intact.
+- Batch consumers: keep `ConsumerRecords` batch processing, offset commit
+  behavior, and batch-level error handling intact.
+- Listener-container services, such as Spring Kafka `@KafkaListener` apps: keep
+  listener annotations, container factories, topic properties, and framework
+  startup intact.
+- Kafka Streams: keep the topology, processors, state stores, topic flow, and
+  stream lifecycle code intact.
+
+The Java agent covers Kafka producer and consumer clients, including clients
+used internally by Kafka Streams and Spring Kafka listener containers. It does
+not create spans for Kafka Streams DSL operations or business batch-processing
+steps by itself. Treat processed-record counts, failed-parse counters,
+batch-size metrics, high-risk alert counts, and topology-level spans as optional
+custom business instrumentation unless the user explicitly requests them.
 
 ---
 
@@ -271,7 +297,11 @@ Use the `-javaagent` JVM flag in the `bootRun` task or application config.
 
 - **Agent vs SDK**: The javaagent approach requires no code changes for basic coverage. Only add the OTel API dependency when you need custom spans or metrics.
 - **`JAVA_TOOL_OPTIONS`**: This env var is the cleanest way to inject the agent in containerized or service-managed environments.
-- **Spring Boot**: The agent covers Spring MVC, WebFlux, Data, RestTemplate, WebClient, Kafka, and RabbitMQ automatically. No additional setup needed.
+- **Spring Boot and Kafka**: The agent covers Spring MVC, WebFlux, Data,
+  RestTemplate, WebClient, Kafka producers/consumers including clients used
+  internally by Kafka Streams, and RabbitMQ automatically. Topology-level
+  Kafka Streams DSL spans require custom instrumentation. No additional setup
+  needed for basic spans and runtime metrics.
 - **Metric export interval and timeout**: For local runtime checks, set both
   `OTEL_METRIC_EXPORT_INTERVAL=1000` and `OTEL_METRIC_EXPORT_TIMEOUT=500` so
   HTTP duration metrics flush promptly.


### PR DESCRIPTION
## Summary
- Add Java Kafka eval fixtures organized by processing pattern: direct producer/consumer, batch consumer, listener container, and Kafka Streams.
- Add otel-audit and otel-instrument qual evals for each Kafka fixture.
- Update Java Kafka audit/instrument guidance to preserve producer/consumer, batch, listener-container, and Streams runtime shapes while clarifying Java-agent versus custom-signal boundaries.

## Validation
- `mvn -q -s <empty-temp-settings> test` in `evals/java/kafka-producer-consumer`.
- `mvn -q -s <empty-temp-settings> test` in `evals/java/kafka-batch-consumer`.
- `mvn -q -s <empty-temp-settings> test` in `evals/java/kafka-listener-container`.
- `mvn -q -s <empty-temp-settings> test` in `evals/java/kafka-streams`.
- Parsed `evals/java/*/eval/qual/*.json` and `evals/java/*/pom.xml`.
- Ran `git diff --check`.
- Combined review: protocol-style, baseline, and bounded Claude diff-only passes found no verified P0-P2 issues.