### PR TITLE
Add deployment context readiness to observability skills

### DIFF
--- a/evals/deployment/app-only/eval/qual/audit.json
+++ b/evals/deployment/app-only/eval/qual/audit.json
@@ -1,0 +1,23 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "app-only-deployment-path-prompt",
+      "task": "Scan ./service for observability gaps. This fixture intentionally contains app code only and no chart, values, GitOps, IaC, CI/CD, or runtime deployment repo. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for app code.",
+    "Confirm there are no ./chart, ./values, ./gitops, ./terraform, or deployment manifest directories in the fixture.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies app.js and package.json as the app code surfaces.",
+    "Recognizes that production deployment/config sources are not discoverable in the workspace.",
+    "Before treating deployment context as final, asks the user for optional chart, values, GitOps, IaC, CI/CD, or runtime repo paths or URLs.",
+    "Uses concrete examples such as ./chart, ./values, ./gitops, ./terraform, a Helm chart repo, environment-values repo, or deployment pipeline path.",
+    "Does not invent deployment context, production values, or deployment health signals from the app-only repo.",
+    "If continuing app-code-only, marks deployment context as unknown rather than missing."
+  ]
+}

--- a/evals/deployment/app-only/service/app.js
+++ b/evals/deployment/app-only/service/app.js
@@ -1,0 +1,13 @@
+import express from "express";
+
+const app = express();
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.get("/orders", (_req, res) => {
+  res.json([{ id: "order-1" }]);
+});
+
+app.listen(process.env.PORT || 3000);

--- a/evals/deployment/app-only/service/package.json
+++ b/evals/deployment/app-only/service/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "orders-api",
+  "version": "1.4.2",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/evals/deployment/dependency-config/.observe/otel.md
+++ b/evals/deployment/dependency-config/.observe/otel.md
@@ -1,0 +1,67 @@
+# Observability Report: orders-api
+
+**Language:** Node.js | **Framework:** Express | **Date:** 2026-06-07
+
+## Evidence
+
+- Manifest: service/package.json
+- Entry point: service/app.js
+- Route source: service/app.js
+- Runtime/startup: none detected
+- Deployment/runtime: chart/, gitops/application.yaml, terraform/main.tf
+
+## Routes
+
+| Method | Path |
+|--------|------|
+| GET | /health |
+| GET | /orders/{id} |
+
+## Current Instrumentation
+
+### Spans
+
+| Name | Source | Type |
+|------|--------|------|
+| GET /orders/{id} | existing HTTP server instrumentation | auto |
+| HTTP GET payments | existing HTTP client instrumentation | auto |
+| db.query orders | existing database client instrumentation | auto |
+
+### Metrics
+
+| Name | Source | Type |
+|------|--------|------|
+| http.server.request.duration | existing HTTP server instrumentation | auto histogram |
+| http.client.request.duration | existing HTTP client instrumentation | auto histogram |
+| db.client.operation.duration | existing database client instrumentation | auto histogram |
+
+### Logs
+
+No OTel log instrumentation detected.
+
+## RED Signals
+
+| Signal | Status | Detail |
+|--------|--------|--------|
+| Rate | covered | Can be derived from request-duration histogram counts. |
+| Errors | partial | Spans exist, but dependency error classification is not proven. |
+| Duration | covered | Server, HTTP client, and database duration histograms are available. |
+
+## Deployment Context
+
+| Area | Status | Evidence | Gap |
+|------|--------|----------|-----|
+| Platform/source | partial | Helm chart at chart/; Argo CD Application at gitops/application.yaml; Terraform helm_release at terraform/main.tf | Argo CD references $deps/prod/orders-api-dependencies.yaml and Terraform references ../dependency-values/prod/orders-api-dependencies.yaml, but the dependency values source is referenced but not inspected |
+| Service identity | missing | No service.name or OTEL_SERVICE_NAME in inspected sources | Add service identity in app/startup/deployment config |
+| Release/config | partial | chart image tag 2.1.0 is present | config version and rollout id may live in referenced dependency values source |
+| Dependency config | partial | app uses PAYMENTS_API_URL, PAYMENTS_TIMEOUT_MS, PAYMENTS_RETRY_POLICY, PAYMENTS_CIRCUIT_BREAKER, DATABASE_URL, and DB_POOL_MAX; chart maps timeout, retry policy, circuit breaker, pool max, ConfigMap ref, and Secret ref | referenced dependency values source not inspected; endpoint value, provider region, database URL value, credential reference target, and dependency config version are unknown |
+| Dependency health | missing | HTTP client and database duration metrics exist, but no endpoint health, target health, unhealthy target, timeout count, or rate-limit metric is proven | add dependency endpoint health or platform target health metrics before endpoint-health detectors |
+| Health/capacity | partial | readinessProbe exists; DB_POOL_MAX is configured | no runtime pool saturation, disk saturation, desired-vs-healthy, dependency availability, or platform health metrics are proven |
+| Export path | missing | no OTLP endpoint in inspected deployment sources | add collector/export config |
+
+## Gaps
+
+- Missing service identity and export path.
+- Dependency endpoint values, provider region, and config version are referenced but not inspected.
+- Dependency endpoint health is not proven by deployment config alone.
+- Dependency timeout/retry/circuit-breaker source names are visible, but detector dimensions must avoid full URLs and secret values.

--- a/evals/deployment/dependency-config/chart/Chart.yaml
+++ b/evals/deployment/dependency-config/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: orders-api
+version: 0.2.0
+appVersion: "2.1.0"

--- a/evals/deployment/dependency-config/chart/templates/deployment.yaml
+++ b/evals/deployment/dependency-config/chart/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orders-api
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orders-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: orders-api
+    spec:
+      containers:
+        - name: orders-api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: PAYMENTS_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.dependencies.payments.configMapName | quote }}
+                  key: {{ .Values.dependencies.payments.endpointKey | quote }}
+            - name: PAYMENTS_TIMEOUT_MS
+              value: {{ .Values.dependencies.payments.timeoutMs | quote }}
+            - name: PAYMENTS_RETRY_POLICY
+              value: {{ .Values.dependencies.payments.retryPolicy | quote }}
+            - name: PAYMENTS_CIRCUIT_BREAKER
+              value: {{ .Values.dependencies.payments.circuitBreaker | quote }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.dependencies.database.secretName | quote }}
+                  key: {{ .Values.dependencies.database.urlKey | quote }}
+            - name: DB_POOL_MAX
+              value: {{ .Values.dependencies.database.poolMax | quote }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000

--- a/evals/deployment/dependency-config/chart/values.yaml
+++ b/evals/deployment/dependency-config/chart/values.yaml
@@ -1,0 +1,17 @@
+replicaCount: 2
+
+image:
+  repository: example.com/orders-api
+  tag: 2.1.0
+
+dependencies:
+  payments:
+    configMapName: orders-api-dependencies
+    endpointKey: payments_api_url
+    timeoutMs: 2000
+    retryPolicy: standard-3
+    circuitBreaker: payments-primary
+  database:
+    secretName: orders-api-db
+    urlKey: database_url
+    poolMax: 20

--- a/evals/deployment/dependency-config/eval/qual/audit.json
+++ b/evals/deployment/dependency-config/eval/qual/audit.json
@@ -1,0 +1,23 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "dependency-config-sources",
+      "task": "Scan ./service for observability gaps and include deployment context from ./chart, ./gitops, and ./terraform. Map app dependencies to deployment-owned endpoint, timeout, retry, circuit breaker, pool, region, and credential-reference config. Do not inspect or assume any external dependency-values repo."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service, ./chart, ./gitops, and ./terraform for resulting files when present.",
+    "Confirm there is no ./dependency-values directory in the fixture.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies outbound dependencies from app code and package.json, including HTTP client and database dependencies.",
+    "Maps dependency config to deployment sources such as env vars, ConfigMap refs, Secret refs, chart values, Argo CD valueFiles, and Terraform helm_release.values.",
+    "Reports endpoint, provider region, credential reference target, and config version from the external dependency-values source as referenced but not inspected or unknown.",
+    "Recognizes timeout, retry policy, circuit breaker, and pool settings when present in inspected chart values or templates.",
+    "Reports dependency endpoint health as missing or unknown unless endpoint health, target health, timeout count, rate-limit count, or unhealthy target metrics are proven.",
+    "Does not treat full URLs, secret values, or credential values as safe detector dimensions."
+  ]
+}

