### PR TITLE
Add MTTD incident readiness to observability skills

### DIFF
--- a/evals/test_incident_readiness_skill_guidance.py
+++ b/evals/test_incident_readiness_skill_guidance.py
@@ -241,6 +241,61 @@ def test_splunk_configure_consumes_current_main_gaps_section():
     assert not missing
 
 
+def test_audit_emits_gap_ledger_contract():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    required_terms = [
+        "## Gap Ledger",
+        "gap_id",
+        "required_signals",
+        "owner",
+        "code_surface",
+        "acceptance_criteria",
+        "audit output is a contract",
+        "not background context",
+        "partial",
+    ]
+    missing = [term for term in required_terms if term not in audit]
+    assert not missing
+
+
+def test_instrument_reconciles_audit_gap_contract():
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "Audit Gap Contract",
+        "gap_id",
+        "required_signals",
+        "implemented_signals",
+        "remaining_signals",
+        "App-owned + patchable",
+        "Code added + tests",
+        "App-owned but unsafe/too large",
+        "Explicitly split into named follow-up batch",
+        "Provider/platform-owned",
+        "Owner mapped with exact missing source",
+        "Already covered",
+        "Proven with source path and signal name",
+        "cannot say",
+        "covered",
+        "fixed",
+        "closed",
+    ]
+    missing = [term for term in required_terms if term not in instrument]
+    assert not missing
+
+
+def test_splunk_configure_demotes_partial_gap_coverage():
+    skill = _read(SPLUNK_CONFIGURE)
+    required_terms = [
+        "partial closure",
+        "generate detectors only for implemented or proven signals",
+        "Do not imply complete coverage",
+        "remaining_signals",
+        "Instrumentation Prerequisites",
+    ]
+    missing = [term for term in required_terms if term not in skill]
+    assert not missing
+
+
 def test_splunk_configure_no_metrics_still_reports_prerequisites():
     skill = _read(SPLUNK_CONFIGURE)
     required_terms = [

--- a/evals/test_incident_readiness_skill_guidance.py
+++ b/evals/test_incident_readiness_skill_guidance.py
@@ -1,0 +1,430 @@
+"""Deterministic checks for incident-readiness skill guidance."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+INCIDENT_REF = SKILLS_DIR / "references" / "incident-readiness.md"
+SPLUNK_CONFIGURE = SKILLS_DIR / "splunk-configure" / "SKILL.md"
+SPLUNK_CONFIGURE_REFS = SKILLS_DIR / "splunk-configure" / "references"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"Expected file not found: {path}"
+    return path.read_text()
+
+
+def test_incident_reference_covers_generic_incident_patterns():
+    text = _read(INCIDENT_REF)
+    required_terms = [
+        "API/workflow",
+        "Customer impact",
+        "Dependency",
+        "Freshness",
+        "Backpressure",
+        "Auth/edge",
+        "Capacity",
+        "Release context",
+        "detector group-by keys",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_incident_reference_covers_generic_mttd_signal_checklist():
+    text = _read(INCIDENT_REF)
+    required_terms = [
+        "service.version",
+        "deployment.environment",
+        "deployment.region",
+        "deployment.platform",
+        "container.image.tag",
+        "artifact version",
+        "config version",
+        "canary/rollout batch",
+        "restart/crash-loop",
+        "desired-vs-healthy",
+        "startup/readiness/healthcheck",
+        "CPU/memory/disk",
+        "concurrency",
+        "quota",
+        "throttling",
+        "endpoint health",
+        "target health",
+        "traffic target health",
+        "Synthetic/canary workflow checks",
+        "input size/complexity bucket",
+        "metadata count when relevant",
+        "offline/derived data",
+        "schema/migration version when present",
+        "fallback target readiness",
+        "compatibility failure class",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_audit_and_instrument_load_incident_reference():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    for text in (audit, instrument):
+        assert "../references/incident-readiness.md" in text
+        assert "incident-readiness" in text
+        assert "faster incident detection" in text
+
+
+def test_instrument_allows_recommended_semconv_readiness_signals():
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "recommended optional metrics or attributes",
+        "requested readiness",
+        "observe the values accurately",
+        "privacy/cardinality",
+    ]
+    missing = [term for term in required_terms if term not in instrument]
+    assert not missing
+
+
+def test_instrument_converts_incident_readiness_audit_to_patchable_work():
+    text = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "Audit-Driven Incident Readiness",
+        "approved request for custom incident-readiness instrumentation",
+        "Do not stop",
+        "auto-instrumentation",
+        "gap-closure matrix",
+        "workflow outcome/error/latency",
+        "dependency timeout/retry/rate-limit/error",
+        "queue/backpressure",
+        "Do not call incident-readiness instrumentation complete",
+        "no safe app-owned",
+        "incident-readiness patch found",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_instrument_requires_gap_closure_matrix_for_incident_readiness():
+    text = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "gap-closure matrix",
+        "gap -> repo evidence -> owner -> code location",
+        "add instrumentation",
+        "prove existing instrumentation",
+        "mark out of scope with owner",
+        "Do not call incident-readiness instrumentation complete",
+        "executor/backpressure",
+        "streaming",
+        "auth/edge",
+        "freshness/job",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_instrument_requires_incident_evidence_gap_closure():
+    skill = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(INCIDENT_REF)
+    required_skill_terms = [
+        "incident-evidence mode",
+        "failure mechanism",
+        "owning code surface",
+        "MTTD/localization impact",
+        "executor/backpressure",
+        "streaming",
+        "auth/edge",
+        "freshness/job",
+        "release/config",
+    ]
+    missing_skill = [term for term in required_skill_terms if term not in skill]
+    assert not missing_skill
+
+    required_reference_terms = [
+        "Incident-Evidence Mode",
+        "MTTD-improving",
+        "localization-only",
+        "Required Surface Patterns",
+        "Auth, edge, and secrets",
+        "missing or stale output",
+        "dependency target loss",
+        "Jobs and offline/derived data outputs",
+        "expected-vs-running version",
+    ]
+    missing_reference = [term for term in required_reference_terms if term not in reference]
+    assert not missing_reference
+
+
+def test_instrument_requires_generic_runtime_surface_closure():
+    text = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "generic runtime surfaces",
+        "executor services",
+        "thread pools",
+        "worker pools",
+        "bounded queues",
+        "rejected-execution paths",
+        "queue-full handling",
+        "queue depth",
+        "active/inflight work",
+        "pool capacity",
+        "rejected/shed work",
+        "saturation outcome",
+        "long-lived connection or streaming surfaces",
+        "WebSocket",
+        "SSE",
+        "streaming HTTP/RPC",
+        "broker streams",
+        "bidirectional",
+        "client streams",
+        "connect/open",
+        "authentication/authorization",
+        "start/stop/detach/keepalive",
+        "close reason family",
+        "send/write failure",
+        "active",
+        "connections/channels/streams",
+        "stream duration/outcome",
+        "remains only",
+        "listed as a follow-up",
+        "explicitly narrowed scope",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_instrument_skips_custom_prompt_for_incident_readiness_requests():
+    text = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "Skip this prompt",
+        "incident-readiness work",
+        "Audit-Driven Incident Readiness path",
+        "implement the safe",
+        "scoped",
+        "signals",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_incident_readiness_guidance_is_present_across_all_skills():
+    paths = [
+        SKILLS_DIR / "otel-audit" / "SKILL.md",
+        SKILLS_DIR / "otel-instrument" / "SKILL.md",
+        SPLUNK_CONFIGURE,
+    ]
+    required_terms = [
+        "customer-impact",
+        "dependency",
+        "freshness",
+        "backpressure",
+        "auth/edge",
+        "capacity",
+        "release/config",
+    ]
+    for path in paths:
+        text = _read(path)
+        missing = [term for term in required_terms if term not in text]
+        assert not missing, f"{path} missing incident-readiness terms: {missing}"
+
+
+def test_splunk_configure_consumes_current_main_gaps_section():
+    skill = _read(SPLUNK_CONFIGURE)
+    required_terms = [
+        "## Gaps",
+        "current-main",
+        "instrumentation prerequisite",
+        "Instrumentation Prerequisites",
+        "detector for a missing signal",
+    ]
+    missing = [term for term in required_terms if term not in skill]
+    assert not missing
+
+
+def test_splunk_configure_no_metrics_still_reports_prerequisites():
+    skill = _read(SPLUNK_CONFIGURE)
+    required_terms = [
+        "No metrics detected",
+        "do not generate detector or",
+        "Continue processing `## Gaps`",
+        "`## Incident Readiness`",
+        ".observe/detectors.md",
+        "alert coverage matrix",
+    ]
+    missing = [term for term in required_terms if term not in skill]
+    assert not missing
+
+
+def test_splunk_configure_consumes_incident_readiness_section():
+    skill = _read(SPLUNK_CONFIGURE)
+    required_terms = [
+        "## Incident Readiness",
+        "incident-readiness areas become instrumentation",
+        "For every incident-readiness area",
+        "unless equivalent metrics are present",
+        "Do not generate detectors",
+    ]
+    missing = [term for term in required_terms if term not in skill]
+    assert not missing
+
+
+def test_splunk_configure_owns_detector_reliability_handoff():
+    skill = _read(SPLUNK_CONFIGURE)
+    classification = _read(SPLUNK_CONFIGURE_REFS / "detector-classification.md")
+    templates = _read(SPLUNK_CONFIGURE_REFS / "terraform-templates.md")
+    required_terms = [
+        "detector reliability evidence",
+        "missed, flapping, auto-resolved, or no-data alerts",
+        "alert-coverage-audit",
+        "Do not ask app instrumentation",
+        "Do not generate service metric Terraform",
+    ]
+    combined = "\n".join((skill, classification, templates))
+    missing = [term for term in required_terms if term not in combined]
+    assert not missing
+
+
+def test_splunk_configure_covers_dependency_release_and_capacity_mttd_signals():
+    skill = _read(SPLUNK_CONFIGURE)
+    classification = _read(SPLUNK_CONFIGURE_REFS / "detector-classification.md")
+    required_terms = [
+        "endpoint health",
+        "target health",
+        "rate-limit",
+        "unhealthy target",
+        "disk",
+        "filesystem",
+        "desired-vs-healthy",
+        "startup/readiness/healthcheck",
+        "deployment.region",
+        "deployment.platform",
+        "container.image.tag",
+        "artifact version",
+    ]
+    for text in (skill, classification):
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_splunk_configure_dashboard_signalflow_guardrails():
+    skill = _read(SPLUNK_CONFIGURE)
+    templates = _read(SPLUNK_CONFIGURE_REFS / "terraform-templates.md")
+    required_skill_terms = [
+        "Keep the Splunk Observability Cloud API `realm` variable separate",
+        "Do not use `var.realm` as a SignalFlow filter",
+        "`sfx_realm`",
+        "dashboard variables",
+        "Before writing chart `program_text`",
+        "pre-aggregated percentile metrics",
+        "do not average",
+        "value sanity check",
+        "apply_if_exist = true",
+        "stale `configId` parameter",
+        "mixed-unit signals",
+        "separate panels",
+        "provider-derived",
+        "stale/unowned evidence",
+        "source-backed coverage",
+        "cumulative counters",
+        "`rollup='rate'`",
+    ]
+    required_template_terms = [
+        "Do not equate the provider/API `realm` variable with telemetry",
+        "`sfx_realm`",
+        "dashboard variables",
+        "apply_if_exist = true",
+        "apply_if_exist = false",
+        "pre-aggregated",
+        "do not average",
+        "known-traffic window",
+        "unverified in `.observe/dashboards.md`",
+        "stale `configId` parameter",
+        "mixed-unit signals",
+        "separate panels",
+        "provider-derived",
+        "stale/unowned evidence",
+        "source-backed emitter",
+        "cumulative timers",
+        "`rollup='rate'`",
+    ]
+    assert not [term for term in required_skill_terms if term not in skill]
+    assert not [term for term in required_template_terms if term not in templates]
+    for term in ["e.g. us1, eu0, lab0", "e.g. us1, eu0", "us1", "eu0", "lab0"]:
+        assert term not in skill
+        assert term not in templates
+
+
+def test_splunk_configure_preserves_runtime_cpu_coverage():
+    skill = _read(SPLUNK_CONFIGURE)
+    classification = _read(SPLUNK_CONFIGURE_REFS / "detector-classification.md")
+    templates = _read(SPLUNK_CONFIGURE_REFS / "terraform-templates.md")
+    required_terms = [
+        "source-backed CPU utilization",
+        "CPU saturation detector",
+        "Do not use thread count",
+        "cumulative CPU time",
+        "diagnostic rate",
+        "`rollup='rate'`",
+        "normalized CPU utilization",
+    ]
+    for text in (skill, classification, templates):
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_audit_keeps_current_main_report_contract():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    unmerged_report_terms = [
+        "## Signal Flow",
+        "### Component Flow Map",
+        "### Step-by-Step Signal Coverage",
+        "| Priority | Area | Gap | User Impact | Fix | Instrument Mode |",
+    ]
+    present = [term for term in unmerged_report_terms if term in audit]
+    assert not present
+
+
+def test_incident_readiness_guidance_stays_generic_and_non_genai():
+    paths = [
+        INCIDENT_REF,
+        SKILLS_DIR / "otel-audit" / "SKILL.md",
+        SKILLS_DIR / "otel-instrument" / "SKILL.md",
+        SPLUNK_CONFIGURE,
+        SPLUNK_CONFIGURE_REFS / "detector-classification.md",
+        SPLUNK_CONFIGURE_REFS / "terraform-templates.md",
+    ]
+    blocked_terms = [
+        "GenAI",
+        "LLM",
+        "gen_ai",
+        "RAG",
+        "IR-",
+        "guildcore",
+        "Guildcore",
+        "guild.ai",
+        "sb-rest",
+        "signalboost",
+        "signalboost-rest",
+        "sbrest",
+        "metadata-server",
+        "matt-server",
+        "Matt",
+        "meatballs",
+        "Meatballs",
+        "US1",
+        "EU0",
+        "us1",
+        "eu0",
+        "lab0",
+        "checkout",
+        "missing report output",
+        "active-node",
+        "active node",
+        "Decision or delivery workflow",
+        "decision or delivery workflow",
+        "workflow delivery/evaluation",
+    ]
+    for path in paths:
+        text = _read(path)
+        bad = [term for term in blocked_terms if term in text]
+        assert not bad, f"{path} contains non-generic terms: {bad}"

--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -144,7 +144,34 @@ the user asks for faster incident detection/localization, use
 `../references/incident-readiness.md` to check API/workflow, customer-impact,
 dependency, freshness, backpressure, auth/edge, capacity, and release/config
 signals. Add `## Incident Readiness` rows and `## Gaps` entries for missing
-signals that would make incidents faster to detect, route, or localize.
+signals that would make incidents faster to detect, route, or localize. For
+each gap, include the expected instrumentation action:
+`add instrumentation`, `prove existing instrumentation`, or
+`mark out of scope with owner`.
+
+**Gap ledger contract** -- the audit output is a contract, not background context.
+For every app-owned, provider-owned, platform-owned, or already-covered
+readiness gap, create a structured ledger row with: `gap_id`,
+`required_signals`, `owner`, `code_surface`, and `acceptance_criteria`. Use
+stable IDs such as `G1`, `G2`, and split a gap when required signals have
+different owners or acceptance criteria. Required signals must be concrete
+signal names or signal intents, not vague area labels. Use owner values that map
+directly to the instrumentation result categories: `App-owned + patchable`,
+`App-owned but unsafe/too large`, `Provider/platform-owned`, or
+`Already covered`.
+
+Status must be computed against every required signal in the ledger:
+
+| Ledger result | Rule |
+|---|---|
+| `covered` | Every required signal is proven existing with source path and signal name. |
+| `partial` | Some required signals exist, but remaining required signals are named. |
+| `missing` | No required app-owned signal exists. |
+| `owner-mapped` | The repo cannot accurately observe the signal and the provider/platform/deployment owner plus exact missing source is named. |
+
+Do not collapse a partial gap into `covered` because one metric or span exists.
+The ledger is the source of truth for `$otel-instrument` and
+`$splunk-configure`.
 
 **Anti-patterns** -- flag any of these:
 
@@ -264,6 +291,18 @@ incident detection/localization.
 | Freshness/backpressure | {covered / partial / missing} | {lag, age, queue depth, consumer lag, dropped count} | {missing freshness lag, drop reason, oldest age, or paused consumer signal} | {stale data or backlog may not alert before user impact} |
 | Auth/edge/capacity/release | {covered / partial / missing} | {auth/edge, CPU/memory/disk/concurrency capacity, desired-vs-healthy/readiness/startup/healthcheck, `service.version`, `deployment.environment`, `deployment.region`, `deployment.platform`, `container.image.tag`, artifact/config/rollout dimensions} | {missing auth failure class, disk or concurrency saturation, desired-vs-healthy, startup/readiness/healthcheck failure, traffic target health, or release/config context} | {impact cannot be correlated quickly to edge, capacity, platform health, or rollout changes} |
 
+## Gap Ledger
+
+This is the contract for `$otel-instrument` and `$splunk-configure`; do not
+treat it as background context. Use the field names `gap_id`,
+`required_signals`, `owner`, `code_surface`, and `acceptance_criteria` as the
+handoff schema even though the table headers are human-readable.
+
+| Gap ID | Status | Required Signals | Owner | Code Surface | Acceptance Criteria |
+|--------|--------|------------------|-------|--------------|---------------------|
+| G1 | {missing / partial / covered / owner-mapped} | {signal A; signal B; signal C} | {App-owned + patchable / App-owned but unsafe/too large / Provider/platform-owned / Already covered} | {file/path or referenced source} | {code + tests, proof path + signal name, or exact external owner/source} |
+| ... | ... | ... | ... | ... | ... |
+
 ## Gaps
 - {remaining non-RED gaps: missing auto-instrumentation packages, missing
   context propagation, missing OTLP exporter configuration, missing
@@ -292,6 +331,8 @@ Report requirements:
   group-by keys.
 - If incident-readiness coverage is requested or detected, include
   `## Incident Readiness` after `## RED Signals`.
+- Always include `## Gap Ledger` after readiness sections and before `## Gaps`.
+  Every `## Gaps` bullet must map back to a Gap ID.
 - Keep incident-readiness guidance generic: no organization-specific service
   names, incident IDs, customer names, realms, or product-specific workflow
   names.

--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -5,12 +5,13 @@ description: >-
   on observability coverage gaps. Read-only -- does not modify code.
   Use when the user types $otel-audit, asks about observability gaps,
   wants to assess instrumentation coverage, says "what signals am I
-  missing", "scan this service for observability", or asks about
-  "observability readiness". Do NOT use for implementing code changes --
-  use $otel-instrument instead.
+  missing", "scan this service for observability", asks about
+  "observability readiness", or asks whether instrumentation can make incidents
+  faster to detect or localize. Do NOT use for implementing code changes -- use
+  $otel-instrument instead.
 metadata:
   author: otel-studio
-  version: 0.6.0
+  version: 0.6.1
   category: observability
 ---
 
@@ -29,6 +30,10 @@ is modified.
 - Checking what auto-instrumentation is already wired up
 - Identifying dependencies that lack matching OTel instrumentation
 - Quick health check of an existing OTel setup
+- Assessing whether API/workflow, dependency, data freshness, queue,
+  auth/edge, capacity, and release/config signals can support incident
+  detection and localization
+
 **When NOT to use:** If you want to add instrumentation, use `$otel-instrument`.
 
 ## Process
@@ -47,7 +52,12 @@ Scan the repository to determine language, framework, and existing instrumentati
 2. Identify entry points (`main`, `cmd/`, `app.py`, `index.ts`, etc.)
 3. Enumerate all HTTP routes with method and path pattern (e.g. `GET /tasks`, `POST /tasks`, `GET /tasks/{id}`). List them explicitly in the report.
 4. Use the Auto-Instrumentation Library Map below to identify which packages should be present for each detected dependency.
-5. Record exact evidence paths that should appear in the report:
+5. Detect incident-readiness ownership: user-visible workflows, dependency
+  calls, background processing, queues/streams, data freshness, auth/edge
+  paths, capacity limits, and release/config context. When present or when the
+  user asks for faster incident detection/localization, load
+  `../references/incident-readiness.md`.
+6. Record exact evidence paths that should appear in the report:
   - Dependency manifest: `go.mod`, `package.json`, `pyproject.toml`, `pom.xml`, etc.
   - Process entry point: `main.go`, `cmd/.../main.go`, `app.py`, `app.js`, `TasksApplication.java`, etc.
   - Route source: router/controller files such as `TaskController.java`, `app.py`, `app.js`, or `kvstore/http.go`.
@@ -120,6 +130,7 @@ for Python, `@opentelemetry/instrumentation-winston` /
 derivation? (e.g. `http.server.request.duration` histogram counts, or
 server spans from auto-instrumentation.)
 Status: `covered` / `partial` / `missing`.
+
 - **Errors:** Are span status codes set on failures? Is `recordException`
 called? Do HTTP auto-instrumentation spans capture 5xx status?
 Status: `covered` / `partial` / `missing`.
@@ -127,6 +138,13 @@ Status: `covered` / `partial` / `missing`.
 percentiles? (e.g. `http.server.request.duration` histogram, or span
 duration from auto-instrumentation.)
 Status: `covered` / `partial` / `missing`.
+
+**Incident readiness assessment** -- when incident-readiness evidence exists or
+the user asks for faster incident detection/localization, use
+`../references/incident-readiness.md` to check API/workflow, customer-impact,
+dependency, freshness, backpressure, auth/edge, capacity, and release/config
+signals. Add `## Incident Readiness` rows and `## Gaps` entries for missing
+signals that would make incidents faster to detect, route, or localize.
 
 **Anti-patterns** -- flag any of these:
 
@@ -234,10 +252,25 @@ Status values:
   exist but no histogram for percentile breakdown).
 - **missing** -- no data source provides this signal.
 
+## Incident Readiness
+
+Include when incident-readiness evidence exists or when the user asks for faster
+incident detection/localization.
+
+| Area | Status | Evidence | Gap | Detection/Localization Impact |
+|------|--------|----------|-----|-------------------------------|
+| API/workflow impact | {covered / partial / missing} | {route/workflow spans, latency/error/outcome metrics} | {missing workflow outcome, status code, error class, or latency metric} | {app-down vs degraded workflow remains slow to classify} |
+| Dependencies | {covered / partial / missing} | {client spans/metrics by dependency and operation; endpoint health or target health metrics when available} | {missing retry, timeout, rate-limit, error class, endpoint health, target health, availability, or circuit-breaker state} | {root-cause dependency remains slow to localize} |
+| Freshness/backpressure | {covered / partial / missing} | {lag, age, queue depth, consumer lag, dropped count} | {missing freshness lag, drop reason, oldest age, or paused consumer signal} | {stale data or backlog may not alert before user impact} |
+| Auth/edge/capacity/release | {covered / partial / missing} | {auth/edge, CPU/memory/disk/concurrency capacity, desired-vs-healthy/readiness/startup/healthcheck, `service.version`, `deployment.environment`, `deployment.region`, `deployment.platform`, `container.image.tag`, artifact/config/rollout dimensions} | {missing auth failure class, disk or concurrency saturation, desired-vs-healthy, startup/readiness/healthcheck failure, traffic target health, or release/config context} | {impact cannot be correlated quickly to edge, capacity, platform health, or rollout changes} |
+
 ## Gaps
 - {remaining non-RED gaps: missing auto-instrumentation packages, missing
   context propagation, missing OTLP exporter configuration, missing
-  service.name resource, etc.}
+  service.name resource, missing API/workflow impact, dependency endpoint
+  health, freshness, backpressure, auth/edge, CPU/memory/disk capacity,
+  desired-vs-healthy/readiness/startup/healthcheck, release/config signals,
+  etc.}
 - If no gaps remain, write: "No additional gaps detected."
 
 ## Anti-Patterns
@@ -249,11 +282,24 @@ Status values:
   $otel-instrument for custom business metrics"}
 
 ---
-*Generated by obstudio v0.6.0 otel-audit on {YYYY-MM-DD HH:MM UTC}*
+*Generated by obstudio v0.6.1 otel-audit on {YYYY-MM-DD HH:MM UTC}*
 ```
 
 Report requirements:
 
+- IDs for users, accounts, tenants, sessions, tasks, conversations, and traces
+  may help trace drilldown, but must not be metric dimensions or detector
+  group-by keys.
+- If incident-readiness coverage is requested or detected, include
+  `## Incident Readiness` after `## RED Signals`.
+- Keep incident-readiness guidance generic: no organization-specific service
+  names, incident IDs, customer names, realms, or product-specific workflow
+  names.
+- Treat missing workflow outcome, dependency endpoint health,
+  freshness/backpressure, auth/edge, CPU/memory/disk/concurrency saturation,
+  desired-vs-healthy/readiness/startup/healthcheck, and release/config
+  correlation as gaps only when code or runtime evidence shows the service owns
+  that surface.
 - If instrumentation is incomplete, always include the exact token `$otel-instrument` in the recommendation.
 - If OpenTelemetry is absent, include both words `OpenTelemetry` and `missing`.
 - Name the concrete files that support findings; do not only refer to "the service" or "./service".

--- a/skills/otel-instrument/SKILL.md
+++ b/skills/otel-instrument/SKILL.md
@@ -82,11 +82,42 @@ needs to be set up first and continue with the full workflow (Steps 2-3).
 
 ### Audit-Driven Incident Readiness
 
+#### Audit Gap Contract
+
+If `.observe/otel.md` contains `## Gap Ledger`, use that ledger as the source
+of truth. The audit output is a contract, not background context. Start by
+parsing every row into `gap_id`, `required_signals`, `owner`, `code_surface`,
+and `acceptance_criteria`. If the audit predates `## Gap Ledger`, synthesize
+the same fields from `## Gaps` and `## Incident Readiness` before editing code.
+
+Reconcile every audit gap to a required instrumentation result:
+
+| Audit Gap | Required Instrumentation Result |
+|---|---|
+| App-owned + patchable | Code added + tests |
+| App-owned but unsafe/too large | Explicitly split into named follow-up batch |
+| Provider/platform-owned | Owner mapped with exact missing source |
+| Already covered | Proven with source path and signal name |
+
+For each row, produce and maintain a closure matrix:
+`gap_id -> required_signals -> implemented_signals -> tests ->
+remaining_signals -> status`. The final gate is strict: the instrumentation
+pass cannot say `covered`, `fixed`, `closed`, or `complete` unless every
+required signal is either implemented with tests, proven existing with source
+path and signal name, or explicitly owner-mapped with the exact missing source.
+Optimize for honesty over broad progress. Partial closure is acceptable; silent
+partial closure is the bug.
+
 If `.observe/otel.md` contains `## Incident Readiness` rows with `partial` or
 `missing` status and the user asked to instrument, treat those rows as an
 approved request for custom incident-readiness instrumentation. Do not stop
 after auto-instrumentation and do not ask the Step 4 custom-instrumentation
 question for gaps that the repo clearly owns.
+
+When the user asks broadly to apply readiness skills, improve MTTD, or fix
+found gaps, treat the scope as **all discovered app-owned gaps**. Do not select
+one representative or highest-value gap unless the user explicitly narrows the
+scope to that gap.
 
 1. Convert each partial/missing row into candidate signals using
    `../references/incident-readiness.md`.
@@ -94,14 +125,23 @@ question for gaps that the repo clearly owns.
    - **app-owned and patchable**: the code exposes the value accurately and a
      low-cardinality metric/span can be added in an owned handler, client,
      queue, worker, limiter, or health path.
+   - **app-owned but unsafe/too large**: the code owns the signal, but the
+     change cannot be safely completed in the current batch; split it into a
+     named follow-up batch with exact remaining signals.
    - **deployment/platform-owned**: the signal belongs in Helm, Kubernetes,
      Terraform, VM/systemd, load balancer, collector, or runtime telemetry.
+   - **already covered**: the signal exists and is proven with source path and
+     signal name.
    - **unknown owner**: the audit names a dependency/config source that was not
      inspected.
-3. Implement the highest-value app-owned patchable signal per affected area
-   before moving to verification. Prefer workflow outcome/error/latency,
-   dependency timeout/retry/rate-limit/error, queue/backpressure, freshness, or
-   capacity saturation signals that can become detectors.
+3. Implement every safe app-owned patchable signal before moving to
+   verification. Prefer workflow outcome/error/latency, dependency
+   timeout/retry/rate-limit/error, queue/backpressure, freshness, or capacity
+   saturation signals that can become detectors. If the full set is too large
+   for one change, stop and report the scoped batch before editing; otherwise
+   do not leave an app-owned candidate as a follow-up.
+   Keep dependency timeout/retry/rate-limit/error coverage explicit when a
+   downstream dependency is part of the gap.
 4. Also close generic runtime surfaces discovered during the scan:
    - If the target code owns executor services, thread pools, worker pools,
      bounded queues, rejected-execution paths, queue-full handling, or async
@@ -126,10 +166,20 @@ question for gaps that the repo clearly owns.
      low-cardinality version, config version, rollout batch, expected-vs-running,
      and decision outcome dimensions.
 5. Before finalizing, maintain a gap-closure matrix with one row per incident
-   or readiness gap: `gap -> repo evidence -> owner -> code location -> action
-   -> signal names/attributes -> test/verification -> remaining owner`. The
+   or readiness gap: `gap_id -> required_signals -> implemented_signals ->
+   tests -> remaining_signals -> status`, plus repo evidence, owner, code
+   location, action, trace evidence, metric evidence, log/event evidence, signal
+   names/attributes, test/verification, and remaining owner/source. The
+   compatibility form `gap -> repo evidence -> owner -> code location ->
+   action -> trace evidence -> metric evidence -> log/event evidence -> signal
+   names/attributes -> test/verification -> remaining owner` is acceptable only
+   when no structured `gap_id` exists.
    action must be `add instrumentation`, `prove existing instrumentation`, or
    `mark out of scope with owner`.
+   Every discovered gap must resolve to one of those actions before the work is
+   called complete. A final response, audit, or PR description must not say
+   complete, covered, or fixed while any app-owned gap is still only a
+   follow-up.
 6. Do not call incident-readiness instrumentation complete when an app-owned
    executor/backpressure, streaming, auth/edge, freshness/job, dependency, or
    release/config surface remains only listed as a follow-up, unless the user

--- a/skills/otel-instrument/SKILL.md
+++ b/skills/otel-instrument/SKILL.md
@@ -6,10 +6,11 @@ description: >-
   asks to "add OTel", "add tracing", "add metrics", "implement observability",
   "wire up telemetry", "instrument this service", or asks to add a specific
   custom signal like "add a metric to track queue depth", "add a span for
-  payment processing", "track error rate for X".
+  payment processing", "track error rate for X", asks to add signals that make
+  incidents faster to detect or localize.
 metadata:
   author: otel-studio
-  version: 0.1.1
+  version: 0.1.2
   category: observability
 ---
 
@@ -28,8 +29,25 @@ Before editing anything, ground the plan with repo evidence:
 - Confirm the language and framework from actual dependency or source files
 - Confirm the target process from the repo's real start surface: `docker-compose.yml`, Kubernetes manifests, `package.json` scripts, `Makefile`, `Procfile`, PM2 configs, Supervisor configs, systemd units, launchd plists, PowerShell scripts, or a plain shell command
 - Confirm existing telemetry indicators or record `none found`
+- Detect incident-readiness surfaces. Search source and config for user-visible
+  workflows, dependency clients, background jobs, queues/streams, data
+  freshness, auth/edge paths, capacity limits, and release/config context. When
+  present or when the user asks for faster incident detection/localization, load
+  `../references/incident-readiness.md`.
+- When incident reports, postmortems, tickets, alerts, or user-provided failure
+  examples are part of the request, use incident-evidence mode from
+  `../references/incident-readiness.md`: map each failure mechanism to the
+  owning code surface before editing, and judge proposed signals by whether they
+  improve detection, routing, localization, or only documentation.
 - For Java projects, build a trace wiring inventory per `./references/languages/java.md` (Preflight section) and classify as `auto-only`, `custom-with-provider`, `custom-provider-external`, or `missing` before editing.
-- Confirm the planned `service.name` source and `deployment.environment` source
+- Confirm the planned `service.name`, `service.version`,
+  `deployment.environment`, `deployment.region`, `deployment.platform`, and
+  `container.image.tag` or artifact-version sources when those dimensions are
+  available and low-cardinality
+- Prefer existing OTel semantic-convention or platform resource attribute names
+  when they are already emitted. Treat `deployment.region`,
+  `deployment.platform`, and `container.image.tag` as generic context aliases
+  unless the repo already uses those exact attribute names.
 - Distinguish between application repos and tooling repos such as CLIs, MCP servers, workers, libraries, installers, and build tools. Instrument the executable path users or operators actually run today. Do not invent a web app, Docker path, or entrypoint that is not present.
 - If the repo has multiple runnable surfaces, instrument the one the user actually cares about; otherwise ask which one matters
 - If the repo is primarily tooling or library code and no runnable surface is obvious, stop and ask instead of inventing an app shell
@@ -43,7 +61,11 @@ Do not proceed until you can state all of these clearly:
 - environment dimension
 - incremental addition vs new scaffold
 - for Java, trace source of truth (see `./references/languages/java.md` Preflight section)
-
+- incident-readiness surfaces and the workflow/dependency/freshness/backpressure
+  signals to add, when the repo owns those surfaces
+- incident-evidence coverage when incidents are supplied: failure mechanism,
+  owning code surface, signal to add or prove, expected MTTD/localization impact,
+  and remaining non-code or dependency owner
 ### Fast Path: Targeted Custom Signal
 
 If the user is asking for a specific signal ("add a metric for queue depth",
@@ -57,6 +79,65 @@ preflight scan finds OTel SDK already initialized:
 
 If the preflight scan finds no OTel SDK, tell the user auto-instrumentation
 needs to be set up first and continue with the full workflow (Steps 2-3).
+
+### Audit-Driven Incident Readiness
+
+If `.observe/otel.md` contains `## Incident Readiness` rows with `partial` or
+`missing` status and the user asked to instrument, treat those rows as an
+approved request for custom incident-readiness instrumentation. Do not stop
+after auto-instrumentation and do not ask the Step 4 custom-instrumentation
+question for gaps that the repo clearly owns.
+
+1. Convert each partial/missing row into candidate signals using
+   `../references/incident-readiness.md`.
+2. Classify each candidate as:
+   - **app-owned and patchable**: the code exposes the value accurately and a
+     low-cardinality metric/span can be added in an owned handler, client,
+     queue, worker, limiter, or health path.
+   - **deployment/platform-owned**: the signal belongs in Helm, Kubernetes,
+     Terraform, VM/systemd, load balancer, collector, or runtime telemetry.
+   - **unknown owner**: the audit names a dependency/config source that was not
+     inspected.
+3. Implement the highest-value app-owned patchable signal per affected area
+   before moving to verification. Prefer workflow outcome/error/latency,
+   dependency timeout/retry/rate-limit/error, queue/backpressure, freshness, or
+   capacity saturation signals that can become detectors.
+4. Also close generic runtime surfaces discovered during the scan:
+   - If the target code owns executor services, thread pools, worker pools,
+     bounded queues, rejected-execution paths, queue-full handling, or async
+     dispatch, add or prove detector-ready queue depth, active/inflight work,
+     pool capacity, queue wait, rejected/shed work, timeout, and saturation outcome
+     signals.
+   - If the target code owns long-lived connection or streaming surfaces such as
+     WebSocket, SSE, streaming HTTP/RPC, broker streams, or bidirectional client streams,
+     add or prove lifecycle signals for connect/open,
+     authentication/authorization, start/stop/detach/keepalive, close reason
+     family, send/write failure, active connections/channels/streams, and stream
+     duration/outcome. Treat close reason family and stream duration/outcome as
+     required lifecycle signals when the code owns the stream.
+   - If the target code owns auth, identity, token, secret, certificate, domain,
+     or edge-routing flows, add or prove lifecycle, failure reason family,
+     expiry/rotation, and route/config mismatch signals.
+   - If the target code owns scheduled jobs, reports, exports, notifications,
+     ingestion, sync, or derived data, add or prove last-success timestamp,
+     freshness/age, duration, output count, dropped/skipped reason, and
+     publish/consume outcome signals.
+   - If the target code owns rollout/config/feature-flag decisions, add or prove
+     low-cardinality version, config version, rollout batch, expected-vs-running,
+     and decision outcome dimensions.
+5. Before finalizing, maintain a gap-closure matrix with one row per incident
+   or readiness gap: `gap -> repo evidence -> owner -> code location -> action
+   -> signal names/attributes -> test/verification -> remaining owner`. The
+   action must be `add instrumentation`, `prove existing instrumentation`, or
+   `mark out of scope with owner`.
+6. Do not call incident-readiness instrumentation complete when an app-owned
+   executor/backpressure, streaming, auth/edge, freshness/job, dependency, or
+   release/config surface remains only listed as a follow-up, unless the user
+   explicitly narrowed scope.
+7. If no app-owned candidate is safe to patch, make no placeholder instruments.
+   Instead, update the report or final response with `no safe app-owned
+   incident-readiness patch found`, list the missing owner/source, and name the
+   exact signal that remains a prerequisite for `$splunk-configure`.
 
 ### 2. Dependencies
 
@@ -97,7 +178,21 @@ Apply auto-instrumentation first, then add manual spans for key business operati
 - HTTP server instrumentation must produce request-duration metrics as well as spans. Accept the current stable metric `http.server.request.duration` and the older `http.server.duration` name where SDK versions differ.
 - For local, Docker, and eval-style runtime checks, configure metric export to flush quickly. When constructing a metric reader manually, use the language equivalent of `OTEL_METRIC_EXPORT_INTERVAL` with a safe local default of `1000` ms and `OTEL_METRIC_EXPORT_TIMEOUT` with a safe local default of `500` ms instead of relying on SDK defaults.
 - Strictly adhere to OTel [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) for span and metric naming and attributes for domains where such semantic conventions are defined.
-- For domains where OTel semantic conventions exist, emit required spans and metrics only, with required attributes only. Do not emit spans or metrics that are marked optional, do not include attributes that are marked optional. Do not invent custom spans, metrics or attributes in domains where OTel semantic conventions exist.
+- For domains where OTel semantic conventions exist, use semantic-convention
+  names and attributes. Start with required spans, metrics, and attributes; add
+  recommended optional metrics or attributes only when a requested readiness
+  signal depends on them, the service can observe the values accurately, and
+  privacy/cardinality rules allow them. Do not invent custom spans, metrics, or
+  attributes in domains where OTel semantic conventions exist.
+- For incident-readiness work, follow `../references/incident-readiness.md`:
+  instrument only code-evidenced API/workflow, customer-impact, dependency,
+  freshness, backpressure, auth/edge, capacity, and release/config surfaces;
+  prefer semantic-convention HTTP/RPC/database/messaging/runtime signals; add
+  custom workflow, lag, freshness, outcome, retry, timeout, rate-limit,
+  endpoint-health, target-health, drop-reason, circuit-breaker, CPU/memory/disk
+  saturation, desired-vs-healthy, startup/readiness/healthcheck failure,
+  traffic target health, and release/config signals only when the service owns
+  and can observe them accurately.
 - For custom attribute names use `{domain}.{noun}.{adjective}` format.
 - Span names must be low-cardinality (no IDs, no variable path segments).
 - Metric attributes must avoid high cardinality.
@@ -151,6 +246,12 @@ After auto-instrumentation is wired up, prompt the user:
 
 Then wait for the user's answer.
 
+Skip this prompt when the user already asked for a specific custom signal,
+incident-readiness work, or when the Audit-Driven Incident Readiness path
+applies. In those cases, the user's request and audit gaps are the approval
+context; implement the safe scoped signals and clearly list any unpatched
+prerequisites.
+
 - **If no**: proceed to the build check (Step 5).
 - **If yes**: analyze the codebase for high-value custom instrumentation points:
   - Error handling paths that catch and handle exceptions
@@ -158,6 +259,18 @@ Then wait for the user's answer.
   - External calls not covered by auto-instrumentation libraries
   - Background workers and scheduled jobs
   - Cache interactions without auto-instrumentation support
+  - Incident-readiness boundaries: customer-impact workflow outcome, dependency
+    retry/timeout/rate-limit/error class, dependency endpoint or target health,
+    data freshness, queue depth/lag/oldest age, auth/edge failure class,
+    CPU/memory/disk/concurrency saturation, desired-vs-healthy,
+    startup/readiness/healthcheck failure, traffic target health, and
+    release/config context when code evidence exists
+  - Incident-evidence boundaries: every incident mechanism supplied by the user
+    or available in local reports must map to either added/proven code-owned
+    signals or an explicit external owner; do not stop at generic endpoint
+    metrics when the incident mechanism was auth handshake, secret expiry,
+    output freshness, rollout skew, dependency target health, or pool
+    saturation
   - Suggest specific spans and metrics with names, attributes, and rationale
   - Apply after user approval
 
@@ -197,7 +310,17 @@ This step is REQUIRED whenever `.vscode/launch.json` exists.
 - In the final response, separate file changes from verified outcomes
 - If verification is partial, say exactly what is working and what is still missing instead of reporting full success
 - Always include the service-name configuration, OTLP endpoint configuration, and which automatic spans/metrics are expected from the instrumentation.
-
+- For incident-readiness work, state which workflow, dependency, freshness,
+  backpressure, auth/edge, capacity, and release/config signals were added and
+  which gaps remain prerequisites for `$splunk-configure`.
+- For incident-evidence work, include a concise coverage summary explaining
+  whether each incident class would likely improve MTTD, improve localization
+  only, or remain uncovered.
+- Include exact deployment-context dimensions that were wired, such as
+  `service.version`, `deployment.environment`, `deployment.region`,
+  `deployment.platform`, `container.image.tag`, artifact version, config
+  version, and rollout/canary id, or state which ones were not available from
+  the repo.
 ## Credential Safety
 
 When the project uses or introduces env files:

--- a/skills/references/incident-readiness.md
+++ b/skills/references/incident-readiness.md
@@ -1,0 +1,150 @@
+# Incident Readiness Reference
+
+Load this reference when a repo owns user-visible workflows, background
+processing, dependency calls, queues, data freshness, auth/edge paths, capacity
+limits, release/config changes, or when the user asks for faster incident
+detection, localization, or debugging.
+
+## Goal
+
+Create traces, metrics, and logs that can answer these questions quickly:
+
+- Is the whole app down, or is one workflow degraded?
+- Which workflow, dependency, queue, region/environment, or release is involved?
+- Is the symptom request latency, errors, stale data, backlog, auth/edge failure,
+  capacity saturation, or release/config related?
+- What signal can become a detector or dashboard without manual trace search?
+
+## Audit Checklist
+
+- API/workflow paths: route spans, workflow spans, status code, error class,
+  request count, latency histogram, and outcome by low-cardinality workflow.
+- Customer-impact workflows: login, search, render/load, request/response,
+  transaction, decision/evaluation, notification, ingestion, export, sync, or
+  another user-visible path.
+- Dependencies: datastore, cache, search, message broker, object store, cloud API,
+  internal service, and third-party client spans with operation, retry, timeout,
+  circuit-breaker state, endpoint health, target health, availability, and
+  rate-limit/throttle outcomes when available.
+- Data freshness: newest event age, ingest lag, processing lag, accepted count,
+  dropped count, and drop reason.
+- Input/payload complexity: request or job payload size bucket, item/entity
+  count bucket, metadata count when relevant, parse/validation failure, and
+  complexity bucket when these predict latency, errors, or saturation.
+- Queue/backpressure: queue depth, consumer lag, oldest message age, rebalance
+  count, paused/blocked consumers, worker saturation, and retry/dead-letter rate.
+- Synthetic/canary workflow checks: result, latency, failed stage, timeout
+  class, and workflow/environment dimensions when the service owns the check.
+- Auth/edge: login, identity provider, token/session, domain routing, DNS, TLS,
+  certificate, gateway, and edge route failures.
+- Capacity: memory, heap, CPU, disk/filesystem, thread/worker pool, inflight
+  work, concurrency, quota, throttling, rate limit, restart/crash-loop,
+  desired-vs-healthy instances, startup/readiness/healthcheck failure, traffic
+  target health, and autoscaling saturation.
+- Release/config context: `service.version`, `deployment.environment`,
+  `deployment.region`, `deployment.platform`, `container.image.tag`, artifact
+  version, config version, feature flag, canary/rollout batch, runtime
+  environment, and region/zone on spans and metrics when low-cardinality.
+
+## Instrumentation Guidance
+
+- Start with baseline request/job tracing, metrics, resource attributes, context
+  propagation, and error status.
+- Add workflow spans only at diagnostic boundaries: controller/handler, service
+  workflow, dependency call, queue publish/consume, worker job, and scheduled job.
+- Emit metrics only from values the service can observe accurately. Do not create
+  placeholder instruments for unavailable signals.
+- Prefer OTel semantic-convention names for HTTP, RPC, database, messaging, and
+  runtime signals. Use custom metrics only when no convention exists.
+- Use stable dimensions: `service.name`, `service.version`,
+  `deployment.environment`, `deployment.region`, `deployment.platform`,
+  `container.image.tag`, route or workflow name, dependency name, operation,
+  status code, error class, region, artifact version, config version,
+  canary/rollout batch, and low-cardinality outcome.
+- Prefer existing OTel semantic-convention or platform resource attribute names
+  when the repo already emits them. Treat generic names such as
+  `deployment.region`, `deployment.platform`, and `container.image.tag` as
+  context aliases, not as a reason to invent duplicate attributes beside proven
+  names such as `cloud.region` or platform-provided container image attributes.
+- Do not use user, account, tenant, request, session, task, trace, raw URL,
+  payload, or high-cardinality IDs as metric attributes or detector group-by keys.
+
+## Incident-Evidence Mode
+
+Use this mode when incidents, alerts, postmortems, tickets, or failure examples
+are supplied. Build a coverage matrix before editing:
+
+`incident class -> failure mechanism -> owner -> code surface -> signal -> MTTD impact -> remaining owner`
+
+- Treat the failure mechanism as the target, not the symptom. Endpoint 2xx/5xx
+  metrics are not enough when the mechanism is an auth handshake, secret expiry,
+  missing or stale output, rollout skew, dependency target loss, queue
+  saturation, or streaming lifecycle failure.
+- Mark a signal **MTTD-improving** only when it can become a detector before or
+  at first customer impact. Mark it **localization-only** when another alert
+  already detects the incident and the signal mainly narrows the owner.
+- For each app-owned mechanism, add or prove low-cardinality metrics in the
+  owning handler, client, worker, queue, limiter, router, health, or lifecycle
+  class. If ownership is external, name that owner and the prerequisite signal.
+- Do not call incident coverage complete while an app-owned mechanism remains
+  only a follow-up unless the user explicitly narrows scope.
+
+## Required Surface Patterns
+
+- Executors and queues: queue depth, queue remaining/capacity, active or
+  inflight work, pool size/max, queue wait, oldest age, timeout, rejected/shed
+  work, and saturation outcome by low-cardinality pool/workflow/dependency.
+- Streams and long-lived connections: open/connect, auth result, stream start,
+  stop/detach/keepalive, close reason family, send/write failure, active
+  connections/channels/streams, duration, and final outcome.
+- Input and payload complexity: payload size bucket, input size/complexity
+  bucket, item/entity count, metadata count when relevant, parse/validation
+  failure, truncation/drop reason, and final outcome.
+- Auth, edge, and secrets: login/auth handshake started/completed/failed,
+  identity-provider outcome, token/session/domain-routing reason family,
+  certificate or secret expiry age, rotation outcome, and config mismatch.
+- Jobs and offline/derived data outputs: last-success timestamp, freshness/age,
+  duration, output count,
+  skipped/dropped reason, publish or delivery outcome, backlog/lag, and oldest
+  pending work.
+- Synthetic/canary workflow checks: result, latency, failed stage, timeout
+  class, no-run/stale-run age, and workflow/environment dimensions.
+- Dependency and routing: dependency outcome, timeout, retry, throttle/rate
+  limit, circuit-breaker state, endpoint or active-target health, route decision,
+  fallback reason, fallback target readiness, and no-route/no-active-target
+  outcome.
+- Release and deployment/config compatibility: service version,
+  artifact/image tag, config version, feature flag, rollout/canary batch,
+  schema/migration version when present, expected-vs-running version, rollout
+  progress or stalled rollout, compatibility failure class, and decision
+  outcome when code or deployment sources expose them.
+
+## Signal Targets
+
+| Area | Useful signals |
+|---|---|
+| API/workflow | request/workflow duration, count, error count, status code, error class, outcome |
+| Customer impact | workflow success/error/degraded/timeout by workflow and environment |
+| Dependency | dependency duration/error/timeout/retry/rate-limit, endpoint health, target health, availability, and circuit-breaker state by dependency and operation |
+| Freshness | newest event age, ingest lag, processing lag, accepted/dropped count by reason |
+| Input complexity | payload size bucket, input size/complexity bucket, item/entity count, metadata count when relevant, parse/validation failure |
+| Backpressure | queue depth, consumer lag, oldest message age, rebalance count, paused consumers |
+| Synthetic/canary | workflow check result, latency, failed stage, timeout class, no-run/stale-run age |
+| Auth/edge | login/auth duration/error, identity provider failure, DNS/TLS/cert/gateway failure |
+| Capacity | CPU/memory/disk utilization, inflight work, worker/thread pool, concurrency, quota/throttle, restart/crash-loop, desired-vs-healthy, startup/readiness/healthcheck failure, traffic target health |
+| Release context | service version, deployment environment/region/platform, container image tag, artifact version, config version, schema/migration version when present, feature flag, canary/rollout batch |
+
+## Readiness Rules
+
+- If a signal already exists, record its source and whether it is safe for alerting
+  and dashboard grouping.
+- If a signal is missing, record it as an instrumentation prerequisite for
+  `$otel-instrument`; do not imply `$splunk-configure` can create detectors from
+  absent metrics.
+- If only traces exist, recommend metrics for detector-critical signals such as
+  workflow latency, error count, freshness lag, queue lag, dependency failure,
+  dependency endpoint health, desired-vs-healthy, readiness failure, and
+  capacity saturation.
+- If only metrics exist, recommend trace attributes or logs that localize the
+  fault domain: workflow, dependency, operation, error class, release/config,
+  deployment platform, deployment region, and environment.

--- a/skills/splunk-configure/SKILL.md
+++ b/skills/splunk-configure/SKILL.md
@@ -95,7 +95,22 @@ Extract from `.observe/otel.md`:
    - Each row provides: metric name, source, and type (auto/custom)
    - Record all metrics for classification in Step 3
 
-3. **Gaps** from the `## Gaps` section. This is the current-main
+3. **Gap Ledger** from the `## Gap Ledger` section when present. This is the
+   structured handoff contract from `$otel-audit` and `$otel-instrument`:
+   - Parse `gap_id`, status, `required_signals`, owner, `code_surface`, and
+     `acceptance_criteria`.
+   - Treat any row with status `missing` or `partial` as an instrumentation
+     prerequisite unless matching metrics already exist in the Metrics table.
+   - For partial closure or closure matrices that include `remaining_signals`,
+     generate detectors only for implemented or proven signals. Do not imply
+     complete coverage in detector names, descriptions, dashboards, or coverage
+     summaries while required signals remain missing, even when one matching
+     metric exists.
+   - List `remaining_signals` under `Instrumentation Prerequisites` with the
+     owning code surface, provider, platform, deployment source, or exact
+     missing source from the ledger.
+
+4. **Gaps** from the `## Gaps` section. This is the current-main
    `$otel-audit` handoff:
    - Treat each bullet as an instrumentation prerequisite candidate.
    - Infer impact from the wording, available metric evidence, and readiness
@@ -103,7 +118,7 @@ Extract from `.observe/otel.md`:
    - Add missing readiness signals to the generated report instead of creating
      detector placeholders for absent data.
 
-4. **Legacy APM Readiness Coverage** from the `## APM Readiness Coverage`
+5. **Legacy APM Readiness Coverage** from the `## APM Readiness Coverage`
    section when present. Use this only when `## Gaps` is absent:
    - Area
    - Status
@@ -111,7 +126,7 @@ Extract from `.observe/otel.md`:
    - Gap
    - Detection/Localization Impact, or the legacy column name MTTD Impact
 
-5. **Incident Readiness** from the `## Incident Readiness` section when present:
+6. **Incident Readiness** from the `## Incident Readiness` section when present:
    - API/workflow impact
    - dependencies
    - freshness/backpressure
@@ -119,7 +134,7 @@ Extract from `.observe/otel.md`:
    Missing or partial incident-readiness areas become instrumentation
    prerequisites unless matching metrics already exist in the Metrics table.
 
-6. **Detector reliability evidence** from gaps, readiness sections, local alert
+7. **Detector reliability evidence** from gaps, readiness sections, local alert
    config, or incident evidence:
    - missed, flapping, auto-resolved, or no-data alerts
    - detectors that cannot distinguish no traffic from no telemetry
@@ -181,10 +196,16 @@ signals do not collapse into generic RED buckets.
 Skip metrics that match the exclusion rules (auto-instrumented library metrics
 that duplicate custom signals).
 
-For every `## Gaps` entry that is still missing a metric, add an entry to the
-generated report's "Instrumentation Prerequisites" section. Do not generate a
-detector for a missing signal. Recommend `$otel-instrument` with the specific
-coverage area that must be added first.
+For every `## Gap Ledger` row or `## Gaps` entry that is still missing a metric,
+add an entry to the generated report's "Instrumentation Prerequisites" section.
+Do not generate a detector for a missing signal. Recommend `$otel-instrument`
+with the specific coverage area that must be added first.
+
+For partial closure, generate detectors only for implemented or proven signals.
+Do not imply complete coverage from a partially closed audit gap. If a ledger or
+instrumentation closure matrix includes `remaining_signals`, list those signals
+under `Instrumentation Prerequisites` and avoid detector names or dashboard
+headings that claim the whole readiness area is covered.
 
 For legacy APM readiness rows, add prerequisites for every area with status
 `missing` or `partial` when no `## Gaps` entry covers the same area.

--- a/skills/splunk-configure/SKILL.md
+++ b/skills/splunk-configure/SKILL.md
@@ -1,37 +1,76 @@
 ---
 name: splunk-configure
 description: >-
-  Generate Splunk Observability Cloud detector Terraform from an existing
-  otel-audit report. Reads .observe/otel.md, classifies metrics into
-  detector categories, and outputs ready-to-apply HCL with SignalFlow
-  program_text. Use when the user types $splunk-configure, asks to "generate
-  detectors", "create alerts from audit", "build Terraform for monitors",
-  or "set up Splunk detectors".
+  Generate Splunk Observability Cloud detector and dashboard Terraform from an
+  existing otel-audit report. Reads .observe/otel.md, classifies metrics and
+  APM readiness coverage into detector/dashboard categories, and outputs
+  ready-to-apply HCL with SignalFlow program_text. Use when the user types
+  $splunk-configure, asks to "generate detectors", "create alerts from audit",
+  "build Terraform for monitors", "set up Splunk detectors", "create
+  dashboards", "audit alert coverage", "classify app down vs degraded impact",
+  "build blast-radius dashboards", or asks to improve alerting or incident
+  localization from observability gaps.
 metadata:
   author: otel-studio
   version: 0.1.0
   category: observability
 ---
 
-# Detect -- Splunk O11y Detector Terraform from Audit Report
+# Detect -- Splunk O11y Detector and Dashboard Terraform from Audit Report
 
 ## Overview
 
-Read an existing `.observe/otel.md` audit report, classify detected metrics
-into detector categories (latency, error, saturation, throughput), and generate
-Terraform configuration for Splunk Observability Cloud `signalfx_detector`
-resources with inline SignalFlow programs.
+Read an existing `.observe/otel.md` audit report, classify detected metrics and
+APM readiness coverage into detector categories, and generate Terraform
+configuration for Splunk Observability Cloud detectors and dashboards. Use
+metric detectors for available signals and report missing readiness coverage as
+instrumentation prerequisites instead of inventing alerts from absent data.
+
+When a prompt mentions MTTD, faster incident detection, better alerts, easier
+incident debugging, or blast-radius visibility, generate detectors and
+dashboards that make customer impact, affected workflow, likely fault domain,
+blast radius, and release/config correlation faster to detect and localize.
+
+When incident evidence mentions missed, flapping, auto-resolved, or no-data
+alerts, treat that as detector reliability evidence. Do not ask app instrumentation
+to emit alert lifecycle metrics unless the app owns those events; audit the
+detector, dashboard, data quality, and alert coverage behavior in
+`alert-coverage-audit` output.
 
 ## When to Use
 
 - After running `$otel-audit` to generate `.observe/otel.md`
 - When the user wants alerting/detection Terraform for their service
 - When creating monitors for RED signals or saturation metrics
+- When creating dashboards for API workflows, dependencies, freshness,
+  queue/backpressure, customer impact, or release context
+- When auditing whether existing or desired alerts cover app-down,
+  primary workflow degradation, auth degradation, ingest lag/drops,
+  critical workflow delay, dependency failure, blast radius, or capacity
+  saturation
 
 **When NOT to use:** If no audit report exists yet, instruct the user to run
 `$otel-audit` first.
 
 ## Process
+
+### Supported Modes
+
+Use the default detector/dashboard generation path unless the user asks for a
+specific mode. Modes share the same `.observe/otel.md` input and should be
+implemented as report sections or Terraform output, not as separate skills.
+
+| Mode | Trigger | Output |
+|---|---|---|
+| `generate` | Generate detectors/dashboards from audit metrics | `.observe/terraform/`, `.observe/detectors.md`, `.observe/dashboards.md` |
+| `alert-coverage-audit` | Audit existing or desired alerts/dashboards for incident detection/localization gaps | Coverage matrix comparing readiness areas to detectors/dashboards, including detector reliability evidence for missed, flapping, auto-resolved, or no-data alerts; missing app-owned signals become instrumentation prerequisites |
+| `impact-classify` | Distinguish app down from degraded API, workflow, auth, ingest, or workflow-specific impact | Impact detectors/dashboard sections grouped by workflow, outcome, region/environment, dependency, and release context |
+| `blast-radius` | Detect region-wide or multi-workflow incidents earlier | Region/environment/workflow rollups and dashboards that show single-service, single-region, multi-region, or all-region blast radius |
+
+If existing Splunk detectors or dashboards are not available in the repository
+or through an approved API/source, do not claim they were audited. Generate the
+desired-state coverage matrix and clearly label it as based on `.observe/otel.md`
+and local Terraform/config evidence only.
 
 ### Step 1 -- Locate Audit Report
 
@@ -43,7 +82,7 @@ Look for `.observe/otel.md` in the repository root.
 > No audit report found at `.observe/otel.md`. Please run `$otel-audit` first
 > to generate the observability coverage report.
 
-### Step 2 -- Parse Service Metadata and Metrics
+### Step 2 -- Parse Service Metadata, Metrics, and Readiness Coverage
 
 Extract from `.observe/otel.md`:
 
@@ -56,30 +95,118 @@ Extract from `.observe/otel.md`:
    - Each row provides: metric name, source, and type (auto/custom)
    - Record all metrics for classification in Step 3
 
-If the Metrics section says "No metrics detected.", stop and respond:
+3. **Gaps** from the `## Gaps` section. This is the current-main
+   `$otel-audit` handoff:
+   - Treat each bullet as an instrumentation prerequisite candidate.
+   - Infer impact from the wording, available metric evidence, and readiness
+     sections.
+   - Add missing readiness signals to the generated report instead of creating
+     detector placeholders for absent data.
+
+4. **Legacy APM Readiness Coverage** from the `## APM Readiness Coverage`
+   section when present. Use this only when `## Gaps` is absent:
+   - Area
+   - Status
+   - Evidence
+   - Gap
+   - Detection/Localization Impact, or the legacy column name MTTD Impact
+
+5. **Incident Readiness** from the `## Incident Readiness` section when present:
+   - API/workflow impact
+   - dependencies
+   - freshness/backpressure
+   - auth/edge/capacity/release context
+   Missing or partial incident-readiness areas become instrumentation
+   prerequisites unless matching metrics already exist in the Metrics table.
+
+6. **Detector reliability evidence** from gaps, readiness sections, local alert
+   config, or incident evidence:
+   - missed, flapping, auto-resolved, or no-data alerts
+   - detectors that cannot distinguish no traffic from no telemetry
+   - dashboard or detector group-by keys that hide workflow, region,
+     environment, dependency, or release blast radius
+   Record these in `alert-coverage-audit` output. Only turn them into
+   instrumentation prerequisites when the missing data is app-owned and absent.
+
+If the Metrics section says "No metrics detected.", do not generate detector or
+dashboard Terraform from metrics. Continue processing `## Gaps`,
+`## APM Readiness Coverage`, and `## Incident Readiness` so the output still
+includes `.observe/detectors.md` instrumentation prerequisites and, for
+`alert-coverage-audit` mode, an alert coverage matrix. Include an alert
+coverage matrix when running `alert-coverage-audit`. If there are no metrics,
+no gaps, and no readiness sections, stop and respond:
 
 > The audit report contains no metrics. Detectors require metric data.
 > Run `$otel-instrument` to add instrumentation, then re-run `$otel-audit`.
 
 ### Step 3 -- Classify Metrics into Detector Categories
 
-Load `references/detector-classification.md` and apply the classification rules
-to each metric from Step 2.
+When metrics exist, load `references/detector-classification.md` and apply the
+classification rules to each metric from Step 2.
 
-Assign each metric to exactly one category:
+Assign each metric to exactly one category. Apply incident-readiness categories
+before generic latency, error, throughput, or saturation so customer-impact,
+dependency, freshness, backpressure, auth/edge, capacity, and release/config
+signals do not collapse into generic RED buckets.
+
 - **latency** -- duration histograms
 - **error** -- counters with failure/error/invalid keywords
 - **throughput** -- counters without error keywords
-- **saturation** -- gauges for connections, buffers, queues, lag
-
+- **saturation** -- gauges for connections, buffers, queues, lag,
+  disk/filesystem, and resource utilization
+- **freshness** -- gauges/histograms for event age, ingest lag, processing lag
+- **backpressure** -- queue depth, consumer lag, oldest-message age, rebalance
+  count, paused/blocked consumer gauges
+- **dependency** -- dependency error, timeout, retry, rate-limit, throttle,
+  circuit-breaker, endpoint health, target health, availability, unhealthy
+  target count, or operation-duration metrics
+- **customer-impact** -- workflow success/error/degraded/timeout counters or
+  duration histograms for rendering, transaction, auth, notification, or other
+  user-visible workflows
+- **impact-classification** -- app/workflow availability, synthetic probe/client telemetry,
+  degraded/unavailable impact, or customer-impact summary metrics used to
+  distinguish app down from degraded API, workflow, auth, ingest, or
+  workflow-specific impact
+- **auth-edge** -- login, identity provider, domain routing, token/session, DNS, TLS,
+  certificate, gateway, or edge workflow metrics
+- **capacity-saturation** -- memory, CPU, disk/filesystem, JVM,
+  worker/thread-pool utilization, inflight/concurrency, queue saturation,
+  quota, throttling, crash-loop/restart, desired-vs-healthy,
+  startup/readiness/healthcheck failure, HPA/ASG, pod, task, process, or node
+  capacity metrics
+- **release-context** -- `service.version`, `deployment.environment`,
+  `deployment.region`, `deployment.platform`, `container.image.tag`, artifact
+  version, config/canary/rollout metadata used as dashboard filters and
+  detector dimensions, not as standalone alert metrics
 Skip metrics that match the exclusion rules (auto-instrumented library metrics
 that duplicate custom signals).
+
+For every `## Gaps` entry that is still missing a metric, add an entry to the
+generated report's "Instrumentation Prerequisites" section. Do not generate a
+detector for a missing signal. Recommend `$otel-instrument` with the specific
+coverage area that must be added first.
+
+For legacy APM readiness rows, add prerequisites for every area with status
+`missing` or `partial` when no `## Gaps` entry covers the same area.
+
+For every incident-readiness area with status `missing` or `partial`, add a
+prerequisite unless equivalent metrics are present. Do not generate detectors
+from desired impact, dependency, freshness, backpressure, auth/edge, capacity,
+or release/config rows unless the Metrics table contains the corresponding
+metric evidence.
 
 ### Step 4 -- Generate Terraform
 
 Create the output directory `.observe/terraform/` if it does not exist.
 
-Generate three files using the templates from `references/terraform-templates.md`:
+Generate detector Terraform using `references/terraform-templates.md`. Also
+generate dashboard Terraform or, when a dashboard panel cannot be expressed
+confidently from available metrics, a dashboard specification in
+`.observe/dashboards.md`.
+Dashboard Terraform should use `signalfx_dashboard_group`,
+`signalfx_dashboard`, and chart resources such as `signalfx_time_chart`,
+`signalfx_single_value_chart`, `signalfx_table_chart`, or `signalfx_list_chart`
+when enough metric evidence exists.
 
 #### `.observe/terraform/detectors.tf`
 
@@ -111,7 +238,7 @@ underscores, strip leading digits.
 
 ```hcl
 variable "realm" {
-  description = "Splunk Observability Cloud realm (e.g. us1, eu0)"
+  description = "Splunk Observability Cloud realm"
   type        = string
 }
 
@@ -136,27 +263,129 @@ variable "notification_channel" {
 <one variable block per detector with its default threshold>
 ```
 
+#### `.observe/terraform/dashboards.tf`
+
+Generate a service dashboard with sections for every detector category that has
+metrics:
+
+| Section | Charts |
+|---|---|
+| API workflows | request rate, p99 latency, 5xx/error rate by route/status |
+| External dependencies | dependency latency, error/timeout/retry/rate-limit rate, circuit-breaker state, endpoint health, target health, availability, and unhealthy target count when present |
+| Data freshness | newest event age, ingest lag, processing lag, accepted/dropped by reason |
+| Queue/backpressure | queue depth, consumer lag, oldest message age, rebalance count, paused consumers |
+| Customer impact | user workflow duration, success/error/degraded/timeout by workflow |
+| Impact classification | app-down vs degraded workflow counts, synthetic probe/client telemetry/API/freshness/dependency correlation, impact by region/environment |
+| Auth/edge workflows | auth success/error/latency, identity provider failures, domain-routing/DNS/TLS/gateway failures |
+| Capacity saturation | memory/CPU/disk/runtime/thread-pool/concurrency/quota/throttle/restart, desired-vs-healthy, startup/readiness/healthcheck failure, and traffic target health where metrics exist |
+| Blast radius | impacted workflows and regions over time, grouped by service, deployment region, environment, platform, release, and dependency |
+| Release context | dashboard filters or event overlays for service version, deployment environment/region/platform, container image tag, artifact version, config version, and canary/rollout dimensions |
+
+Every dashboard must include a `service.name` filter. Include
+`deployment.environment`, `deployment.region`, `deployment.platform`,
+`service.version`, `container.image.tag`, artifact version, config version, and
+rollout/canary filters when the metrics or audit evidence show those dimensions
+exist and are low-cardinality.
+Prefer exact metric/resource attribute names proven by the audit, such as
+`cloud.region` or platform-provided container image attributes. Do not create
+duplicate filters only to force generic alias names.
+Dashboard variables that apply globally across multiple charts must use
+`apply_if_exist = true`. This is required for optional dimensions such as
+environment, region, namespace, platform, version, image tag, config version,
+rollout, dependency, and custom realm, because not every chart metric has every
+dimension. Never generate wildcard variables for optional
+dimensions with `apply_if_exist = false`; they can silently filter all data out
+of charts whose metric lacks that dimension.
+Keep the Splunk Observability Cloud API `realm` variable separate from service
+telemetry dimensions. Do not use `var.realm` as a SignalFlow filter for
+`sfx_realm`, `deployment.region`, `cloud.region`, or any application/runtime
+dimension unless live metric metadata or the audit proves that exact dimension
+and value. Prefer dashboard variables for dimensions such as environment,
+region, namespace, platform, version, image tag, and custom realm so users can
+select the active stream. If a chart needs a fixed dimension value, the value
+must come from proven metric metadata or an explicit user choice, not from the
+provider/API realm.
+Before writing chart `program_text`, verify every filter and group-by dimension
+against audit evidence, local metric metadata, or approved Splunk API metadata.
+If a dimension is not present on the target metric, omit the filter/group-by and
+document the missing dimension in `.observe/dashboards.md`. Never group by a
+dimension solely because instrumentation code intended to emit it.
+Only generate a dashboard panel for a metric name that is present in the audit
+or verified through live metric metadata. If using a provider-derived,
+precomputed, or transformed metric name instead of the audited OTel name, record
+the live metadata provenance in `.observe/dashboards.md` and mark the panel as
+verified.
+Live metric metadata alone is not enough to claim source-backed coverage when
+the repository does not contain the emitter. If the metric is found only in
+build output, generated artifacts, `target/`, `build/`, `.class`, jar, coverage,
+or stale runtime files, treat it as stale/unowned evidence: do not generate the
+panel by default, and list it as a verification issue or cleanup prerequisite.
+Use source files, checked-in IaC/config, audited instrumentation evidence, or an
+explicit user-approved external source as provenance.
+Do not combine mixed-unit signals on one chart. Split boolean readiness,
+availability, ratios/percentages, bytes, counts, rates, cumulative counters,
+and durations into separate panels unless the dashboard type has explicit
+per-series units or axes and the report documents the unit handling. For
+example, database readiness and connection-pool utilization should be separate
+panels, not one shared-axis time chart.
+For runtime capacity, generate separate dashboard panels and detectors for each
+source-backed resource class instead of substituting adjacent runtime metrics.
+When source-backed CPU utilization metrics such as `process.cpu.utilization`,
+`process.runtime.*.cpu.utilization`, `jvm.cpu.recent_utilization`, or a
+runtime-specific equivalent are present, generate a CPU utilization panel and
+a CPU saturation detector. Memory/heap usage, thread/goroutine/worker count, GC
+pressure, concurrency, disk, and quota signals belong in separate panels with
+their own units. Do not use thread count, heap usage, or GC metrics as a CPU
+proxy. If only cumulative CPU time is available, chart it as a diagnostic rate
+with `rollup='rate'` or equivalent and list normalized CPU utilization as a
+missing signal before creating a CPU saturation detector.
+For pre-aggregated percentile metrics, including names such as `.p99`, `.p95`,
+`p50`, `quantile`, or metrics marked as already-quantized, do not average
+series for the headline chart. Use `max()` for current worst-case values and
+`max(by=[...])` for breakdowns. Use `.percentile(pct=99)` only for raw
+duration/histogram distributions. Match units to metric names and metadata:
+convert nanoseconds to seconds or milliseconds, convert ratios to percent only
+when the metric is a ratio, and label bytes/counts/rates honestly.
+For cumulative counters or cumulative timers, including names that end in
+`.total`, `.count`, `.time`, or metrics whose metadata shows cumulative
+temporality, do not chart the raw cumulative value as current health. Use
+`rollup='rate'`, a delta/rate transform, or a true duration histogram/summary.
+If neither is available, label the chart as cumulative and mark it unverified
+instead of presenting it as a latency, utilization, or health-rate panel.
+After generating dashboard Terraform, run a value sanity check when a Splunk API
+token or local metric query path is available. Execute each chart's SignalFlow
+over a recent window with known traffic or a representative historical window
+and confirm it returns non-empty series with plausible magnitude and expected
+dimensions. If live verification is unavailable, mark the dashboard report as
+unverified and call out the exact metric names, filters, units, and group-bys
+that still need validation before `terraform apply`. When validating in the UI
+after an update, reload the dashboard URL without a stale `configId` parameter
+or reset saved dashboard overrides so the browser uses the updated dashboard
+definition.
+
 #### `.observe/terraform/terraform.tfvars.example`
 
 Generate a `.tfvars.example` file the user copies and fills in to apply:
 
 ```hcl
-realm                = ""   # e.g. us1, eu0, lab0
+realm                = ""   # Splunk Observability Cloud realm
 api_token            = ""   # Splunk O11y API token (org-level, detector write)
 service_name         = "<service-name from report>"
 notification_channel = ""   # e.g. "Email,team@example.com" or PagerDuty routing key
 ```
 
-Do NOT include per-detector threshold variables in this file — they already have
+Do NOT include per-detector threshold variables in this file -- they already have
 sensible defaults in `variables.tf`. Include `realm`, `api_token`, and
 `notification_channel` (which have no defaults) plus `service_name` for
 convenience (it has a default from the report but users often override it).
 
-### Step 5 -- Generate Detectors Report
+### Step 5 -- Generate Detectors and Dashboards Report
 
-Create `.observe/detectors.md` as a human-readable companion to the Terraform
-files. This report documents every detector that was generated, its
-classification rationale, thresholds, and which metrics were skipped.
+Create `.observe/detectors.md` and `.observe/dashboards.md` as human-readable
+companions to the Terraform files. The detector report documents every detector
+that was generated, its classification rationale, thresholds, and which metrics
+were skipped. The dashboard report documents generated panels, filters, and any
+readiness coverage that still requires `$otel-instrument`.
 
 Use the following structure:
 
@@ -174,6 +403,13 @@ Use the following structure:
 | Error      | N     | Critical | Sudden change (mean + stddev) |
 | Saturation | N     | Warning  | Static threshold |
 | Throughput | N     | Major    | Sudden change (mean + stddev) |
+| Freshness  | N     | Critical | Static lag/age threshold |
+| Backpressure | N   | Major    | Static lag/depth threshold |
+| Dependency | N     | Major    | Latency/error/timeout threshold |
+| Customer Impact | N | Critical | Workflow success/error/latency threshold |
+| Impact Classification | N | Critical | App-down/degraded workflow rollup |
+| Auth/Edge | N | Critical | Login/edge success/error/latency threshold |
+| Capacity Saturation | N | Major | Resource/quota/throttle/restart threshold |
 | **Total**  | **N** | | |
 
 ## Latency Detectors
@@ -216,6 +452,31 @@ Default: **3.0 stddev**, 5m current window vs 1h history.
 |--------|--------|
 | `<metric>` | <why it was not classified> |
 
+## Instrumentation Prerequisites
+
+| Area | Audit Status | Missing Signal | Why No Detector Was Generated | Next Step |
+|------|--------------|----------------|-------------------------------|-----------|
+| Data freshness | missing | newest event age, ingest lag, dropped records by reason | No metric exists in `.observe/otel.md` | Run `$otel-instrument` to add data freshness signals |
+| Dependency health | missing | endpoint health, target health, availability, timeout/rate-limit count, or unhealthy target count | No matching dependency health metric exists in `.observe/otel.md` | Run `$otel-instrument` or configure platform telemetry for dependency health signals |
+| Capacity health | missing | disk saturation, desired-vs-healthy, startup/readiness/healthcheck failure, restart count, or traffic target health | No runtime/platform metric exists in `.observe/otel.md` | Run `$otel-instrument` or add platform telemetry before creating detectors |
+
+## Alert Coverage Matrix
+
+Use this section for `alert-coverage-audit` mode and include it in the detector
+report when readiness coverage is partial or missing.
+
+| Incident Pattern | Existing/Generated Coverage | Missing Signal or Dashboard | Detection/Localization Risk | Next Step |
+|---|---|---|---|---|
+| Primary workflow unavailable | {detector/dashboard or "none found"} | {workflow impact metric, dependency metric, or synthetic/client telemetry signal} | {why detection/debugging remains slow} | {configure detector or instrument signal} |
+| Ingest lag/drops | {detector/dashboard or "none found"} | {freshness/drop/lag signal} | {risk} | {next step} |
+| Auth/domain-routing/edge | {detector/dashboard or "none found"} | {auth/edge workflow signal} | {risk} | {next step} |
+| Critical business workflow | {detector/dashboard or "none found"} | {workflow outcome signal} | {risk} | {next step} |
+| Multi-region blast radius | {detector/dashboard or "none found"} | {region/environment/workflow rollup} | {risk} | {next step} |
+| Dependency endpoint health | {detector/dashboard or "none found"} | {endpoint health, target health, unavailable, timeout, rate-limit, or unhealthy target signal} | {risk} | {next step} |
+| Capacity saturation | {detector/dashboard or "none found"} | {CPU/memory/disk/quota/throttle/concurrency/restart/readiness/desired-vs-healthy/platform signal} | {risk} | {next step} |
+| Release/config correlation | {dashboard filter/event overlay or "none found"} | {service.version, deployment.region, deployment.platform, container.image.tag, artifact version, config version, or rollout/canary id} | {risk} | {next step} |
+| Detector reliability | {detector/dashboard evidence or "none found"} | {missing no-data handling, anti-flap tuning, auto-resolve guard, data-quality signal, or alert route evidence} | {risk} | {tune detector, fix alert coverage, or instrument app-owned missing signal} |
+
 ## Classification Rules Applied
 
 <include the decision flowchart from references/detector-classification.md>
@@ -225,6 +486,7 @@ Default: **3.0 stddev**, 5m current window vs 1h history.
 | File | Contents |
 |------|----------|
 | `detectors.tf` | N `signalfx_detector` resources with inline SignalFlow |
+| `dashboards.tf` | dashboard group, dashboard, and panel resources for classified metrics when metric evidence exists |
 | `variables.tf` | 4 required + N threshold variables |
 | `terraform.tfvars.example` | Template for required variables |
 
@@ -241,7 +503,7 @@ Default: **3.0 stddev**, 5m current window vs 1h history.
 
 ### Step 6 -- Chat Summary
 
-After generating all files (Terraform + report), present a summary:
+After generating all files (Terraform + reports), present a summary:
 
 ```
 ## Detectors Generated
@@ -252,14 +514,23 @@ After generating all files (Terraform + report), present a summary:
 | Error       | N     |
 | Saturation  | N     |
 | Throughput  | N     |
+| Freshness   | N     |
+| Backpressure | N    |
+| Dependency  | N     |
+| Customer Impact | N |
+| Impact Classification | N |
+| Auth/Edge | N |
+| Capacity Saturation | N |
 
 **Output:** `.observe/terraform/`
 
 Files:
-- `.observe/terraform/detectors.tf` — N detector resources
-- `.observe/terraform/variables.tf` — realm, api_token, service_name, notification_channel + N threshold variables
-- `.observe/terraform/terraform.tfvars.example` — copy to `terraform.tfvars`, fill in credentials
-- `.observe/detectors.md` — full detectors report with classification details
+- `.observe/terraform/detectors.tf` -- N detector resources
+- `.observe/terraform/dashboards.tf` -- service dashboard and panel resources when metric evidence exists
+- `.observe/terraform/variables.tf` -- realm, api_token, service_name, notification_channel + N threshold variables
+- `.observe/terraform/terraform.tfvars.example` -- copy to `terraform.tfvars`, fill in credentials
+- `.observe/detectors.md` -- full detectors report with classification details
+- `.observe/dashboards.md` -- dashboard sections, filters, and readiness prerequisites
 
 Next:
 1. `cp .observe/terraform/terraform.tfvars.example .observe/terraform/terraform.tfvars`
@@ -310,7 +581,7 @@ resource "signalfx_detector" "latency_http_server_request_duration" {
 
 ```hcl
 variable "realm" {
-  description = "Splunk Observability Cloud realm (e.g. us1, eu0)"
+  description = "Splunk Observability Cloud realm"
   type        = string
 }
 

--- a/skills/splunk-configure/references/detector-classification.md
+++ b/skills/splunk-configure/references/detector-classification.md
@@ -5,6 +5,144 @@ Apply these rules in order; the first match wins.
 
 ## Classification Rules
 
+Apply incident-readiness categories before generic RED categories. Impact
+classification, auth/edge, customer impact, freshness, backpressure,
+dependency, and capacity signals are usually more useful for incident detection
+and localization than generic throughput when the metric names and dimensions
+make the domain clear.
+
+Detector reliability evidence is not a service metric category. If incident
+evidence mentions missed, flapping, auto-resolved, or no-data alerts, capture
+that in `alert-coverage-audit` output and only create an instrumentation
+prerequisite when the service lacks an app-owned signal needed by the detector.
+
+### Impact Classification
+
+A metric is an **impact-classification** detector candidate when:
+
+- The metric name contains one of: `impact`, `availability`, `synthetic`,
+  `client_telemetry`, `workflow.state`, `workflow.outcome`, `degraded`,
+  `unavailable`
+- AND the metric can be grouped by low-cardinality workflow, region/environment,
+  service, dependency, or release dimensions
+
+These metrics distinguish app down from degraded API, workflow, auth, ingest,
+or workflow-specific impact. They should use critical thresholds for unavailable
+impact and major/critical thresholds for degraded workflow impact.
+
+### Auth/Edge
+
+A metric is an **auth-edge** detector candidate when:
+
+- The metric name contains one of: `login`, `auth`, `identity_provider`,
+  `token`, `session`, `domain_route`, `domain.routing`, `domain-routing`,
+  `dns`, `tls`, `cert`, `certificate`, `gateway`, `edge`, `edge.route`,
+  `gateway.route`
+- AND the metric measures duration, success, error, timeout, expiry, or
+  unavailable outcomes
+
+Auth/edge metrics should prioritize authentication, domain-routing, TLS, and
+certificate failures because they often appear as generic HTTP failures unless
+the service emits a more specific outcome or failure class.
+
+### Customer Impact
+
+A metric is a **customer-impact** detector candidate when:
+
+- The metric name contains one of: `workflow`, `user_flow`, `journey`,
+  `operation`, `render`, `load`, `transaction`, `customer_impact`
+- AND the metric measures duration, success, error, degraded, timeout, or
+  unavailable outcomes
+
+These metrics answer whether customers are down or degraded and should use
+critical workflow success/error and latency thresholds.
+
+### Freshness
+
+A metric is a **freshness** detector candidate when:
+
+- The metric name contains one of: `freshness`, `newest_event_age`,
+  `event.age`, `ingest.lag`, `processing.lag`, `data.age`, `staleness`
+- The metric measures age or lag as a gauge or histogram
+
+Freshness metrics should use static warning/critical thresholds because stale
+data is often customer-impacting before request RED signals move.
+
+### Backpressure
+
+A metric is a **backpressure** detector candidate when:
+
+- The metric name contains one of: `queue.depth`, `queue.size`,
+  `consumer.lag`, `oldest_message_age`, `rebalance`, `paused_consumer`,
+  `blocked_consumer`, `backpressure`
+- The source is a queue, worker, stream consumer, or async task processor
+
+Backpressure metrics should use static thresholds for lag/depth/age and
+sudden-change detection for rebalance count.
+
+### Dependency
+
+A metric is a **dependency** detector candidate when:
+
+- The metric name contains one of: `dependency`, `client`, `external`,
+  `datastore`, `database`, `search`, `cache`, `broker`, `stream`, `cloud`,
+  `endpoint_health`, `target_health`, `availability`, `unavailable`,
+  `unhealthy`
+- AND the metric measures `.duration`, `error`, `timeout`, `retry`,
+  `rate_limit`, `throttle`, `circuit_breaker`, endpoint health, target health,
+  availability, unhealthy target count, or operation failure
+
+Dependency metrics should be grouped by low-cardinality dependency and
+operation dimensions when those dimensions exist.
+
+### Capacity Saturation
+
+A metric is a **capacity-saturation** detector candidate when:
+
+- The metric name contains one of: `capacity`, `utilization`, `memory`, `heap`,
+  `cpu`, `disk`, `filesystem`, `fs.`, `jvm`, `threadpool`, `thread_pool`,
+  `worker.active`, `inflight`, `concurrency`, `desired`, `healthy`,
+  `readiness`, `startup`, `healthcheck`, `quota`, `throttle`, `rate_limit`,
+  `restart`, `crashloop`, `pod`, `node`, `task`, `process`, `hpa`, `asg`
+- The metric is a gauge/up-down counter, or a counter for throttled/rejected
+  work, restarts, crash-loop events, readiness/startup failures, healthcheck
+  failures, desired-vs-healthy gaps, or quota/rate-limit breaches
+
+Capacity-saturation metrics should use static thresholds for utilization/quota,
+disk/filesystem pressure, startup/readiness/healthcheck failures, and
+sudden-change detection for throttles/restarts.
+For runtime CPU, prefer normalized utilization gauges such as
+`process.cpu.utilization`, `process.runtime.*.cpu.utilization`,
+`jvm.cpu.recent_utilization`, or a runtime-specific equivalent. When
+source-backed CPU utilization is available, these are capacity-saturation
+signals and should produce CPU-specific dashboards and a CPU saturation detector.
+Do not use thread count, heap usage, memory usage, GC duration, or
+worker counts as CPU coverage. For cumulative CPU time metrics such as
+`process.cpu.time`, `jvm.cpu.time`, or runtime-specific CPU time counters, use
+diagnostic rate charts with `rollup='rate'` or equivalent only unless the audit
+also proves a normalized CPU utilization signal or a safe normalization formula.
+
+### Release Context
+
+A metric or metric dimension is a **release-context** candidate when:
+
+- The metric or dimension name contains one of: `service.version`,
+  `deployment.environment`, `deployment.region`, `deployment.platform`,
+  `container.image.tag`, `artifact.version`, `artifact_version`,
+  `config.version`, `config_version`, `feature_flag`, `canary`, `rollout`,
+  `build.version`, or `image.tag`
+- AND the value is stable and low-cardinality enough for dashboard filters,
+  event overlays, or detector dimensions
+
+Release-context data should be used to correlate incidents to releases,
+config changes, platforms, regions, images, and canary/rollout batches. It is
+not a standalone alert metric unless another rule also matches a health,
+latency, error, dependency, or capacity signal. When a metric has both release
+context and a detector-worthy signal, classify the metric by the detector-worthy
+signal and use the release context as a dashboard filter or detector dimension.
+Classify pure release/config/version metadata as `release-context` only after no
+detector-worthy category matches.
+
 ### Latency
 
 A metric is a **latency** detector candidate when:
@@ -48,7 +186,7 @@ A metric is a **saturation** detector candidate when:
 - The metric type is gauge (observable gauge, up-down counter)
 - The metric name contains one of: `connections`, `pool`, `buffer`, `queue`,
   `lag`, `utilization`, `capacity`, `active`, `pending`, `heap`, `memory`,
-  `goroutines`, `threads`
+  `disk`, `filesystem`, `goroutines`, `threads`
 - Examples: `db.pool.connections.active`, `process.runtime.go.goroutines`,
   `kafka.consumer.lag`, `jvm.memory.heap.used`
 
@@ -71,6 +209,8 @@ Skip a metric (do not generate a detector) when:
    explicitly requests them:
    - `process.runtime.go.gc.count`
    - `process.runtime.go.mem.heap_alloc` (unless saturation threshold is defined)
+   - `process.cpu.time` or `jvm.cpu.time` when no normalized CPU utilization
+     signal or safe normalization formula is available
 
 3. **Informational-only metrics** -- Metrics that are purely informational
    and not suitable for alerting:
@@ -80,26 +220,66 @@ Skip a metric (do not generate a detector) when:
 ## Decision Flowchart
 
 ```
+metric name contains impact/availability/synthetic/client telemetry keyword?
+  -> YES -> impact-classification detector
+  -> NO
+
+metric name contains specific auth/edge keyword?
+  -> YES -> auth-edge detector
+  -> NO
+
+metric name contains customer workflow keyword?
+  -> YES -> customer-impact detector
+  -> NO
+
+metric name contains freshness/lag/age keyword?
+  -> YES -> freshness detector
+  -> NO
+
+metric name contains queue/backpressure keyword?
+  -> YES -> backpressure detector
+  -> NO
+
+metric name contains capacity/disk/readiness/healthcheck/quota/throttle/restart keyword?
+  -> YES -> capacity-saturation detector
+  -> NO
+
 metric name contains ".duration"?
-  → YES → latency detector
-  → NO ↓
+  -> YES -> customer-impact or dependency keyword present?
+    -> YES -> customer-impact or dependency detector
+    -> NO  -> latency detector
+  -> NO
 
 metric name ends with ".total" or ".count"?
-  → YES → contains error keyword?
-    → YES → error detector
-    → NO  → throughput detector
-  → NO ↓
+  -> YES -> customer-impact or dependency keyword present?
+    -> YES -> customer-impact or dependency detector
+    -> NO  -> contains error keyword?
+      -> YES -> error detector
+      -> NO  -> throughput detector
+  -> NO
 
 metric type is gauge AND name matches saturation keywords?
-  → YES → saturation detector
-  → NO  → skip (no detector)
+  -> YES -> capacity-saturation when incident/capacity keyword is present, otherwise saturation detector
+  -> NO
+
+metric or dimension contains service.version/deployment.region/deployment.platform/container.image.tag/artifact version/config/canary/rollout keyword?
+  -> YES -> pure release-context dashboard filter or detector dimension, not standalone alert
+  -> NO  -> skip (no detector)
 ```
 
 ## Priority Order
 
 When a metric could match multiple categories (rare), use this priority:
 
-1. Latency (duration histograms are unambiguous)
-2. Error (error counters are high-value signals)
-3. Throughput (general counters)
-4. Saturation (gauges)
+1. Impact Classification (answers app-down vs degraded first)
+2. Auth/Edge (auth/domain-routing/certificate failures are high-impact)
+3. Customer Impact (answers user-visible workflow health)
+4. Freshness (stale data is often invisible to request RED)
+5. Backpressure (lag and queue pressure are early incident indicators)
+6. Dependency (root-cause signals for downstream failures)
+7. Capacity Saturation (resource/quota pressure before drops/outage)
+8. Latency (generic duration histograms)
+9. Error (generic error counters)
+10. Throughput (general counters)
+11. Saturation (generic gauges)
+12. Release Context (dashboard filters and health-signal dimensions only after no detector-worthy category matches)

--- a/skills/splunk-configure/references/terraform-templates.md
+++ b/skills/splunk-configure/references/terraform-templates.md
@@ -153,12 +153,180 @@ variable "throughput_<metric_id>_stddev" {
 }
 ```
 
+## Incident-Readiness Detector Defaults
+
+Use these defaults for APM readiness categories from
+`references/detector-classification.md`. Generate concrete HCL with the same
+`signalfx_detector` resource shape used above.
+
+| Category | SignalFlow Method | Default | Severity | Detect Label |
+|---|---|---|---|---|
+| freshness | Static threshold on age/lag gauge or histogram p99 | 300 seconds | Critical | Freshness Lag Too High |
+| backpressure | Static threshold on lag/depth/oldest age; sudden-change for rebalance count | 85 for depth/lag, 3 stddev for rebalances | Major | Backpressure Too High |
+| dependency | P99 latency threshold for duration, sudden-change above baseline for errors/timeouts/retries | 1.0s or 3 stddev | Major | Dependency Health Degraded |
+| customer-impact | P99 workflow latency threshold and error/degraded/timeout rate above baseline | 1.0s or 3 stddev | Critical | Customer Workflow Degraded |
+| impact-classification | Static threshold or sudden-change on unavailable/degraded impact by workflow/region | 1 unavailable event or 3 stddev degraded events | Critical | Customer Impact Classified |
+| auth-edge | P99 login/edge latency, error/timeout/expiry above baseline, certificate/TLS expiry static threshold | 1.0s, 3 stddev, or 14 days for cert expiry | Critical | Auth Edge Degraded |
+| capacity-saturation | Static threshold on utilization/quota, sudden-change for throttles/restarts | 85%, 3 stddev, or 1 restart/crash-loop event | Major | Capacity Saturation Too High |
+
+When a readiness area is missing in `.observe/otel.md`, do not generate a
+detector placeholder. Add it to `.observe/detectors.md` as an instrumentation
+prerequisite and recommend `$otel-instrument`.
+
+When incident evidence mentions missed, flapping, auto-resolved, or no-data
+alerts, document detector reliability evidence in the alert coverage matrix.
+Do not generate service metric Terraform for alert lifecycle behavior unless
+the audit proves an app-owned metric already exists or is a required missing
+signal.
+
+## Dashboard Terraform Shape
+
+Use Splunk Observability Cloud dashboard resources when metric evidence exists:
+
+```hcl
+resource "signalfx_dashboard_group" "service" {
+  name = "${var.service_name} Observability"
+}
+
+resource "signalfx_dashboard" "service" {
+  name            = "${var.service_name} Service Health"
+  dashboard_group = signalfx_dashboard_group.service.id
+  time_range      = "-1h"
+
+  filter {
+    property = "service.name"
+    values   = [var.service_name]
+  }
+}
+```
+
+Add Splunk dashboard chart resources for classified metrics and attach them to
+the dashboard.
+Prefer time charts for rates, latency, freshness, backpressure, and dependency
+health; use single-value charts for current lag/age and list/table charts for
+route, dependency, or workflow breakdowns when dimensions are present.
+Dashboard-wide variables for optional dimensions must set
+`apply_if_exist = true`; otherwise a wildcard variable for a dimension that one
+metric lacks can hide valid chart data. Apply this to optional context such as
+environment, region, namespace, platform, version, image tag, config version,
+rollout, provider, model, dependency, and custom realm:
+
+```hcl
+variable {
+  property       = "deployment.environment"
+  alias          = "Environment"
+  values         = ["*"]
+  apply_if_exist = true
+}
+```
+
+Never generate optional wildcard variables with `apply_if_exist = false`.
+Before writing chart SignalFlow, confirm every metric name, filter, group-by,
+and unit from audit evidence, local metric metadata, or approved Splunk API
+metadata. Do not equate the provider/API `realm` variable with telemetry
+dimensions such as `sfx_realm`, `deployment.region`, or `cloud.region`; expose
+those dimensions as dashboard variables when they are proven low-cardinality,
+and only hard-code a dimension value when the audit or user explicitly provides
+that telemetry value.
+Only generate charts for metric names present in the audit or verified through
+live metric metadata. If a provider-derived, precomputed, or transformed metric
+name is used instead of the audited OTel name, document the live metadata
+provenance and verification result in `.observe/dashboards.md`.
+Live metric metadata alone is not sufficient when the repository has no
+source-backed emitter for the metric. If a metric appears only in build output,
+generated artifacts, `target/`, `build/`, `.class`, jar, coverage, or stale
+runtime files, treat it as stale/unowned evidence: skip the panel by default and
+record a verification issue or cleanup prerequisite instead.
+Do not combine mixed-unit signals on one chart. Split boolean readiness,
+availability, ratios/percentages, bytes, counts, rates, cumulative counters,
+and durations into separate panels unless the chart type explicitly supports
+per-series units or axes and the dashboard report documents the unit handling.
+For example, database readiness and connection-pool utilization belong in
+separate panels.
+Runtime capacity dashboards must preserve the resource class represented by
+each metric. When source-backed CPU utilization is present, create a CPU panel
+and CPU saturation detector from that CPU metric, for example
+`process.cpu.utilization`, `process.runtime.*.cpu.utilization`,
+`jvm.cpu.recent_utilization`, or the runtime-specific equivalent. Do not satisfy
+CPU coverage with thread, heap, memory, GC, or worker-count charts. Do not use thread count
+as a CPU proxy. Memory/heap, thread or goroutine count, GC
+pressure, concurrency, disk/filesystem, quota, and CPU should be separate panels
+because their units and thresholds differ.
+If only cumulative CPU time is available, chart it as a diagnostic rate with
+`rollup='rate'` or an equivalent delta/rate transform and record normalized CPU utilization
+as a missing prerequisite before creating a CPU saturation detector.
+If a metric is pre-aggregated, already quantized, or named like `.p99`, `.p95`,
+`p50`, or `quantile`, do not average it for p99 charts. Use `max()` for a
+current worst-case value or `max(by=[...])` for a split chart. Use
+`.percentile(pct=99)` only with raw duration/histogram metrics. Convert units
+explicitly when the metric name or metadata indicates nanoseconds,
+milliseconds, bytes, ratios, or rates.
+For cumulative counters or cumulative timers, including names that end in
+`.total`, `.count`, `.time`, or metrics whose metadata shows cumulative
+temporality, do not chart the raw cumulative value as current health. Use
+`rollup='rate'`, a delta/rate transform, or a true duration histogram/summary.
+If neither is available, label the chart as cumulative and mark it unverified.
+When a token or local query path is available, run each generated chart program
+over a recent known-traffic window before applying Terraform. If the chart
+returns no series, uses an absent dimension, or has implausible units, fix the
+program or document the panel as unverified in `.observe/dashboards.md`.
+When validating a dashboard in the Splunk UI after Terraform updates, reload
+the canonical dashboard URL without a stale `configId` parameter or reset saved
+dashboard overrides before deciding the chart still has no data.
+
+## Alert Coverage Audit Output
+
+When `splunk-configure` runs in alert-coverage-audit mode, produce a coverage
+matrix even if no Terraform can be generated. Use existing local Terraform,
+dashboard specs, or approved Splunk API results as evidence when available.
+If existing alert inventory is unavailable, label the matrix as desired-state
+coverage derived from `.observe/otel.md`.
+
+Required rows:
+
+- Primary workflow availability
+- API error/latency
+- Ingest lag/drops/freshness
+- Queue/backpressure
+- Dependency health
+- Auth/domain-routing/edge
+- Critical business workflow
+- Multi-region blast radius
+- Capacity saturation
+- Release/config/canary correlation
+
+Each row must say whether coverage is generated, existing, missing, or blocked
+by missing instrumentation. Do not claim coverage from a missing signal.
+
+## Impact and Blast-Radius Dashboards
+
+For impact-classification and blast-radius coverage, include dashboard panels or
+specifications that roll up by low-cardinality dimensions already present in the
+metrics:
+
+- `service.name`
+- `deployment.environment`
+- region or environment when available
+- workflow name/type when available
+- impact class or outcome when available
+- dependency name/operation when available
+- deployment version, config version, canary, or rollout batch when available
+
+The dashboard should make these questions answerable quickly:
+
+1. Is the whole app down, or is one workflow degraded?
+2. Is impact limited to one region/environment or multi-region?
+3. Is the symptom API, workflow, auth, ingest, or workflow specific?
+4. Did impact start near a deploy, config change, canary, or dependency failure?
+5. Is the impact tied to dependency health, capacity, release/config, or
+   backpressure?
+
 ## terraform.tfvars.example
 
 Generated alongside the `.tf` files so users know exactly which values to provide.
 
 ```hcl
-realm                = ""   # e.g. us1, eu0, lab0
+realm                = ""   # Splunk Observability Cloud realm
 api_token            = ""   # Splunk O11y API token (org-level, detector write)
 service_name         = "<service-name>"
 notification_channel = ""   # e.g. "Email,team@example.com" or PagerDuty routing key
@@ -166,7 +334,7 @@ notification_channel = ""   # e.g. "Email,team@example.com" or PagerDuty routing
 
 Includes `realm`, `api_token`, and `notification_channel` (no defaults) plus
 `service_name` for convenience (has a default from the report but commonly overridden).
-Per-detector threshold overrides are omitted — they have sensible defaults in
+Per-detector threshold overrides are omitted -- they have sensible defaults in
 `variables.tf` and users add overrides only when tuning.
 
 The user workflow is:
@@ -179,6 +347,6 @@ The user workflow is:
 
 | Placeholder | Meaning |
 |---|---|
-| `<metric_id>` | Sanitized metric name (dots/hyphens → underscores, no leading digits) |
+| `<metric_id>` | Sanitized metric name (dots/hyphens to underscores, no leading digits) |
 | `<metric_name>` | Original metric name as it appears in telemetry |
 | `var.service_name` | From `variables.tf`; defaults to the service name in the audit report |


### PR DESCRIPTION
## Summary

This PR adds generic MTTD incident-readiness guidance to the observability skills. GenAI/LLM-specific guidance remains in the separate stacked PR #115.

### MTTD / Generic Incident Readiness
- Adds `skills/references/incident-readiness.md` for customer-impact workflows, dependencies, freshness, backpressure, auth/edge, capacity, release/config context, and detector-ready signals.
- Updates `$otel-audit` to report `## Incident Readiness` and emit a structured `## Gap Ledger` contract with `gap_id`, `required_signals`, `owner`, `code_surface`, and `acceptance_criteria`.
- Updates `$otel-instrument` so audit gaps must reconcile through a closure matrix: required signals, implemented signals, tests, remaining signals, and status.
- Requires every gap to resolve as code added + tests, proven existing with source path and signal name, explicit owner mapping, or a named follow-up batch when unsafe/too large.
- Updates `$splunk-configure` to generate detectors only for implemented/proven signals and list `remaining_signals` as instrumentation prerequisites instead of implying complete coverage.
- Adds deterministic eval coverage for generic incident-readiness guidance, runtime surface closure, detector reliability handoff, dashboard guardrails, non-GenAI wording, and the new audit-gap contract.

## Agent Plan
- Keep PR #111 scoped to generic MTTD incident-readiness behavior that applies to non-AI and AI services alike.
- Keep GenAI/LLM semantic-convention and AI-pathway guidance out of this PR.
- Use PR #115 for the GenAI layer on top of this branch.

## Review
- Combine review run: Claude diff-only pass returned no verified P0-P2 findings.
- Baseline review tightened owner vocabulary and partial detector wording before push.

## Verification
- `uv run pytest evals/test_incident_readiness_skill_guidance.py -q`
- `git diff --check $(git merge-base origin/main HEAD)...HEAD`