--- a/evals/deployment/dependency-config/eval/qual/configure.json
+++ b/evals/deployment/dependency-config/eval/qual/configure.json
@@ -1,0 +1,23 @@
+{
+  "skill": "splunk-configure",
+  "prompts": [
+    {
+      "id": "dependency-config-sources",
+      "task": "Use the audit report at ./.observe/otel.md to generate detector Terraform and deployment prerequisites. The report includes dependency config references to an external dependency-values source that was not inspected. Do not invent dependency endpoint, provider, retry, timeout, circuit breaker, region, or config-version detectors from absent metrics or uninspected config."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./.observe/otel.md and any generated .observe detector files.",
+    "Confirm there is no ./dependency-values directory in the fixture.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Uses dependency dimensions only when proven low-cardinality, such as dependency type/name, sanitized endpoint alias, provider region, retry policy name, circuit breaker name, or config version.",
+    "Does not use full URLs, credentials, raw hosts with user/tenant data, request payloads, or secret values as detector filters or group-bys.",
+    "Documents the external dependency-values source as a prerequisite when endpoint, provider region, credential reference, or config version are unknown.",
+    "Does not create dependency endpoint, retry, timeout, circuit breaker, provider, or config-version detectors from absent metrics.",
+    "Does not create dependency endpoint-health detectors from config-only evidence when endpoint health or target health metrics are absent.",
+    "Keeps detector output service-scoped when dependency config dimensions are unknown."
+  ]
+}

--- a/evals/deployment/dependency-config/eval/qual/instrument.json
+++ b/evals/deployment/dependency-config/eval/qual/instrument.json
@@ -1,0 +1,22 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "dependency-config-sources",
+      "task": "Instrument ./service for OpenTelemetry and use ./chart, ./gitops, and ./terraform as deployment context. If dependency endpoint, region, timeout, retry, circuit breaker, pool, or credential-reference config belongs in deployment config, update only reusable app/chart knobs and do not hardcode external dependency-values into app code."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service, ./chart, ./gitops, and ./terraform for resulting files when present.",
+    "Confirm there is no ./dependency-values directory in the fixture.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Confirms app dependencies and inspected deployment config sources before editing.",
+    "Does not hardcode dependency endpoints, provider regions, database URLs, credential values, or secret material into app code or chart defaults.",
+    "Patches app code only for spans/metrics and safe local defaults, while preserving deployment-owned dependency config in chart/values/GitOps/IaC.",
+    "Reports unresolved dependency endpoint, provider region, credential reference, or config version sources as unknown or referenced but not inspected.",
+    "Uses low-cardinality dependency attributes and avoids full URLs, raw hosts with tenant/user data, request payloads, or secret values."
+  ]
+}

--- a/evals/deployment/dependency-config/gitops/application.yaml
+++ b/evals/deployment/dependency-config/gitops/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: orders-api-prod
+spec:
+  project: default
+  sources:
+    - repoURL: https://git.example.com/platform/helm-charts.git
+      path: charts/orders-api
+      targetRevision: main
+      helm:
+        valueFiles:
+          - $deps/prod/orders-api-dependencies.yaml
+    - repoURL: https://git.example.com/platform/dependency-values.git
+      targetRevision: main
+      ref: deps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: orders-prod

--- a/evals/deployment/dependency-config/service/app.js
+++ b/evals/deployment/dependency-config/service/app.js
@@ -1,0 +1,27 @@
+const axios = require("axios");
+const express = require("express");
+const { Pool } = require("pg");
+
+const app = express();
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: Number(process.env.DB_POOL_MAX || 10)
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get("/orders/:id", async (req, res, next) => {
+  try {
+    const order = await pool.query("select $1::text as id", [req.params.id]);
+    const payment = await axios.get(`${process.env.PAYMENTS_API_URL}/payments/${req.params.id}`, {
+      timeout: Number(process.env.PAYMENTS_TIMEOUT_MS || 1000)
+    });
+    res.json({ id: order.rows[0].id, payment: payment.status });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.listen(process.env.PORT || 3000);

--- a/evals/deployment/dependency-config/service/package.json
+++ b/evals/deployment/dependency-config/service/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "axios": "1.7.9",
+    "express": "4.18.2",
+    "pg": "8.13.1"
+  }
+}

--- a/evals/deployment/dependency-config/terraform/main.tf
+++ b/evals/deployment/dependency-config/terraform/main.tf
@@ -1,0 +1,9 @@
+resource "helm_release" "orders_api" {
+  name      = "orders-api"
+  namespace = "orders-prod"
+  chart     = "../chart"
+
+  values = [
+    file("../dependency-values/prod/orders-api-dependencies.yaml")
+  ]
+}

--- a/evals/deployment/multi-repo/.observe/otel.md
+++ b/evals/deployment/multi-repo/.observe/otel.md
@@ -1,0 +1,66 @@
+# Observability Report: orders-api
+
+**Language:** Node.js | **Framework:** Express | **Date:** 2026-06-07
+
+## Evidence
+- Manifest: `service/package.json`
+- Entry point: `service/app.js`
+- Route source: `service/app.js`
+- Runtime/startup: `service/package.json`
+- Deployment/runtime: `chart/Chart.yaml`, `chart/values.yaml`, `chart/templates/deployment.yaml`, `values/prod/orders-api.yaml`, `gitops/application.yaml`, `terraform/main.tf`
+
+## Routes
+
+| Method | Path |
+|--------|------|
+| GET | /health |
+| GET | /orders |
+| POST | /orders |
+
+## Current Instrumentation
+
+### Spans
+
+| Name | Source | Type |
+|------|--------|------|
+| GET /health | existing OTel HTTP instrumentation | auto |
+| GET /orders | existing OTel HTTP instrumentation | auto |
+| POST /orders | existing OTel HTTP instrumentation | auto |
+
+### Metrics
+
+| Name | Source | Type |
+|------|--------|------|
+| http.server.request.duration | existing OTel HTTP instrumentation | auto histogram |
+
+### Logs
+
+No OTel log instrumentation detected.
+
+## RED Signals
+
+| Signal | Status | Detail |
+|--------|--------|--------|
+| Rate | covered | Can be derived from `http.server.request.duration` count. |
+| Errors | missing | No span status or error metric evidence is present. |
+| Duration | covered | `http.server.request.duration` is available for latency detectors. |
+
+## Deployment Context
+
+| Area | Status | Evidence | Gap |
+|------|--------|----------|-----|
+| Platform/source | covered | Helm chart, prod values, Argo CD multi-source Application, Terraform `helm_release` | None |
+| Service identity | covered | `service.name=orders-api` in Helm values | None |
+| Release/config | partial | image tag `1.4.2`, `service.version`, `deployment.rollout.id=batch-20260607` | No explicit config version |
+| Health/capacity | partial | readiness probe and CPU/memory requests/limits in deployment template | No restart/crash-loop or platform health metric evidence |
+| Export path | covered | `OTEL_EXPORTER_OTLP_ENDPOINT` in deployment template and prod values | None |
+
+## Gaps
+- Missing error visibility.
+- Missing config version and runtime health metrics for release/capacity detectors.
+
+## Anti-Patterns
+- None detected.
+
+## Recommendation
+- Run `$otel-instrument` to add error visibility and runtime health metric prerequisites.

--- a/evals/deployment/multi-repo/chart/Chart.yaml
+++ b/evals/deployment/multi-repo/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: orders-api
+version: 0.8.0
+appVersion: 1.4.2

--- a/evals/deployment/multi-repo/chart/templates/deployment.yaml
+++ b/evals/deployment/multi-repo/chart/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    spec:
+      containers:
+        - name: orders-api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.image.tag | urlquery }}{{ range $key, $value := .Values.otel.resourceAttributes }},{{ $key }}={{ $value | toString | urlquery }}{{ end }}"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/evals/deployment/multi-repo/chart/values.yaml
+++ b/evals/deployment/multi-repo/chart/values.yaml
@@ -1,0 +1,14 @@
+replicaCount: 2
+
+image:
+  repository: example.com/orders-api
+  tag: 1.4.2
+
+service:
+  port: 3000
+
+otel:
+  enabled: true
+  endpoint: http://otel-collector.observability.svc.cluster.local:4318
+  resourceAttributes:
+    service.name: orders-api

--- a/evals/deployment/multi-repo/eval/qual/audit.json
+++ b/evals/deployment/multi-repo/eval/qual/audit.json
@@ -1,0 +1,21 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "multi-repo-deployment",
+      "task": "Scan ./service for observability gaps and include deployment context from ./chart, ./values, ./gitops, and ./terraform. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service, ./chart, ./values, ./gitops, and ./terraform for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies app.js and package.json as the app code surfaces.",
+    "Identifies Helm chart, production values, Argo CD multi-source Application, and Terraform helm_release as deployment sources.",
+    "Reports Kubernetes/Helm/GitOps/Terraform deployment context rather than treating the app repo as the only source of runtime truth.",
+    "Recognizes service.name, deployment.environment, service.version or image tag, region, rollout id, OTLP endpoint, readiness probe, and resource requests/limits when present.",
+    "Distinguishes unknown deployment context from missing deployment signals when a source is not inspected."
+  ]
+}

--- a/evals/deployment/multi-repo/eval/qual/configure.json
+++ b/evals/deployment/multi-repo/eval/qual/configure.json
@@ -1,0 +1,21 @@
+{
+  "skill": "splunk-configure",
+  "prompts": [
+    {
+      "id": "deployment-aware-detectors",
+      "task": "Use the audit report at ./.observe/otel.md, which includes deployment context from ./chart, ./values, ./gitops, and ./terraform, to generate detector Terraform and document deployment prerequisites. Do not invent detectors from absent runtime metrics."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service, ./chart, ./values, ./gitops, and ./terraform for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Uses proven deployment dimensions such as service.name, deployment.environment, service.version or image tag, region, namespace, and rollout id only when present.",
+    "Does not group detectors by raw pod, container, request, user, tenant, session, trace, or raw URL values.",
+    "Does not create release/config, health, capacity, or rollout detectors from absent metrics.",
+    "Documents deployment prerequisites for missing or unknown runtime health, capacity, export path, and release/config signals.",
+    "Keeps detector output service-scoped when deployment dimensions are unknown."
+  ]
+}

--- a/evals/deployment/multi-repo/eval/qual/instrument.json
+++ b/evals/deployment/multi-repo/eval/qual/instrument.json
@@ -1,0 +1,21 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "multi-repo-deployment",
+      "task": "Instrument ./service for OpenTelemetry and use ./chart, ./values, ./gitops, and ./terraform as deployment context. If runtime OTel attributes belong in deployment config, update the deployment source instead of hardcoding production values in app code."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service, ./chart, ./values, ./gitops, and ./terraform for resulting files when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Confirms the app process and the separate deployment sources before editing.",
+    "Does not hardcode production OTLP endpoints, tokens, region, or environment into app source.",
+    "Preserves deployment-owned runtime attributes in Helm values or templates when those files already own runtime config.",
+    "States which file class should be patched: app code, chart template, values, GitOps, or Terraform.",
+    "Reports deployment context as unknown rather than missing if a production source is not supplied."
+  ]
+}

--- a/evals/deployment/multi-repo/gitops/application.yaml
+++ b/evals/deployment/multi-repo/gitops/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: orders-api-prod
+spec:
+  project: default
+  sources:
+    - repoURL: https://git.example.com/platform/helm-charts.git
+      path: charts/orders-api
+      targetRevision: main
+      helm:
+        valueFiles:
+          - $values/prod/orders-api.yaml
+    - repoURL: https://git.example.com/platform/env-values.git
+      path: prod/orders-api
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: orders-prod

--- a/evals/deployment/multi-repo/service/app.js
+++ b/evals/deployment/multi-repo/service/app.js
@@ -1,0 +1,17 @@
+import express from "express";
+
+const app = express();
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.get("/orders", (_req, res) => {
+  res.json([{ id: "order-1" }]);
+});
+
+app.post("/orders", (_req, res) => {
+  res.status(201).json({ id: "order-2" });
+});
+
+app.listen(process.env.PORT || 3000);

--- a/evals/deployment/multi-repo/service/package.json
+++ b/evals/deployment/multi-repo/service/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "orders-api",
+  "version": "1.4.2",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/evals/deployment/multi-repo/terraform/main.tf
+++ b/evals/deployment/multi-repo/terraform/main.tf
@@ -1,0 +1,9 @@
+resource "helm_release" "orders_api" {
+  name      = "orders-api"
+  namespace = "orders-prod"
+  chart     = "../chart"
+
+  values = [
+    file("../values/prod/orders-api.yaml")
+  ]
+}

--- a/evals/deployment/multi-repo/values/prod/orders-api.yaml
+++ b/evals/deployment/multi-repo/values/prod/orders-api.yaml
@@ -1,0 +1,13 @@
+replicaCount: 4
+
+image:
+  repository: registry.example.com/platform/orders-api
+  tag: 1.4.2
+
+otel:
+  endpoint: https://otel-collector.example.invalid/v2/trace/otlp
+  resourceAttributes:
+    service.name: orders-api
+    deployment.environment: prod
+    cloud.region: us-east-1
+    deployment.rollout.id: batch-20260607

--- a/evals/deployment/referenced-values/.observe/otel.md
+++ b/evals/deployment/referenced-values/.observe/otel.md
@@ -1,0 +1,57 @@
+# Observability Report: orders-api
+
+**Language:** Node.js | **Framework:** Express | **Date:** 2026-06-07
+
+## Evidence
+
+- Manifest: service/package.json
+- Entry point: service/app.js
+- Route source: service/app.js
+- Runtime/startup: none detected
+- Deployment/runtime: chart/, gitops/application.yaml, terraform/main.tf
+
+## Routes
+
+| Method | Path |
+|--------|------|
+| GET | /health |
+| GET | /orders/{id} |
+
+## Current Instrumentation
+
+### Spans
+
+No spans detected.
+
+### Metrics
+
+No metrics detected.
+
+### Logs
+
+No OTel log instrumentation detected.
+
+## RED Signals
+
+| Signal | Status | Detail |
+|--------|--------|--------|
+| Rate | missing | No request count metric or span source is present. |
+| Errors | missing | No span status or error metric evidence is present. |
+| Duration | missing | No request-duration metric or span source is present. |
+
+## Deployment Context
+
+| Area | Status | Evidence | Gap |
+|------|--------|----------|-----|
+| Platform/source | partial | Helm chart at chart/; Argo CD Application at gitops/application.yaml; Terraform helm_release at terraform/main.tf | Argo CD references $env/prod/orders-api.yaml and Terraform references ../env-values/prod/orders-api.yaml, but the env values source is referenced but not inspected |
+| Service identity | covered | chart/values.yaml sets otel.resourceAttributes.service.name=orders-api | none |
+| Release/config | unknown | chart image tag exists; env values source may override image, environment, region, config, or rollout attributes | referenced env values source not inspected |
+| Health/capacity | partial | chart/templates/deployment.yaml has readinessProbe and memory/cpu settings | runtime health metrics are not proven |
+| Export path | unknown | no OTLP endpoint in inspected chart values | referenced env values source not inspected |
+
+## Gaps
+
+- Missing Express auto-instrumentation and SDK initialization.
+- Missing HTTP duration/error metrics.
+- Missing deployment.environment and region attributes in inspected sources.
+- Referenced values source is not inspected; do not treat its dimensions as available.

--- a/evals/deployment/referenced-values/chart/Chart.yaml
+++ b/evals/deployment/referenced-values/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: orders-api
+version: 0.1.0
+appVersion: "1.4.2"

--- a/evals/deployment/referenced-values/chart/templates/deployment.yaml
+++ b/evals/deployment/referenced-values/chart/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orders-api
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orders-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: orders-api
+    spec:
+      containers:
+        - name: orders-api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.image.tag | urlquery }}{{ range $key, $value := .Values.otel.resourceAttributes }},{{ $key }}={{ $value | toString | urlquery }}{{ end }}"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi

--- a/evals/deployment/referenced-values/chart/values.yaml
+++ b/evals/deployment/referenced-values/chart/values.yaml
@@ -1,0 +1,13 @@
+replicaCount: 2
+
+image:
+  repository: example.com/orders-api
+  tag: 1.4.2
+
+service:
+  port: 3000
+
+otel:
+  enabled: true
+  resourceAttributes:
+    service.name: orders-api

--- a/evals/deployment/referenced-values/eval/qual/audit.json
+++ b/evals/deployment/referenced-values/eval/qual/audit.json
@@ -1,0 +1,22 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "referenced-values-not-supplied",
+      "task": "Scan ./service for observability gaps and include deployment context from ./chart, ./gitops, and ./terraform. Do not inspect or assume any external env-values repo. If deployment files reference values or config sources that are not present, report them as referenced but not inspected."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service, ./chart, ./gitops, and ./terraform for resulting files when present.",
+    "Confirm there is no ./env-values or ./values directory in the fixture.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies app.js and package.json as the app code surfaces.",
+    "Identifies Helm, Argo CD, and Terraform as deployment sources.",
+    "Recognizes that Argo CD valueFiles and Terraform helm_release.values reference an external values source.",
+    "Marks the referenced values source as referenced but not inspected or unknown, not as a proven missing telemetry signal.",
+    "Asks for the referenced values/config source path or URL rather than cloning or inventing it."
+  ]
+}

--- a/evals/deployment/referenced-values/eval/qual/configure.json
+++ b/evals/deployment/referenced-values/eval/qual/configure.json
@@ -1,0 +1,22 @@
+{
+  "skill": "splunk-configure",
+  "prompts": [
+    {
+      "id": "referenced-values-not-supplied",
+      "task": "Use the audit report at ./.observe/otel.md to generate detector Terraform and deployment prerequisites. The report includes deployment references to an external values source that was not inspected. Do not invent detectors, filters, or group-bys from that source."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./.observe/otel.md and any generated .observe detector files.",
+    "Confirm there is no ./env-values or ./values directory in the fixture.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Does not generate detectors from absent metrics.",
+    "Does not use deployment.environment, region, config version, rollout id, or OTLP endpoint as proven dimensions when only the missing values source could provide them.",
+    "Documents the referenced env values source as a deployment prerequisite.",
+    "Keeps any detector output service-scoped when deployment dimensions are unknown.",
+    "Does not group by raw pod, container, request, user, tenant, session, trace, raw URL, or secret values."
+  ]
+}

--- a/evals/deployment/referenced-values/eval/qual/instrument.json
+++ b/evals/deployment/referenced-values/eval/qual/instrument.json
@@ -1,0 +1,22 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "referenced-values-not-supplied",
+      "task": "Instrument ./service for OpenTelemetry and use ./chart, ./gitops, and ./terraform as deployment context. Do not inspect or assume any external env-values repo. If deployment files reference values or config sources that are not present, do not hardcode environment-specific telemetry values into app code or chart defaults."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service, ./chart, ./gitops, and ./terraform for resulting files when present.",
+    "Confirm there is no ./env-values or ./values directory in the fixture.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Confirms the app process and the inspected deployment sources before editing.",
+    "Detects that Argo CD and Terraform reference an external values source that is not supplied.",
+    "Does not hardcode production environment, region, OTLP endpoint, token, rollout, or config values into app source or chart defaults.",
+    "Patches only reusable app or chart instrumentation knobs when appropriate.",
+    "Reports referenced deployment context as unknown or referenced but not inspected and asks for the missing values/config source."
+  ]
+}

--- a/evals/deployment/referenced-values/gitops/application.yaml
+++ b/evals/deployment/referenced-values/gitops/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: orders-api-prod
+spec:
+  project: default
+  sources:
+    - repoURL: https://git.example.com/platform/helm-charts.git
+      path: charts/orders-api
+      targetRevision: main
+      helm:
+        valueFiles:
+          - $env/prod/orders-api.yaml
+    - repoURL: https://git.example.com/platform/env-values.git
+      targetRevision: main
+      ref: env
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: orders-prod

--- a/evals/deployment/referenced-values/service/app.js
+++ b/evals/deployment/referenced-values/service/app.js
@@ -1,0 +1,13 @@
+const express = require("express");
+
+const app = express();
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get("/orders/:id", (req, res) => {
+  res.json({ id: req.params.id, status: "pending" });
+});
+
+app.listen(process.env.PORT || 3000);

--- a/evals/deployment/referenced-values/service/package.json
+++ b/evals/deployment/referenced-values/service/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "4.18.2"
+  }
+}

--- a/evals/deployment/referenced-values/terraform/main.tf
+++ b/evals/deployment/referenced-values/terraform/main.tf
@@ -1,0 +1,9 @@
+resource "helm_release" "orders_api" {
+  name      = "orders-api"
+  namespace = "orders-prod"
+  chart     = "../chart"
+
+  values = [
+    file("../env-values/prod/orders-api.yaml")
+  ]
+}

--- a/evals/test_splunk_configure_signalflow_guidance.py
+++ b/evals/test_splunk_configure_signalflow_guidance.py
@@ -1,0 +1,47 @@
+"""Deterministic checks for splunk-configure SignalFlow guardrails."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPLUNK_CONFIGURE = REPO_ROOT / "skills" / "splunk-configure" / "SKILL.md"
+TEMPLATES = (
+    REPO_ROOT
+    / "skills"
+    / "splunk-configure"
+    / "references"
+    / "terraform-templates.md"
+)
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"Expected file not found: {path}"
+    return path.read_text()
+
+
+def test_configure_uses_only_proven_telemetry_dimensions():
+    skill = _read(SPLUNK_CONFIGURE)
+    templates = _read(TEMPLATES)
+    required_skill_terms = [
+        "Keep the Splunk Observability Cloud API `realm` variable separate",
+        "Do not use `var.realm` as a SignalFlow filter",
+        "`sfx_realm`",
+        "approved Splunk API metadata",
+        "Never use a dimension solely because referenced",
+        "already-quantized",
+        "threshold defaults",
+    ]
+    required_template_terms = [
+        "provider/API `realm` variable",
+        "telemetry dimension",
+        "`sfx_realm`",
+        "deployment.region",
+        "cloud.region",
+        "precomputed percentile metrics",
+        "already-quantized",
+        "`max()`/`max(by=[...])`",
+    ]
+    assert not [term for term in required_skill_terms if term not in skill]
+    assert not [term for term in required_template_terms if term not in templates]
+    assert "e.g. us1, eu0, lab0" not in skill
+    assert "e.g. us1, eu0, lab0" not in templates

--- a/observer/cmd/fetch-weaver/main.go
+++ b/observer/cmd/fetch-weaver/main.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
-	weaverVersion = "v0.22.1"
-	downloadBase  = "https://github.com/open-telemetry/weaver/releases/download/" + weaverVersion
+	weaverVersion         = "v0.22.1"
+	downloadBase          = "https://github.com/open-telemetry/weaver/releases/download/" + weaverVersion
+	downloadRetryDelay    = 500 * time.Millisecond
+	downloadRetryAttempts = 4
 )
 
 type target struct {
@@ -179,32 +181,82 @@ func weaverCacheDir() (string, error) {
 }
 
 func downloadFile(ctx context.Context, url, destination string) error {
+	return downloadFileWithClient(ctx, http.DefaultClient, url, destination, downloadRetryAttempts, downloadRetryDelay)
+}
+
+type httpClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func downloadFileWithClient(ctx context.Context, client httpClient, url, destination string, attempts int, retryDelay time.Duration) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err, retryable := downloadFileOnce(ctx, client, url, destination)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retryable || attempt == attempts {
+			return err
+		}
+
+		wait := retryDelay * time.Duration(attempt)
+		log.Printf("download %s failed on attempt %d/%d: %v; retrying in %s", url, attempt, attempts, err, wait)
+		if wait <= 0 {
+			continue
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("download %s: %w", url, ctx.Err())
+		case <-timer.C:
+		}
+	}
+	return lastErr
+}
+
+func downloadFileOnce(ctx context.Context, client httpClient, url, destination string) (error, bool) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return fmt.Errorf("create download request: %w", err)
+		return fmt.Errorf("create download request: %w", err), false
 	}
 	req.Header.Set("User-Agent", "obstudio-fetch-weaver/"+weaverVersion)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("download %s: %w", url, err)
+		if ctx.Err() != nil {
+			return fmt.Errorf("download %s: %w", url, ctx.Err()), false
+		}
+		return fmt.Errorf("download %s: %w", url, err), true
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
+		err := fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
+		return err, isRetryableDownloadStatus(resp.StatusCode)
 	}
 
 	out, err := os.Create(destination)
 	if err != nil {
-		return fmt.Errorf("create archive file: %w", err)
+		return fmt.Errorf("create archive file: %w", err), false
 	}
 	defer out.Close()
 
 	if _, err := io.Copy(out, resp.Body); err != nil {
-		return fmt.Errorf("write archive file: %w", err)
+		return fmt.Errorf("write archive file: %w", err), true
 	}
-	return nil
+	return nil, false
+}
+
+func isRetryableDownloadStatus(statusCode int) bool {
+	return statusCode == http.StatusRequestTimeout ||
+		statusCode == http.StatusTooManyRequests ||
+		statusCode >= http.StatusInternalServerError
 }
 
 func extractBinary(archivePath, workDir, binaryName string) (string, error) {

--- a/observer/cmd/fetch-weaver/main_test.go
+++ b/observer/cmd/fetch-weaver/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -127,6 +129,56 @@ func TestFetchTargetUsesCachedBinaryFromOverride(t *testing.T) {
 	}
 	if string(data) != "cached-weaver" {
 		t.Fatalf("unexpected output contents: %q", string(data))
+	}
+}
+
+func TestDownloadFileRetriesTransientStatus(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			http.Error(w, "temporary gateway failure", http.StatusGatewayTimeout)
+			return
+		}
+		_, _ = w.Write([]byte("weaver-archive"))
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "weaver.tar.xz")
+	err := downloadFileWithClient(t.Context(), server.Client(), server.URL, destination, 2, 0)
+	if err != nil {
+		t.Fatalf("downloadFileWithClient returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 download attempts, got %d", attempts)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(data) != "weaver-archive" {
+		t.Fatalf("unexpected archive contents: %q", string(data))
+	}
+}
+
+func TestDownloadFileDoesNotRetryPermanentStatus(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "weaver.tar.xz")
+	err := downloadFileWithClient(t.Context(), server.Client(), server.URL, destination, 3, 0)
+	if err == nil {
+		t.Fatal("expected permanent status error")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("expected status in error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected one download attempt for permanent failure, got %d", attempts)
 	}
 }
 

--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -5,12 +5,14 @@ description: >-
   on observability coverage gaps. Read-only -- does not modify code.
   Use when the user types $otel-audit, asks about observability gaps,
   wants to assess instrumentation coverage, says "what signals am I
-  missing", "scan this service for observability", or asks about
-  "observability readiness". Do NOT use for implementing code changes --
-  use $otel-instrument instead.
+  missing", "scan this service for observability", asks about
+  "observability readiness", or asks whether deployment, Helm, GitOps,
+  Terraform, serverless, VM, container, dependency config, or runtime
+  configuration supports observability. Do NOT use for implementing code changes -- use
+  $otel-instrument instead.
 metadata:
   author: otel-studio
-  version: 0.6.0
+  version: 0.6.1
   category: observability
 ---
 
@@ -29,6 +31,11 @@ is modified.
 - Checking what auto-instrumentation is already wired up
 - Identifying dependencies that lack matching OTel instrumentation
 - Quick health check of an existing OTel setup
+- Checking whether deployment/runtime configuration carries service name,
+  environment, version, collector, health, capacity, rollout, and config context
+- Checking whether deployment-owned dependency endpoints, regions, timeouts,
+  retries, circuit breakers, or credential refs are discoverable
+
 **When NOT to use:** If you want to add instrumentation, use `$otel-instrument`.
 
 ## Process
@@ -47,11 +54,49 @@ Scan the repository to determine language, framework, and existing instrumentati
 2. Identify entry points (`main`, `cmd/`, `app.py`, `index.ts`, etc.)
 3. Enumerate all HTTP routes with method and path pattern (e.g. `GET /tasks`, `POST /tasks`, `GET /tasks/{id}`). List them explicitly in the report.
 4. Use the Auto-Instrumentation Library Map below to identify which packages should be present for each detected dependency.
-5. Record exact evidence paths that should appear in the report:
+5. Detect deployment-context ownership. Search the current repo for runtime and
+  deployment sources such as Docker Compose, Dockerfiles, systemd units, Procfiles,
+  Helm charts, values files, Kustomize overlays, Kubernetes workloads, Argo CD,
+  Flux, Terraform/Pulumi/CDK, ECS task definitions, serverless manifests, Nomad
+  jobs, CI/CD release files, and deploy docs. If deployment context exists or the
+  user provides deployment repo paths, load `../references/deployment-context-readiness.md`.
+6. Resolve deployment references visible in inspected files. For example, follow
+  Helm/helmfile value-file references, Argo CD/Flux source and value references,
+  Terraform `helm_release.values` or tfvars, Kubernetes `configMapRef`/`secretRef`,
+  Docker Compose `env_file`, systemd `EnvironmentFile`, serverless stage config,
+  dependency endpoint/config references, and CI/CD chart/value path references
+  when the target is present or supplied.
+  If a referenced source is not available, pause before writing
+  `.observe/otel.md` and ask once for its local path or URL. Name the referenced
+  source from the inspected file, such as a chart path, values file, GitOps
+  repo/path, IaC module, CI/CD template, environment file, ConfigMap, Secret,
+  tfvars, stack config, or deployment pipeline. Do not treat this as optional
+  report text; it is an interaction boundary. If the user provides paths,
+  inspect them and continue. If the user says to continue without those sources,
+  record them as `referenced but not inspected` and mark the affected deployment
+  context as `unknown`, not `missing`.
+7. If app code exists but production deployment sources are not discoverable,
+  pause before writing `.observe/otel.md` and ask once for known chart, values,
+  GitOps, IaC, CI/CD, or runtime repo paths. Ask for local paths or URLs and
+  include examples such as `./chart`, `./values`, `./gitops`, `./terraform`,
+  a Helm chart repo, an environment-values repo, or a deployment pipeline path.
+  Do not treat this as optional report text; it is an interaction boundary.
+  If the user provides paths, inspect them and continue. If the user says there
+  are none, asks to continue app-code-only, or provides no paths after the ask,
+  continue the app-code audit and mark deployment context as `unknown`, not
+  `missing`.
+8. Record exact evidence paths that should appear in the report:
   - Dependency manifest: `go.mod`, `package.json`, `pyproject.toml`, `pom.xml`, etc.
   - Process entry point: `main.go`, `cmd/.../main.go`, `app.py`, `app.js`, `TasksApplication.java`, etc.
   - Route source: router/controller files such as `TaskController.java`, `app.py`, `app.js`, or `kvstore/http.go`.
   - Runtime/startup files when present: `Dockerfile`, `docker-compose.yml`, `Makefile`, `package.json` scripts, launch configs, worker files.
+  - Deployment/runtime files when present: `Chart.yaml`, `values*.yaml`,
+    `kustomization.yaml`, Argo/Flux resources, Terraform/Pulumi/CDK files,
+    task definitions, systemd units, serverless manifests, Nomad jobs, and CI/CD
+    release files.
+  - Dependency config sources when present: app config files, env var names,
+    ConfigMap/Secret references, parameter-store refs, values/tfvars/stack
+    config, service mesh or egress config, and gateway/route config.
 
 ### Step 2 -- Instrumentation Assessment
 
@@ -113,6 +158,10 @@ for Python, `@opentelemetry/instrumentation-winston` /
 - Check if a matching auto-instrumentation package is installed
 - Use the Auto-Instrumentation Library Map below as the checklist
 - Flag any dependency that has an available auto-instrumentation package but is not instrumented
+- When deployment context is available, map app dependencies to deployment-owned
+  endpoint, region, timeout, retry, circuit breaker, pool/concurrency, config
+  version, and credential-reference sources. Record source names and references,
+  not secret values.
 
 **RED signal assessment** -- for each RED dimension, determine status:
 
@@ -128,6 +177,22 @@ percentiles? (e.g. `http.server.request.duration` histogram, or span
 duration from auto-instrumentation.)
 Status: `covered` / `partial` / `missing`.
 
+**Deployment context assessment** -- when deployment/runtime sources are found
+or supplied, use `../references/deployment-context-readiness.md` to identify
+platform, source repo/path, runtime workload, and whether telemetry-critical
+runtime settings exist. Add a `## Deployment Context` section and `## Gaps`
+entries for missing service identity, environment, version, collector, health,
+capacity, dependency config, rollout, or config signals. Use these status values:
+
+- **covered** -- inspected deployment sources configure the signal.
+- **partial** -- some runtime context exists, but key dimensions or health/capacity
+  signals are missing.
+- **missing** -- inspected deployment sources prove the signal is absent.
+- **unknown** -- deployment sources were not discoverable or not provided.
+  Include `referenced but not inspected` evidence when inspected deployment
+  files point to another chart, values, GitOps, IaC, env, secret, or runtime
+  config source that is not available in the workspace.
+
 **Anti-patterns** -- flag any of these:
 
 - Multiple SDK initializations in the same process
@@ -136,6 +201,12 @@ Status: `covered` / `partial` / `missing`.
 - High-cardinality attributes on metrics (user IDs, request IDs)
 - Missing `recordException` in error handling paths
 - Custom span names with variable segments (IDs, paths)
+- Claiming deployment/runtime signals are missing when the deployment source was
+  not inspected; use `unknown` instead
+- Ignoring referenced deployment sources such as values files, env files,
+  GitOps sources, IaC modules, ConfigMaps, Secrets, or CI/CD release inputs
+- Claiming dependency endpoint, timeout, retry, circuit breaker, region, or
+  credential-reference coverage when those values live in an uninspected source
 - Use of community or third-party OTel wrappers when an official OpenTelemetry package exists (e.g. `go.opentelemetry.io/contrib`, `@opentelemetry/`*, `opentelemetry-*`)
 
 For partially instrumented Go services, explicitly check and report:
@@ -164,6 +235,7 @@ Use this template for `.observe/otel.md`:
 - Entry point: {path}
 - Route source: {path(s)}
 - Runtime/startup: {path(s) or "none detected"}
+- Deployment/runtime: {path(s), supplied paths, or "unknown -- no deployment source found"}
 
 ## Routes
 
@@ -234,6 +306,18 @@ Status values:
   exist but no histogram for percentile breakdown).
 - **missing** -- no data source provides this signal.
 
+## Deployment Context
+
+| Area | Status | Evidence | Gap |
+|------|--------|----------|-----|
+| Platform/source | {covered / partial / unknown} | {Kubernetes/Helm/GitOps/Terraform/Compose/ECS/Lambda/VM/etc. evidence} | {missing repo path or source detail} |
+| Service identity | {covered / partial / missing / unknown} | {service.name / OTEL_SERVICE_NAME / resource attrs} | {missing identity signal} |
+| Release/config | {covered / partial / missing / unknown} | {service.version, container.image.tag/artifact version, config version, rollout/canary id} | {missing release/config signal} |
+| Dependency config | {covered / partial / missing / unknown} | {dependency endpoint alias, dependency type/name, timeout, retry, circuit breaker, provider region/deployment, config ref/version} | {missing dependency config source or referenced source detail} |
+| Dependency health | {covered / partial / missing / unknown} | {endpoint health, target health, availability, error/timeout/rate-limit metrics, unhealthy target count} | {missing dependency health signal or platform metric source} |
+| Health/capacity | {covered / partial / missing / unknown} | {startup/readiness/liveness checks, health checks, task health, restarts, desired vs healthy instances, CPU/memory/disk/concurrency/limits, throttles, quotas} | {missing health/capacity signal} |
+| Export path | {covered / partial / missing / unknown} | {OTLP endpoint, collector sidecar/gateway, OTel Operator, env vars} | {missing export config} |
+
 ## Gaps
 - {remaining non-RED gaps: missing auto-instrumentation packages, missing
   context propagation, missing OTLP exporter configuration, missing
@@ -249,7 +333,7 @@ Status values:
   $otel-instrument for custom business metrics"}
 
 ---
-*Generated by obstudio v0.6.0 otel-audit on {YYYY-MM-DD HH:MM UTC}*
+*Generated by obstudio v0.6.1 otel-audit on {YYYY-MM-DD HH:MM UTC}*
 ```
 
 Report requirements:

--- a/skills/otel-instrument/SKILL.md
+++ b/skills/otel-instrument/SKILL.md
@@ -6,10 +6,12 @@ description: >-
   asks to "add OTel", "add tracing", "add metrics", "implement observability",
   "wire up telemetry", "instrument this service", or asks to add a specific
   custom signal like "add a metric to track queue depth", "add a span for
-  payment processing", "track error rate for X".
+  payment processing", "track error rate for X", or asks to configure
+  runtime/deployment observability or dependency config across Helm, values,
+  GitOps, Terraform, serverless, VM, container, or other deployment repos.
 metadata:
   author: otel-studio
-  version: 0.1.1
+  version: 0.1.2
   category: observability
 ---
 
@@ -28,11 +30,63 @@ Before editing anything, ground the plan with repo evidence:
 - Confirm the language and framework from actual dependency or source files
 - Confirm the target process from the repo's real start surface: `docker-compose.yml`, Kubernetes manifests, `package.json` scripts, `Makefile`, `Procfile`, PM2 configs, Supervisor configs, systemd units, launchd plists, PowerShell scripts, or a plain shell command
 - Confirm existing telemetry indicators or record `none found`
+- Detect deployment context. Search the current repo and any user-provided paths
+  for Docker Compose, Dockerfiles, systemd units, Procfiles, Helm charts, values
+  files, Kustomize overlays, Kubernetes workloads, Argo CD, Flux, Terraform/Pulumi/CDK,
+  ECS task definitions, serverless manifests, Nomad jobs, CI/CD release files,
+  and deploy docs. When found or supplied, load
+  `../references/deployment-context-readiness.md`.
+- Resolve deployment references visible in inspected files before choosing a
+  patch location. For example, follow Helm/helmfile value-file references,
+  Argo CD/Flux sources and value references, Terraform `helm_release.values` or
+  tfvars, Kubernetes `configMapRef`/`secretRef`, Docker Compose `env_file`,
+  systemd `EnvironmentFile`, serverless stage config, dependency endpoint/config
+  references, and CI/CD chart/value path references when the target is present
+  or supplied.
+- If `.observe/otel.md` or inspected files mention referenced deployment,
+  runtime, CI/CD, chart, values, GitOps, IaC, environment, ConfigMap, Secret,
+  tfvars, stack config, or dependency-config sources that were not inspected,
+  pause before editing code, writing instrumentation output, or changing
+  telemetry configuration and ask once for their local paths or URLs. Name the
+  referenced sources from the report or inspected file. This is a hard
+  interaction boundary when the requested work includes deployment-owned
+  resource attributes, exporter settings, service/version/environment/region
+  context, health/capacity signals, dependency endpoint/timeout/retry/circuit
+  breaker config, or provisioning prerequisites. If the user provides paths,
+  inspect them and continue. If the user explicitly says to continue without
+  those sources, keep deployment-owned context `unknown`, avoid patching
+  production OTEL/export/resource settings from app-code guesses, and limit
+  changes to repo-owned spans and metrics.
+- If app code exists but production deployment sources are not discoverable, and
+  the requested work depends on runtime/deployment context, pause before editing
+  and ask once for known chart, values, GitOps, IaC, CI/CD, or runtime repo
+  paths. Continue app-code-only only after the user explicitly says to proceed
+  without those sources.
 - For Java projects, build a trace wiring inventory per `./references/languages/java.md` (Preflight section) and classify as `auto-only`, `custom-with-provider`, `custom-provider-external`, or `missing` before editing.
 - Confirm the planned `service.name` source and `deployment.environment` source
+- Confirm whether telemetry runtime config should be patched in app code, a
+  startup wrapper, Helm chart templates, environment values, GitOps resources,
+  IaC, serverless config, systemd/VM config, or Docker Compose.
+- Map app dependencies to deployment-owned config when possible: endpoint alias,
+  provider region/deployment, timeout, retry/backoff, circuit breaker,
+  pool/concurrency, config version, and credential-reference source. Track
+  source names and refs; do not read or copy secret values.
 - Distinguish between application repos and tooling repos such as CLIs, MCP servers, workers, libraries, installers, and build tools. Instrument the executable path users or operators actually run today. Do not invent a web app, Docker path, or entrypoint that is not present.
 - If the repo has multiple runnable surfaces, instrument the one the user actually cares about; otherwise ask which one matters
 - If the repo is primarily tooling or library code and no runnable surface is obvious, stop and ask instead of inventing an app shell
+- If app code exists but production deployment sources are not discoverable, ask
+  once for known chart, values, GitOps, IaC, CI/CD, or runtime repo paths. If none
+  are provided, continue with app-code-only instrumentation and report deployment
+  context as `unknown`.
+- If inspected deployment files reference another chart, values, GitOps, IaC,
+  env, secret, or runtime config source that is not available, record it as
+  `referenced but not inspected`, ask once for its path or URL, and do not
+  hardcode that source's environment-specific values into app code or chart
+  defaults.
+- If dependency endpoint, timeout, retry, circuit breaker, region, or credential
+  reference values live in an uninspected values/tfvars/secret/config repo, do
+  not duplicate those values in app code. Patch only reusable config knobs and
+  report dependency config as `unknown`.
 - Ask one focused clarifying question only if the target process or runtime shape is still ambiguous after checking the repo
 
 Do not proceed until you can state all of these clearly:
@@ -43,6 +97,16 @@ Do not proceed until you can state all of these clearly:
 - environment dimension
 - incremental addition vs new scaffold
 - for Java, trace source of truth (see `./references/languages/java.md` Preflight section)
+- deployment platform/source status, or `unknown` when not inspected
+- exact file or repo class to patch for runtime OTel env/resource attributes
+- exact file or repo class that owns dependency endpoint, timeout, retry,
+  circuit breaker, region, and credential-reference config, or `unknown`
+
+If the user's request includes aligning resource/export configuration with the
+Java agent or deployment-owned OTEL settings, provisioning detectors, adding
+environment/region/version dimensions, or adding health/capacity/dependency
+config readiness, the exact deployment/config file or repo class must not remain
+`unknown`; ask for the missing repo paths before editing.
 
 ### Fast Path: Targeted Custom Signal
 
@@ -102,6 +166,31 @@ Apply auto-instrumentation first, then add manual spans for key business operati
 - Span names must be low-cardinality (no IDs, no variable path segments).
 - Metric attributes must avoid high cardinality.
 - Preserve existing env-var patterns for telemetry config instead of hardcoding endpoints.
+- When deployment config is separate from app code, patch the deployment source
+  that already owns runtime env/config instead of adding duplicate app-code
+  defaults. Follow `../references/deployment-context-readiness.md`.
+- When only a chart/template repo is available but inspected files reference a
+  separate environment values or release repo, patch reusable chart knobs only;
+  treat environment-specific telemetry values as `unknown` until the referenced
+  source is supplied.
+- When dependency config is separate from app code, patch the source that already
+  owns dependency env/config. Use app code for spans/metrics and safe config
+  defaults, but use values/tfvars/GitOps/IaC/runtime config for environment-
+  specific endpoints, regions, timeouts, retries, circuit breakers, and
+  credential references.
+- Do not clone private deployment repos or guess production values paths. Use
+  local paths or URLs supplied by the user, or report deployment context as
+  `unknown`.
+- Add deployment/runtime attributes only when the platform can supply stable,
+  low-cardinality values: `service.name`, `service.version`,
+  `deployment.environment`, `deployment.region`, `deployment.platform`,
+  region/zone, `container.image.tag`, artifact version, config version,
+  rollout or canary id, cluster/namespace/task/function identifiers, and
+  platform type.
+- Prefer existing OTel semantic-convention or platform resource attribute names
+  when they are already emitted. Treat `deployment.region`,
+  `deployment.platform`, and `container.image.tag` as generic context aliases
+  unless the repo already uses those exact attribute names.
 - If the app is a library, provide an opt-in setup path rather than forcing SDK initialization on import.
 - Keep the codebase idiomatic. Match the repo's dependency manager, config style, and lifecycle patterns.
 - Obtain OTel Tracer, Meter once during startup and reuse it. Do not call `getTracer` or `getMeter` in hot paths.
@@ -158,6 +247,12 @@ Then wait for the user's answer.
   - External calls not covered by auto-instrumentation libraries
   - Background workers and scheduled jobs
   - Cache interactions without auto-instrumentation support
+  - Deployment/runtime context: service identity, version, environment, region,
+    platform, collector endpoint, health checks, restart signals, capacity
+    limits including CPU/memory/disk, rollout or canary identifiers, config
+    version, dependency endpoint/config sources, dependency endpoint health,
+    timeout/retry/circuit-breaker config, and platform-specific health signals
+    when a deployment source is available
   - Suggest specific spans and metrics with names, attributes, and rationale
   - Apply after user approval
 
@@ -197,6 +292,10 @@ This step is REQUIRED whenever `.vscode/launch.json` exists.
 - In the final response, separate file changes from verified outcomes
 - If verification is partial, say exactly what is working and what is still missing instead of reporting full success
 - Always include the service-name configuration, OTLP endpoint configuration, and which automatic spans/metrics are expected from the instrumentation.
+- If deployment context was inspected, state which deployment files were changed,
+  which platform signals are now available, and which release/config or health
+  signals remain missing. If it was not inspected, state `deployment context:
+  unknown`.
 
 ## Credential Safety
 

--- a/skills/references/deployment-context-readiness.md
+++ b/skills/references/deployment-context-readiness.md
@@ -1,0 +1,179 @@
+# Deployment Context Readiness Reference
+
+Load this reference when a task mentions deployment/runtime observability, Helm,
+values files, GitOps, Terraform, serverless, VM, container runtime, release/config
+context, health checks, capacity, rollout, or when deployment artifacts are found.
+
+## Goal
+
+Connect application telemetry to the runtime source of truth so alerts and
+dashboards can answer:
+
+- Which version, environment, region, rollout, or config is affected?
+- Is the app code failing, or is the runtime unhealthy?
+- Is a dependency failing, or is the dependency endpoint, region, timeout,
+  retry, circuit breaker, credential reference, or egress route misconfigured?
+- Are failures tied to health checks, restarts, capacity, target health, or deploys?
+- Which repository should be changed: app code, chart, values, GitOps, IaC, or runtime config?
+
+## Discovery
+
+Inspect the current repo first, then any user-supplied paths. Do not guess or
+clone private deployment repos. If app code exists but deployment sources are not
+discoverable, pause before finalizing the audit or instrumentation plan and ask
+once for chart, values, GitOps, IaC, CI/CD, or runtime paths. Ask for local paths
+or URLs and give examples such as `./chart`, `./values`, `./gitops`,
+`./terraform`, a Helm chart repo, an environment-values repo, or a deployment
+pipeline path. If paths are not provided, mark deployment context as `unknown`,
+not `missing`.
+
+Common sources:
+
+| Platform/source | Files or resources |
+|---|---|
+| Docker Compose | `docker-compose.yml`, `.env.example`, service `healthcheck`, image/env blocks |
+| Kubernetes raw manifests | `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`, `Service`, `Ingress` |
+| Helm | `Chart.yaml`, `values*.yaml`, `templates/*.yaml`, `helmfile.yaml` |
+| Kustomize | `kustomization.yaml`, base/overlay patches, generated ConfigMaps/Secrets |
+| GitOps | Argo CD `Application`/`ApplicationSet`, Flux `HelmRelease`, `GitRepository`, `Kustomization` |
+| IaC | Terraform `helm_release`, Kubernetes provider resources, Pulumi/CDK deploy definitions |
+| ECS/Fargate | task definitions, service definitions, target groups, Terraform/CDK/SAM wrappers |
+| Serverless | Lambda/SAM/CDK/Serverless Framework, Cloud Run/App Runner service config |
+| VM/process | systemd units, Supervisor, launchd, Procfile, shell wrappers, AMI/image metadata |
+| Nomad/batch | Nomad jobs, Cron, Airflow DAGs, scheduled tasks, batch job specs |
+| Edge/gateway | Ingress, ALB/NLB/API Gateway, Envoy/Istio/Linkerd/NGINX config |
+| OTel Operator | `Instrumentation` CRs, workload auto-instrumentation annotations |
+
+## Reference Resolution
+
+Deployment sources often point to other runtime sources. Follow references that
+are visible in inspected files, but do not clone private repos or invent local
+paths. If a referenced source is not present in the workspace or supplied paths,
+pause before writing the audit or instrumentation output and ask once for the
+local path or URL. Name the referenced source from the inspected file, such as a
+chart path, values file, GitOps repo/path, IaC module, CI/CD template,
+environment file, ConfigMap, Secret, tfvars, stack config, or deployment
+pipeline. If the user provides paths, inspect them and continue. If the user
+declines or asks to continue without them, record the source as `referenced but
+not inspected` and mark the affected deployment context as `unknown`, not
+`missing`.
+
+Common reference patterns:
+
+| Source | References to resolve |
+|---|---|
+| Helm | `values*.yaml`, `helmfile.yaml`, `--values`, `-f`, `valuesFrom` |
+| Argo CD | `sources[]`, `repoURL`, `path`, `ref`, `helm.valueFiles`, `ApplicationSet` generators |
+| Flux | `HelmRelease.valuesFrom`, `GitRepository`, `Kustomization`, `OCIRepository` |
+| Terraform/Pulumi/CDK | `helm_release.values`, `set`, `set_sensitive`, `tfvars`, stack config |
+| Kubernetes | `configMapRef`, `secretRef`, projected volumes, mounted config files |
+| Docker Compose | `env_file`, `.env`, extension files passed with multiple `-f` flags |
+| ECS/Fargate | task definition env files, SSM/Secrets Manager refs, service/task modules |
+| Serverless | stage config, parameter refs, secret refs, provider-specific env files |
+| VM/process | `EnvironmentFile`, Supervisor includes, Procfile wrappers, launch scripts |
+| CI/CD | deploy scripts, release workflows, chart path, values path, image tag source |
+
+## Dependency Config Mapping
+
+When app code or manifests show outbound dependencies, map those dependencies to
+deployment-owned configuration before deciding what is covered. Track source
+names and references, not secret values.
+
+Look for:
+
+- Dependency endpoints or aliases: database/cache/search/broker/API base URLs,
+  host aliases, service discovery names, queue/topic/stream names, provider
+  deployment names, or egress routes.
+- Runtime behavior config: timeout, retry count/backoff, circuit breaker state,
+  connection pool, concurrency, batch size, and rate-limit settings.
+- Provider placement: region, realm, zone, account/project, cluster, namespace,
+  gateway, service mesh route, or cloud/provider deployment.
+- Config provenance: ConfigMap/Secret reference names, parameter-store refs,
+  values files, tfvars, stack config, feature flag/config version, or rollout id.
+
+If an app dependency is detected but the deployment config source that owns its
+endpoint, timeout, retry, circuit breaker, region, or credential reference is
+not inspected, mark dependency config as `unknown` with `referenced but not
+inspected` evidence. Do not mark the dependency signal as missing just because
+the values repo, secret provider, tfvars, or release config repo is unavailable.
+
+## Status Semantics
+
+- `covered`: inspected source configures the signal.
+- `partial`: some context exists, but key dimensions or runtime signals are absent.
+- `missing`: inspected source proves the signal is absent.
+- `unknown`: deployment source was not found or not provided.
+
+Do not turn `unknown` into a detector. Ask for source paths or report a
+prerequisite.
+
+## Runtime Signal Checklist
+
+Prefer stable, low-cardinality resource attributes, env vars, labels, or metric
+dimensions:
+
+| Area | Useful signals |
+|---|---|
+| Identity | `service.name`, namespace/app label, task/function/service name |
+| Environment | `deployment.environment`, `deployment.region`, `cloud.region`, realm, region, zone, cluster, namespace |
+| Platform | `deployment.platform`, platform/source, runtime workload type, orchestrator, cloud provider, cluster/namespace |
+| Release/config | `service.version`, `container.image.tag`, image tag/digest, artifact version, config version, rollout/canary/batch id |
+| Dependency config | dependency endpoint alias, dependency type/name, timeout, retry, circuit breaker, pool/concurrency, provider region/deployment, config ref/version |
+| Dependency health | dependency endpoint health, target health, dependency availability, error/timeout/rate-limit counts, unhealthy target count |
+| Export path | OTLP endpoint/protocol/headers, collector gateway, OTel Operator instrumentation |
+| Health | readiness/liveness/startup checks, healthcheck command, target group health |
+| Capacity | CPU/memory/disk limits, filesystem pressure, concurrency, queue workers, autoscaling, quotas, throttles |
+| Runtime health | restart count, crash loop, desired vs healthy instances, stopped task reason |
+| Edge | TLS/cert expiry, DNS/domain routing, gateway route, upstream target health |
+| Jobs | missed runs, late runs, failed runs, duration, retries, oldest queued work |
+
+Never use user, tenant, account, request, session, trace, raw pod, raw container,
+raw URL, payload, or secret values as detector group-by dimensions.
+
+Use existing OTel semantic-convention or platform resource attribute names when
+the repo already emits them. Treat generic names such as `deployment.region`,
+`deployment.platform`, and `container.image.tag` as context aliases, not as a
+reason to invent duplicate attributes beside proven names such as `cloud.region`
+or platform-provided container image attributes.
+
+## Patch Location Rules
+
+- Patch app code for spans, metrics, SDK initialization, and semantic-convention attributes.
+- Patch startup wrappers or Docker Compose for local/runtime env vars.
+- Patch Helm templates only when the chart lacks reusable OTel knobs.
+- Patch values repos for environment-specific values such as realm, collector
+  endpoint, resource attributes, image tag, environment, and rollout metadata.
+- Patch GitOps/IaC only when it owns the deployed state or chart values.
+- Patch dependency config where it is already owned: app config for local
+  defaults, values/tfvars/stack config for environment-specific dependency
+  endpoints, and GitOps/IaC only when those sources own the deployed values.
+- Patch OTel Operator resources/annotations when auto-instrumentation is the
+  platform standard.
+- Do not hardcode production tokens or private collector endpoints in tracked files.
+
+## Detector Guidance
+
+Create detectors only from available metrics. Deployment context should usually
+shape filters, group-by dimensions, dashboard filters, and prerequisites rather
+than create standalone alerts.
+
+Examples:
+
+- Use `deployment.environment`, `deployment.region`, `cloud.region`, or
+  `k8s.namespace.name` to split latency/error detectors when those dimensions
+  exist.
+- Use `deployment.platform` or platform/source dimensions for dashboards and
+  detector filters only when the value is stable and low-cardinality.
+- Use `service.version`, `container.image.tag`, artifact version, config
+  version, or rollout id for dashboards and release correlation, not as a
+  standalone alert.
+- Use dependency dimensions only when proven and low-cardinality, such as
+  dependency type/name, sanitized endpoint alias, provider region, gateway, or
+  config version. Do not use full URLs, credentials, raw hosts with tenant/user
+  data, request payloads, or secret values.
+- Use platform or dependency health metrics for restart, crash-loop,
+  desired-vs-running, startup/readiness failure, healthcheck failure,
+  unhealthy-target, dependency endpoint health, throttle, quota, disk pressure,
+  or capacity detectors when available.
+- If health/capacity metrics are not exposed in the audit, list them as
+  prerequisites for `otel-instrument` or platform telemetry setup.

--- a/skills/splunk-configure/SKILL.md
+++ b/skills/splunk-configure/SKILL.md
@@ -6,10 +6,12 @@ description: >-
   detector categories, and outputs ready-to-apply HCL with SignalFlow
   program_text. Use when the user types $splunk-configure, asks to "generate
   detectors", "create alerts from audit", "build Terraform for monitors",
-  or "set up Splunk detectors".
+  "set up Splunk detectors", or asks to include deployment, release,
+  environment, Helm, GitOps, Terraform, serverless, VM, container, health,
+  capacity, rollout, dependency config, or config context in alerts.
 metadata:
   author: otel-studio
-  version: 0.1.0
+  version: 0.1.1
   category: observability
 ---
 
@@ -20,13 +22,17 @@ metadata:
 Read an existing `.observe/otel.md` audit report, classify detected metrics
 into detector categories (latency, error, saturation, throughput), and generate
 Terraform configuration for Splunk Observability Cloud `signalfx_detector`
-resources with inline SignalFlow programs.
+resources with inline SignalFlow programs. When the audit includes deployment
+context, use it to add safe detector dimensions and to report runtime,
+release/config, health, and capacity prerequisites.
 
 ## When to Use
 
 - After running `$otel-audit` to generate `.observe/otel.md`
 - When the user wants alerting/detection Terraform for their service
 - When creating monitors for RED signals or saturation metrics
+- When deployment/runtime context should shape alert grouping, filters, or
+  prerequisites for release/config, health, rollout, and capacity detection
 
 **When NOT to use:** If no audit report exists yet, instruct the user to run
 `$otel-audit` first.
@@ -56,10 +62,32 @@ Extract from `.observe/otel.md`:
    - Each row provides: metric name, source, and type (auto/custom)
    - Record all metrics for classification in Step 3
 
-If the Metrics section says "No metrics detected.", stop and respond:
+3. **Deployment Context** from `## Deployment Context`, when present:
+   - Platform/source
+   - Service identity
+   - Release/config
+   - Dependency config
+   - Dependency health
+   - Health/capacity
+   - Export path
+   Load `../references/deployment-context-readiness.md` when this section exists.
+   Treat rows with `unknown` as missing repository context, not missing telemetry.
+   Treat `referenced but not inspected` evidence as missing repository context:
+   document the referenced source path or URL as a prerequisite, but do not use
+   its dimensions, values, or metrics in detector Terraform.
+   Add rows with `missing` or `partial` to the detector report's prerequisites
+   unless matching metrics or dimensions exist.
+
+If the Metrics section says "No metrics detected." and there is no Deployment
+Context section, stop and respond:
 
 > The audit report contains no metrics. Detectors require metric data.
 > Run `$otel-instrument` to add instrumentation, then re-run `$otel-audit`.
+
+If the Metrics section says "No metrics detected." but Deployment Context is
+present, do not generate detector Terraform from absent metrics. Continue to
+create `.observe/detectors.md` with Deployment Prerequisites and clearly state
+that detectors require instrumentation or platform metrics first.
 
 ### Step 3 -- Classify Metrics into Detector Categories
 
@@ -74,6 +102,38 @@ Assign each metric to exactly one category:
 
 Skip metrics that match the exclusion rules (auto-instrumented library metrics
 that duplicate custom signals).
+
+If deployment context is present:
+
+- Add `service.name` filters when available.
+- Add environment, region, cluster, namespace, task, function, image tag,
+  service version, config version, rollout, or canary dimensions only when the
+  audit proves they exist and they are low-cardinality.
+- Treat `deployment.region`, `deployment.platform`, `container.image.tag`, and
+  artifact version as aliases for deployment-aware filters only when they are
+  proven and low-cardinality.
+- Prefer exact metric/resource attribute names proven by the audit, such as
+  `cloud.region` or platform-provided container image attributes. Do not create
+  duplicate filters only to force generic alias names.
+- Add dependency filters or dashboard dimensions only when the audit proves they
+  exist and they are low-cardinality, such as dependency type/name, sanitized
+  endpoint alias, provider region/deployment, gateway, timeout tier, retry
+  policy name, circuit breaker name, or config version. Do not use full URLs,
+  credentials, raw hosts with user/tenant data, request payloads, or secret
+  values.
+- If deployment files reference another chart, values, GitOps, IaC, env, secret,
+  or runtime config source that was not inspected, leave affected filters and
+  group-bys service-scoped and list that source under Deployment Prerequisites.
+- Do not group detectors by raw pod, container, request, user, tenant, session,
+  trace, or raw URL values.
+- Do not create release/config, health, capacity, rollout, or platform detectors
+  from absent metrics. Record them as prerequisites instead.
+- Do not create dependency endpoint, retry, timeout, circuit breaker, provider,
+  or config-version detectors from absent metrics. Record the missing source or
+  metric as a prerequisite instead.
+- Create dependency endpoint-health detectors only from available dependency or
+  platform health metrics. If only dependency config is present, document the
+  missing health metric prerequisite instead.
 
 ### Step 4 -- Generate Terraform
 
@@ -106,6 +166,36 @@ resource "signalfx_detector" "<category>_<sanitized_metric_name>" {
 
 Sanitize metric names for HCL identifiers: replace dots and hyphens with
 underscores, strip leading digits.
+
+For deployment-aware output, include only safe proven filters or dimensions in
+SignalFlow. Examples: `service.name`, `deployment.environment`, `service.version`,
+`k8s.namespace.name`, `cloud.region`, `container.image.tag`, `faas.name`, or
+`deployment.rollout.id`. Also accept proven low-cardinality aliases such as
+`deployment.region`, `deployment.platform`, and artifact version. Dependency
+examples include `dependency.type`, `dependency.name`,
+`dependency.endpoint.alias`, `cloud.region`, `deployment.config.version`, or
+`deployment.rollout.id` when proven. When those dimensions are `unknown`, leave
+the detector service-scoped and document the missing deployment context in
+`.observe/detectors.md`.
+Keep the Splunk Observability Cloud API `realm` variable separate from service
+telemetry dimensions. Do not use `var.realm` as a SignalFlow filter for
+`sfx_realm`, `deployment.region`, `cloud.region`, or any application/runtime
+dimension unless live metric metadata or the audit proves that exact dimension
+and value. If a dimension exists but its current value is unknown, leave the
+detector service-scoped or make the dimension a dashboard/filter candidate
+instead of hard-coding it.
+Before writing SignalFlow, verify every filter and group-by dimension against
+the audit, local metric metadata, or approved Splunk API metadata. If a
+dimension is absent from the target metric, omit it and document the missing
+dimension as a prerequisite. Never use a dimension solely because referenced
+deployment files, uninspected values, or intended instrumentation imply it may
+exist.
+For percentile metrics that are already aggregated, including names such as
+`.p99`, `.p95`, `p50`, `quantile`, or metrics marked as already-quantized, do
+not use `.percentile(pct=99)` or average streams. Use raw histograms for
+percentile calculations, or use `max()`/`max(by=[...])` for precomputed
+percentile series. Match units to metric names and metadata before choosing
+threshold defaults.
 
 #### `.observe/terraform/variables.tf`
 
@@ -141,7 +231,7 @@ variable "notification_channel" {
 Generate a `.tfvars.example` file the user copies and fills in to apply:
 
 ```hcl
-realm                = ""   # e.g. us1, eu0, lab0
+realm                = ""   # e.g. us1, eu0
 api_token            = ""   # Splunk O11y API token (org-level, detector write)
 service_name         = "<service-name from report>"
 notification_channel = ""   # e.g. "Email,team@example.com" or PagerDuty routing key
@@ -215,6 +305,16 @@ Default: **3.0 stddev**, 5m current window vs 1h history.
 | Metric | Reason |
 |--------|--------|
 | `<metric>` | <why it was not classified> |
+
+## Deployment Prerequisites
+
+| Area | Status | Needed Before Alerting |
+|------|--------|------------------------|
+| Release/config | <partial/missing/unknown> | <version/config/rollout dimensions or repo path needed> |
+| Dependency config | <partial/missing/unknown> | <dependency endpoint/region/timeout/retry/circuit-breaker/config source or metric needed> |
+| Dependency health | <partial/missing/unknown> | <dependency endpoint health/target health/error/timeout/rate-limit metric needed> |
+| Health/capacity | <partial/missing/unknown> | <restart/readiness/desired-vs-healthy/CPU/memory/disk/throttle/quota/concurrency metrics or deployment source needed> |
+| Export path | <partial/missing/unknown> | <collector/export configuration needed> |
 
 ## Classification Rules Applied
 

--- a/skills/splunk-configure/references/terraform-templates.md
+++ b/skills/splunk-configure/references/terraform-templates.md
@@ -3,6 +3,17 @@
 SignalFlow + HCL templates for each detector category. The agent uses these
 templates to generate `.observe/terraform/detectors.tf` resources.
 
+When adapting a template, use only metric names, filters, group-bys, and units
+proven by the audit, local metric metadata, or approved Splunk API metadata. Do
+not treat the provider/API `realm` variable as a telemetry dimension such as
+`sfx_realm`, `deployment.region`, or `cloud.region`; hard-code telemetry
+dimension values only when the audit or user explicitly provides that value.
+For precomputed percentile metrics such as `.p99`, `.p95`, `p50`, or
+already-quantized streams, do not apply another percentile calculation or
+average the percentile values. Use raw histogram distributions for
+`.percentile(pct=99)`, or `max()`/`max(by=[...])` for already-computed
+percentile series.
+
 ## Latency Detector
 
 Monitors p99 latency using a static threshold on histogram percentile data.
@@ -158,7 +169,7 @@ variable "throughput_<metric_id>_stddev" {
 Generated alongside the `.tf` files so users know exactly which values to provide.
 
 ```hcl
-realm                = ""   # e.g. us1, eu0, lab0
+realm                = ""   # e.g. us1, eu0
 api_token            = ""   # Splunk O11y API token (org-level, detector write)
 service_name         = "<service-name>"
 notification_channel = ""   # e.g. "Email,team@example.com" or PagerDuty routing key


### PR DESCRIPTION
## Summary
- add a shared deployment-context readiness reference for Helm, values, GitOps, IaC, container, serverless, VM, and other runtime sources
- update otel-audit, otel-instrument, and splunk-configure to discover deployment context, resolve visible deployment references, prompt for external repo paths when needed, and distinguish unknown vs missing runtime signals
- map app dependencies to deployment-owned endpoint, provider region/deployment, timeout, retry/backoff, circuit breaker, pool/concurrency, config version, and credential-reference sources without reading or copying secret values
- add explicit generic deployment-context signals for service version, deployment environment/region/platform, container image or artifact version, config version, rollout/canary id, restart/health counts, desired-vs-healthy, startup/readiness failures, CPU/memory/disk/concurrency saturation, throttle/quota, healthcheck failure, traffic target health, and dependency endpoint/target health
- treat `deployment.region`, `deployment.platform`, and `container.image.tag` as context aliases unless the audit proves those exact attributes exist; prefer existing OTel/platform attributes such as `cloud.region` and platform-provided container image attributes
- treat referenced-but-not-inspected chart, values, dependency-values, GitOps, IaC, env, secret, and runtime sources as prerequisites rather than proven detector dimensions or metrics
- add deployment eval fixtures for all-repos-supplied, referenced-values-not-supplied, and dependency-config-sources cases

## Review
- combined review loop: bot-style protocol pass, Claude diff review, and independent baseline review
- fixed earlier fixture/report-shape and credential-reference wording issues
- latest Claude full-diff review reported no verified P0-P2 findings
- local protocol/baseline review found no remaining actionable issues after the deployment-context alias and dependency-health amendments

## Verification
- `git diff --check`
- `git diff --cached --check`
- JSON fixture parsing
- YAML parsing for non-templated fixture files
- audit report shape checks for deployment eval `.observe/otel.md` fixtures
- `make -C evals eval-validation SKILL=skills/otel-audit CASE=deployment`
- `make -C evals eval-validation SKILL=skills/otel-instrument CASE=deployment`
- `make -C evals eval-validation SKILL=skills/splunk-configure CASE=deployment`

