### PR TITLE
Add GenAI readiness guidance to observability skills

### DIFF
--- a/evals/python/ai-assistant-demo/Makefile
+++ b/evals/python/ai-assistant-demo/Makefile
@@ -1,0 +1,18 @@
+.PHONY: sync dev load build test clean
+
+sync:
+	uv sync
+
+dev: sync
+	OTEL_SERVICE_NAME=ai-assistant-demo uv run uvicorn app:app --host 0.0.0.0 --port 8010 --reload
+
+load: sync
+	uv run python load_demo.py --base-url http://localhost:8010 --duration 60
+
+build: test
+
+test: sync
+	uv run python -m compileall app.py load_demo.py
+
+clean:
+	rm -rf .venv __pycache__ .pytest_cache .observe

--- a/evals/python/ai-assistant-demo/README.md
+++ b/evals/python/ai-assistant-demo/README.md
@@ -1,0 +1,53 @@
+# AI Assistant Demo
+
+Small FastAPI service that mimics the observability surfaces of an AI assistant:
+chat turns, streaming responses, provider calls, tool fanout, context pressure,
+and offline feedback export.
+
+The app is intentionally a baseline fixture. It has realistic code paths but no
+custom OpenTelemetry instrumentation. Use it to demonstrate the before/after
+effect of the OTel skills.
+
+## Run
+
+```sh
+cd examples/python/ai-assistant-demo
+make dev
+```
+
+In another terminal:
+
+```sh
+make load
+```
+
+The service listens on `http://localhost:8010`.
+
+## Demo Workflow
+
+1. Run the baseline app and load generator.
+2. Run `/otel-audit` on this directory and review the GenAI gaps.
+3. Run `/otel-instrument` on this directory.
+4. Run the instrumented app with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`.
+5. Run `make load` again and inspect Explorer for turn, provider, tool, stream,
+   context, and feedback export telemetry.
+
+## Eval Workflow
+
+The eval fixture definitions are checked into:
+
+```text
+evals/python/ai-assistant-demo/eval/qual/audit.json
+evals/python/ai-assistant-demo/eval/qual/instrument.json
+```
+
+Validate the eval fixture and render a report:
+
+```sh
+make -C evals eval-validation SKILL=skills/otel-audit EVAL_PATTERN='python/ai-assistant-demo/eval/qual/audit.json'
+make -C evals eval-validation SKILL=skills/otel-instrument EVAL_PATTERN='python/ai-assistant-demo/eval/qual/instrument.json'
+```
+
+This lets the example act as a before/after eval fixture: the baseline should
+show gaps, and the instrumented version should satisfy the rubric signal
+criteria.

--- a/evals/python/ai-assistant-demo/app.py
+++ b/evals/python/ai-assistant-demo/app.py
@@ -1,0 +1,192 @@
+import asyncio
+import json
+import logging
+import random
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("ai_assistant_demo")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="AI Assistant Demo")
+
+CONTEXT_LIMIT_TOKENS = 4096
+TOKEN_LIMIT_ERROR_THRESHOLD = 3800
+active_streams: dict[str, float] = {}
+feedback_queue: list[dict[str, Any]] = []
+
+
+class ChatRequest(BaseModel):
+    prompt: str = Field(min_length=1)
+    session_id: str = "demo-session"
+    tools: list[str] = Field(default_factory=lambda: ["search_docs", "lookup_customer"])
+    stream: bool = False
+
+
+class FeedbackRequest(BaseModel):
+    session_id: str
+    rating: int = Field(ge=1, le=5)
+    comment: str = ""
+
+
+@dataclass
+class ProviderResult:
+    text: str
+    input_tokens: int
+    output_tokens: int
+    finish_reason: str
+    truncated: bool
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text.split()) * 2)
+
+
+def _context_usage(prompt: str, tool_results: list[dict[str, Any]]) -> tuple[int, float]:
+    prompt_tokens = _estimate_tokens(prompt)
+    tool_tokens = sum(_estimate_tokens(json.dumps(result)) for result in tool_results)
+    used = prompt_tokens + tool_tokens + 256
+    return used, min(1.0, used / CONTEXT_LIMIT_TOKENS)
+
+
+async def run_tool(name: str, prompt: str) -> dict[str, Any]:
+    started = time.perf_counter()
+    await asyncio.sleep(random.uniform(0.02, 0.08))
+    if "tool_error" in prompt and name == "lookup_customer":
+        raise RuntimeError("lookup dependency failed")
+    if name == "search_docs":
+        result = {"tool": name, "matches": 3, "top_score": 0.91}
+    elif name == "lookup_customer":
+        result = {"tool": name, "tier": "enterprise", "region": "us0"}
+    else:
+        result = {"tool": name, "status": "unknown_tool"}
+    result["duration_ms"] = round((time.perf_counter() - started) * 1000, 2)
+    return result
+
+
+async def call_provider(prompt: str, tool_results: list[dict[str, Any]]) -> ProviderResult:
+    context_tokens, usage = _context_usage(prompt, tool_results)
+    await asyncio.sleep(random.uniform(0.05, 0.16))
+    if "provider_error" in prompt:
+        raise RuntimeError("provider unavailable")
+    if context_tokens > TOKEN_LIMIT_ERROR_THRESHOLD or "too_long" in prompt:
+        raise HTTPException(status_code=413, detail="context token limit exceeded")
+    truncated = usage > 0.75 or "truncate" in prompt
+    output = "I found relevant metadata, checked tools, and prepared a short answer."
+    if truncated:
+        output = output[:48]
+    return ProviderResult(
+        text=output,
+        input_tokens=context_tokens,
+        output_tokens=_estimate_tokens(output),
+        finish_reason="length" if truncated else "stop",
+        truncated=truncated,
+    )
+
+
+async def build_turn(request: ChatRequest) -> dict[str, Any]:
+    started = time.perf_counter()
+    tool_results = []
+    tool_errors = []
+    for tool_name in request.tools:
+        try:
+            tool_results.append(await run_tool(tool_name, request.prompt))
+        except Exception as exc:
+            logger.warning("tool failed", extra={"tool": tool_name, "error": type(exc).__name__})
+            tool_errors.append({"tool": tool_name, "error": type(exc).__name__})
+
+    provider = await call_provider(request.prompt, tool_results)
+    context_tokens, context_budget = _context_usage(request.prompt, tool_results)
+    return {
+        "session_id": request.session_id,
+        "message_id": uuid.uuid4().hex,
+        "answer": provider.text,
+        "provider": "demo-provider",
+        "model": "demo-gpt-4o-mini",
+        "finish_reason": provider.finish_reason,
+        "truncated": provider.truncated,
+        "input_tokens": provider.input_tokens,
+        "output_tokens": provider.output_tokens,
+        "context_tokens": context_tokens,
+        "context_budget": round(context_budget, 3),
+        "tool_call_count": len(request.tools),
+        "tool_error_count": len(tool_errors),
+        "tool_results": tool_results,
+        "tool_errors": tool_errors,
+        "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+    }
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/v1/chat")
+async def chat(request: ChatRequest) -> dict[str, Any]:
+    if request.stream:
+        raise HTTPException(status_code=400, detail="use /v1/chat/stream for streaming")
+    return await build_turn(request)
+
+
+@app.post("/v1/chat/stream")
+async def chat_stream(request: ChatRequest) -> StreamingResponse:
+    stream_id = uuid.uuid4().hex
+    active_streams[stream_id] = time.time()
+
+    async def events():
+        try:
+            yield f"event: connected\ndata: {json.dumps({'stream_id': stream_id})}\n\n"
+            turn = await build_turn(request)
+            words = turn["answer"].split()
+            for index, word in enumerate(words):
+                await asyncio.sleep(0.03)
+                yield f"event: token\ndata: {json.dumps({'index': index, 'text': word})}\n\n"
+            yield f"event: done\ndata: {json.dumps(turn)}\n\n"
+        except asyncio.CancelledError:
+            logger.info("stream detached", extra={"stream_id": stream_id})
+            raise
+        except Exception as exc:
+            logger.exception("stream failed", extra={"stream_id": stream_id, "error": type(exc).__name__})
+            yield f"event: error\ndata: {json.dumps({'error': type(exc).__name__})}\n\n"
+        finally:
+            active_streams.pop(stream_id, None)
+
+    return StreamingResponse(events(), media_type="text/event-stream")
+
+
+@app.get("/v1/streams")
+async def streams() -> dict[str, Any]:
+    now = time.time()
+    oldest_age = max((now - started for started in active_streams.values()), default=0.0)
+    return {"active": len(active_streams), "oldest_age_seconds": round(oldest_age, 3)}
+
+
+@app.post("/v1/feedback")
+async def feedback(request: FeedbackRequest) -> dict[str, Any]:
+    record = request.model_dump()
+    record["received_at"] = time.time()
+    feedback_queue.append(record)
+    return {"queued": len(feedback_queue)}
+
+
+@app.post("/v1/feedback/export")
+async def export_feedback() -> dict[str, Any]:
+    started = time.perf_counter()
+    await asyncio.sleep(random.uniform(0.03, 0.12))
+    if random.random() < 0.08:
+        logger.error("feedback export destination failed")
+        raise HTTPException(status_code=502, detail="feedback destination failed")
+    exported = len(feedback_queue)
+    feedback_queue.clear()
+    return {
+        "records_exported": exported,
+        "destination": "demo-warehouse",
+        "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+    }

--- a/evals/python/ai-assistant-demo/eval/qual/audit.json
+++ b/evals/python/ai-assistant-demo/eval/qual/audit.json
@@ -1,0 +1,25 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Scan the AI assistant FastAPI service in ./service for OpenTelemetry and GenAI readiness gaps. Do not modify files."
+    },
+    {
+      "id": "genai-readiness",
+      "task": "Produce an observability readiness review for the AI assistant service in ./service. Identify existing telemetry, GenAI pathway gaps, incident-detection impact, and the next instrumentation step. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for app.py, load_demo.py, pyproject.toml, and generated .observe output when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies app.py, load_demo.py, pyproject.toml, and FastAPI routes for chat, streaming chat, stream inventory, feedback, and feedback export.",
+    "Reports that the baseline service has no custom OpenTelemetry SDK setup, no GenAI semantic-convention spans or metrics, and no exporter/resource configuration beyond demo environment variables.",
+    "Maps GenAI readiness gaps for provider/model calls, tool fanout, token/context pressure, streaming lifecycle, prompt/response outcome, and offline AI data export.",
+    "Creates or describes a Gap Ledger-style contract with required signals instead of treating the audit as background context.",
+    "Keeps privacy and cardinality safe by not recommending raw prompt, completion, session, user, request, or tool argument values as metric dimensions."
+  ]
+}

--- a/evals/python/ai-assistant-demo/eval/qual/instrument.json
+++ b/evals/python/ai-assistant-demo/eval/qual/instrument.json
@@ -1,0 +1,25 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Instrument the AI assistant FastAPI service in ./service for OpenTelemetry and GenAI readiness. Add safe app-owned signals and tests where practical."
+    },
+    {
+      "id": "audit-ledger",
+      "task": "Use the audit gap-ledger contract implied by the AI assistant service in ./service. Add instrumentation for patchable GenAI gaps and explicitly report any remaining signals."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for changed files, tests, and generated .observe output when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Adds one reusable OpenTelemetry setup path and avoids duplicate SDK initialization.",
+    "Instruments FastAPI plus app-owned assistant turn, provider/model call, tool execution, streaming lifecycle, token/context pressure, and feedback export surfaces.",
+    "Uses OTel GenAI semantic-convention names where data is available, including gen_ai operation/model/provider attributes and token usage metrics.",
+    "Handles partial token-pressure closure honestly by naming remaining truncation, token-limit, prompt/tool schema size, or fanout signals when not implemented.",
+    "Adds or updates tests or compile checks and keeps raw prompts, completions, sessions, users, tenants, requests, and tool arguments out of metric dimensions."
+  ]
+}

--- a/evals/python/ai-assistant-demo/load_demo.py
+++ b/evals/python/ai-assistant-demo/load_demo.py
@@ -1,0 +1,87 @@
+import argparse
+import asyncio
+import random
+import time
+
+import httpx
+
+
+PROMPTS = [
+    "summarize metadata health for workspace alpha",
+    "search docs and lookup customer routing",
+    "truncate this response because the context is large",
+    "tool_error while looking up the customer profile",
+    "too_long " + "metadata " * 1500,
+]
+
+
+async def post_chat(client: httpx.AsyncClient, prompt: str) -> None:
+    response = await client.post(
+        "/v1/chat",
+        json={
+            "session_id": f"demo-{random.randint(1, 5)}",
+            "prompt": prompt,
+            "tools": ["search_docs", "lookup_customer"],
+        },
+    )
+    if response.status_code not in {200, 413}:
+        response.raise_for_status()
+
+
+async def post_stream(client: httpx.AsyncClient, prompt: str) -> None:
+    async with client.stream(
+        "POST",
+        "/v1/chat/stream",
+        json={
+            "session_id": f"stream-{random.randint(1, 3)}",
+            "prompt": prompt,
+            "tools": ["search_docs"],
+        },
+    ) as response:
+        if response.status_code != 200:
+            return
+        async for _ in response.aiter_lines():
+            pass
+
+
+async def post_feedback(client: httpx.AsyncClient) -> None:
+    await client.post(
+        "/v1/feedback",
+        json={
+            "session_id": f"demo-{random.randint(1, 5)}",
+            "rating": random.randint(1, 5),
+            "comment": "demo feedback",
+        },
+    )
+    if random.random() < 0.25:
+        await client.post("/v1/feedback/export")
+
+
+async def run_load(base_url: str, duration: int, concurrency: int) -> None:
+    deadline = time.monotonic() + duration
+    async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+        while time.monotonic() < deadline:
+            tasks = []
+            for _ in range(concurrency):
+                prompt = random.choice(PROMPTS)
+                if random.random() < 0.2:
+                    tasks.append(post_stream(client, prompt))
+                elif random.random() < 0.3:
+                    tasks.append(post_feedback(client))
+                else:
+                    tasks.append(post_chat(client, prompt))
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await asyncio.sleep(0.2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8010")
+    parser.add_argument("--duration", type=int, default=60)
+    parser.add_argument("--concurrency", type=int, default=4)
+    args = parser.parse_args()
+    asyncio.run(run_load(args.base_url, args.duration, args.concurrency))
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/python/ai-assistant-demo/pyproject.toml
+++ b/evals/python/ai-assistant-demo/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "python-ai-assistant-demo"
+version = "0.1.0"
+description = "AI assistant-like FastAPI app for OTel GenAI skill demos"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "httpx>=0.28",
+    "uvicorn[standard]>=0.34",
+]

--- a/evals/python/assistant-v3-framework-bridge-demo/Makefile
+++ b/evals/python/assistant-v3-framework-bridge-demo/Makefile
@@ -1,0 +1,13 @@
+.PHONY: sync dev test clean
+
+sync:
+	uv sync
+
+dev: sync
+	OTEL_SERVICE_NAME=assistant-v3-framework-demo uv run opentelemetry-instrument uvicorn app:app --host 0.0.0.0 --port 8030 --reload
+
+test: sync
+	uv run python -m compileall app.py
+
+clean:
+	rm -rf .venv __pycache__ .pytest_cache .observe

--- a/evals/python/assistant-v3-framework-bridge-demo/README.md
+++ b/evals/python/assistant-v3-framework-bridge-demo/README.md
@@ -1,0 +1,20 @@
+# Assistant v3 Framework Bridge Demo
+
+Small fixture for the GenAI single-source span contract. It represents an app
+that already emits app-owned assistant v3 workflow, agent, chat, and tool spans,
+while the runtime also preloads framework instrumentation for LangChain/OpenAI.
+
+The correct skill behavior is to choose one canonical GenAI span source. For
+this app, the app-owned spans are canonical because they preserve the stable
+workflow name `assistant_v3_turn`, the stable agent name `deepagents`, and the
+tool/model lifecycle emitted from the app's event translator. The instrumented
+startup surface must suppress overlapping framework GenAI instrumentors before
+`opentelemetry-instrument` bootstraps, while keeping HTTP/database/runtime
+instrumentation active.
+
+The fixture intentionally models the bad coexistence mode. When
+`OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` does not include both `langchain` and
+`openai`, `app.py` returns framework shadow nodes such as `LangGraph` and
+`step tools` alongside the app-owned nodes. A correct instrumentation pass
+removes those shadow nodes by changing the startup surface, not by renaming the
+canonical app-owned spans.

--- a/evals/python/assistant-v3-framework-bridge-demo/app.py
+++ b/evals/python/assistant-v3-framework-bridge-demo/app.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+WORKFLOW_NAME = "assistant_v3_turn"
+AGENT_NAME = "deepagents"
+MODEL_NAME = "gpt-5.5"
+OVERLAPPING_FRAMEWORK_INSTRUMENTORS = ("langchain", "openai")
+
+app = FastAPI(title="Assistant v3 Framework Bridge Demo")
+
+
+class TurnRequest(BaseModel):
+    prompt: str
+    model: str = MODEL_NAME
+
+
+@dataclass
+class SpanHandle:
+    name: str
+
+    def end(self) -> None:
+        return None
+
+
+def start_workflow_span(name: str) -> SpanHandle:
+    # App-owned canonical span: gen_ai.operation.name=invoke_workflow.
+    return SpanHandle(f"invoke_workflow {name}")
+
+
+def start_agent_span(name: str) -> SpanHandle:
+    # App-owned canonical span: gen_ai.operation.name=invoke_agent.
+    return SpanHandle(f"invoke_agent {name}")
+
+
+def start_chat_span(model: str) -> SpanHandle:
+    # App-owned canonical span: gen_ai.operation.name=chat.
+    return SpanHandle(f"chat {model}")
+
+
+def start_tool_span(tool_name: str) -> SpanHandle:
+    # App-owned canonical span: gen_ai.operation.name=execute_tool.
+    return SpanHandle(f"execute_tool {tool_name}")
+
+
+def framework_genai_instrumentation_enabled() -> bool:
+    disabled = {
+        name.strip().lower()
+        for name in os.getenv("OTEL_PYTHON_DISABLED_INSTRUMENTATIONS", "").split(",")
+        if name.strip()
+    }
+    return any(name not in disabled for name in OVERLAPPING_FRAMEWORK_INSTRUMENTORS)
+
+
+def simulate_framework_shadow_nodes(events: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Model the duplicate GenAI DAG emitted when framework hooks are not suppressed."""
+    shadow_nodes = [{"source": "framework", "kind": "agent", "name": "LangGraph"}]
+    for event in events:
+        if event["event"] == "on_chat_model_start":
+            shadow_nodes.append({"source": "framework", "kind": "llm", "name": f"chat {MODEL_NAME}"})
+        if event["event"] == "on_tool_start":
+            shadow_nodes.extend(
+                [
+                    {"source": "framework", "kind": "tool", "name": "step tools"},
+                    {"source": "framework", "kind": "tool", "name": event["name"]},
+                ]
+            )
+    return shadow_nodes
+
+
+async def deepagents_event_stream(prompt: str) -> list[dict[str, Any]]:
+    await asyncio.sleep(0.01)
+    events = [
+        {"event": "on_chat_model_start", "model": MODEL_NAME},
+        {"event": "on_chat_model_end", "model": MODEL_NAME, "input_tokens": 32, "output_tokens": 8},
+    ]
+    if "time" in prompt.lower():
+        events.extend(
+            [
+                {"event": "on_tool_start", "name": "get_current_time"},
+                {"event": "on_tool_end", "name": "get_current_time"},
+                {"event": "on_chat_model_start", "model": MODEL_NAME},
+                {"event": "on_chat_model_end", "model": MODEL_NAME, "input_tokens": 48, "output_tokens": 12},
+            ]
+        )
+    return events
+
+
+@app.post("/v2/assistant/sessions")
+async def assistant_session(request: TurnRequest) -> dict[str, Any]:
+    workflow = start_workflow_span(WORKFLOW_NAME)
+    agent = start_agent_span(AGENT_NAME)
+    llm_calls = 0
+    tool_calls = 0
+    events = await deepagents_event_stream(request.prompt)
+    framework_shadow_nodes = (
+        simulate_framework_shadow_nodes(events)
+        if framework_genai_instrumentation_enabled()
+        else []
+    )
+    for event in events:
+        if event["event"] == "on_chat_model_start":
+            llm_calls += 1
+            start_chat_span(request.model).end()
+        if event["event"] == "on_tool_start":
+            tool_calls += 1
+            start_tool_span(event["name"]).end()
+    agent.end()
+    workflow.end()
+    return {
+        "workflow": WORKFLOW_NAME,
+        "agent": AGENT_NAME,
+        "llm_calls": llm_calls,
+        "tool_calls": tool_calls,
+        "framework_shadow_nodes": framework_shadow_nodes,
+    }

--- a/evals/python/assistant-v3-framework-bridge-demo/eval/qual/audit.json
+++ b/evals/python/assistant-v3-framework-bridge-demo/eval/qual/audit.json
@@ -1,0 +1,21 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "framework-bridge",
+      "task": "Scan the assistant v3 FastAPI service in ./service. It has app-owned GenAI spans and a startup command that preloads framework instrumentation. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for app.py, Makefile, pyproject.toml, and generated .observe output when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Detects the app-owned assistant_v3_turn workflow and deepagents agent names as stable source identities that must be preserved.",
+    "Detects framework/vendor GenAI bridge risk from LangChain/OpenAI dependencies, opentelemetry-instrument startup, and app.py framework_shadow_nodes such as LangGraph and step tools.",
+    "Marks trace/semconv coverage partial unless there is proof of one canonical GenAI span source per logical workflow, chat/model call, and tool call.",
+    "Requires duplicate-span remediation in the real startup surface before bootstrap, not only app module code that mutates environment variables after import.",
+    "States that POST /v2/assistant/sessions can remain the HTTP root span but must not become the GenAI workflow card."
+  ]
+}

--- a/evals/python/assistant-v3-framework-bridge-demo/eval/qual/instrument.json
+++ b/evals/python/assistant-v3-framework-bridge-demo/eval/qual/instrument.json
@@ -1,0 +1,21 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "framework-bridge",
+      "task": "Instrument the assistant v3 service in ./service. It already has app-owned GenAI lifecycle spans and also preloads framework instrumentation. Preserve the app-owned DAG and prevent duplicate framework GenAI nodes."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for changed files, tests, and generated .observe output when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Chooses the app-owned GenAI spans as the canonical source for this fixture and does not add duplicate app-owned chat or execute_tool spans.",
+    "For app-owned canonical spans, suppresses overlapping LangChain/OpenAI GenAI instrumentors in the Makefile or another real startup surface before opentelemetry-instrument bootstraps.",
+    "Keeps baseline HTTP/database/runtime auto-instrumentation active while suppressing only overlapping GenAI framework emitters.",
+    "Preserves assistant_v3_turn and deepagents exactly; it does not invent assistant_v3_session_turn, assistant_v3_agent, or POST /v2/assistant/sessions as GenAI names.",
+    "Requires runtime/static proof that Obstudio would show one workflow node, one agent node, expected LLM/tool counts, stable model/tool names, and no wrapper-only LangGraph or step nodes."
+  ]
+}

--- a/evals/python/assistant-v3-framework-bridge-demo/pyproject.toml
+++ b/evals/python/assistant-v3-framework-bridge-demo/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "python-assistant-v3-framework-bridge-demo"
+version = "0.1.0"
+description = "Assistant v3 fixture for GenAI framework bridge collision handling"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "langchain>=1.0",
+    "langchain-openai>=1.0",
+    "opentelemetry-instrumentation-openai-v2",
+    "splunk-otel-instrumentation-langchain",
+]

--- a/evals/python/mcp-ai-tool-demo/Makefile
+++ b/evals/python/mcp-ai-tool-demo/Makefile
@@ -1,0 +1,18 @@
+.PHONY: sync dev load build test clean
+
+sync:
+	uv sync
+
+dev: sync
+	OTEL_SERVICE_NAME=mcp-ai-tool-demo uv run uvicorn app:app --host 0.0.0.0 --port 8020 --reload
+
+load: sync
+	uv run python load_demo.py --base-url http://localhost:8020 --duration 60
+
+build: test
+
+test: sync
+	uv run python -m compileall app.py load_demo.py
+
+clean:
+	rm -rf .venv __pycache__ .pytest_cache .observe

--- a/evals/python/mcp-ai-tool-demo/README.md
+++ b/evals/python/mcp-ai-tool-demo/README.md
@@ -1,0 +1,49 @@
+# MCP AI Tool Demo
+
+Small FastAPI service that mimics an MCP-style AI tool gateway. It exposes
+JSON-RPC methods, tool execution, session lifecycle, streaming keepalives,
+provider calls, and tool fanout without custom OpenTelemetry instrumentation.
+
+Use it as a before/after demo for the GenAI readiness skills. The baseline app
+has the code surfaces the skills should audit and patch: MCP method routing,
+tool execution, long-lived streams, provider/model calls, and session state.
+
+## Run
+
+```sh
+cd examples/python/mcp-ai-tool-demo
+make dev
+```
+
+In another terminal:
+
+```sh
+make load
+```
+
+The service listens on `http://localhost:8020`.
+
+## Demo Workflow
+
+1. Run the baseline app and load generator.
+2. Run `/otel-audit` on this directory and review MCP and GenAI pathway gaps.
+3. Run `/otel-instrument` on this directory.
+4. Run the instrumented app with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`.
+5. Run `make load` again and inspect Explorer for MCP method, session, stream,
+   provider, tool, and context-pressure telemetry.
+
+## Eval Workflow
+
+The eval fixture definitions are checked into:
+
+```text
+evals/python/mcp-ai-tool-demo/eval/qual/audit.json
+evals/python/mcp-ai-tool-demo/eval/qual/instrument.json
+```
+
+Validate the eval fixture and render a report:
+
+```sh
+make -C evals eval-validation SKILL=skills/otel-audit EVAL_PATTERN='python/mcp-ai-tool-demo/eval/qual/audit.json'
+make -C evals eval-validation SKILL=skills/otel-instrument EVAL_PATTERN='python/mcp-ai-tool-demo/eval/qual/instrument.json'
+```

--- a/evals/python/mcp-ai-tool-demo/app.py
+++ b/evals/python/mcp-ai-tool-demo/app.py
@@ -1,0 +1,198 @@
+import asyncio
+import json
+import logging
+import random
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("mcp_ai_tool_demo")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="MCP AI Tool Demo")
+
+sessions: dict[str, dict[str, Any]] = {}
+active_streams: dict[str, float] = {}
+
+
+class JsonRpcRequest(BaseModel):
+    jsonrpc: str = "2.0"
+    id: str | int | None = None
+    method: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+@dataclass
+class ProviderResult:
+    text: str
+    input_tokens: int
+    output_tokens: int
+    finish_reason: str
+
+
+def _require_auth(authorization: str | None) -> None:
+    if authorization != "Bearer demo-token":
+        raise HTTPException(status_code=401, detail="invalid demo token")
+
+
+def _estimate_tokens(payload: Any) -> int:
+    return max(1, len(json.dumps(payload).split()) * 2)
+
+
+def _response(request: JsonRpcRequest, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request.id, "result": result}
+
+
+def _error(request: JsonRpcRequest, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request.id, "error": {"code": code, "message": message}}
+
+
+async def _call_provider(tool_name: str, arguments: dict[str, Any]) -> ProviderResult:
+    await asyncio.sleep(random.uniform(0.04, 0.12))
+    if arguments.get("provider_error"):
+        raise RuntimeError("provider unavailable")
+    input_tokens = _estimate_tokens(arguments) + 64
+    text = f"{tool_name} completed with {random.randint(2, 5)} findings"
+    return ProviderResult(
+        text=text,
+        input_tokens=input_tokens,
+        output_tokens=_estimate_tokens(text),
+        finish_reason="stop",
+    )
+
+
+async def _execute_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    started = time.perf_counter()
+    await asyncio.sleep(random.uniform(0.02, 0.08))
+    if name not in {"summarize_metadata", "search_knowledge"}:
+        raise ValueError("unknown tool")
+    if arguments.get("tool_error"):
+        raise RuntimeError("tool dependency failed")
+    provider = await _call_provider(name, arguments)
+    return {
+        "tool": name,
+        "content": provider.text,
+        "model": "demo-tool-model",
+        "finish_reason": provider.finish_reason,
+        "input_tokens": provider.input_tokens,
+        "output_tokens": provider.output_tokens,
+        "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+    }
+
+
+async def _handle_initialize(request: JsonRpcRequest) -> dict[str, Any]:
+    session_id = uuid.uuid4().hex
+    sessions[session_id] = {
+        "created_at": time.time(),
+        "authenticated": True,
+        "method_count": 1,
+        "tool_call_count": 0,
+    }
+    return _response(
+        request,
+        {
+            "session_id": session_id,
+            "server": "mcp-ai-tool-demo",
+            "capabilities": {"tools": True, "streaming": True},
+        },
+    )
+
+
+async def _handle_tools_list(request: JsonRpcRequest) -> dict[str, Any]:
+    return _response(
+        request,
+        {
+            "tools": [
+                {"name": "summarize_metadata", "input_schema": {"type": "object"}},
+                {"name": "search_knowledge", "input_schema": {"type": "object"}},
+            ]
+        },
+    )
+
+
+async def _handle_tools_call(request: JsonRpcRequest) -> dict[str, Any]:
+    session_id = request.params.get("session_id")
+    if session_id not in sessions:
+        return _error(request, -32001, "unknown session")
+    name = str(request.params.get("name", ""))
+    arguments = dict(request.params.get("arguments", {}))
+    sessions[session_id]["method_count"] += 1
+    sessions[session_id]["tool_call_count"] += 1
+    try:
+        result = await _execute_tool(name, arguments)
+    except ValueError as exc:
+        return _error(request, -32602, str(exc))
+    except Exception as exc:
+        logger.warning("tool call failed", extra={"tool": name, "error": type(exc).__name__})
+        return _error(request, -32002, type(exc).__name__)
+    return _response(request, result)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/mcp")
+async def mcp_rpc(request: Request, authorization: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_auth(authorization)
+    payload = JsonRpcRequest.model_validate(await request.json())
+    if payload.method == "initialize":
+        return await _handle_initialize(payload)
+    if payload.method == "tools/list":
+        return await _handle_tools_list(payload)
+    if payload.method == "tools/call":
+        return await _handle_tools_call(payload)
+    return _error(payload, -32601, "method not found")
+
+
+@app.get("/mcp/sessions")
+async def list_sessions() -> dict[str, Any]:
+    now = time.time()
+    oldest_age = max((now - item["created_at"] for item in sessions.values()), default=0.0)
+    return {
+        "active_sessions": len(sessions),
+        "active_streams": len(active_streams),
+        "oldest_session_age_seconds": round(oldest_age, 3),
+    }
+
+
+@app.delete("/mcp/sessions/{session_id}")
+async def close_session(session_id: str) -> dict[str, Any]:
+    existed = sessions.pop(session_id, None) is not None
+    return {"session_id": session_id, "closed": existed}
+
+
+@app.get("/mcp/sessions/{session_id}/stream")
+async def session_stream(session_id: str, authorization: str | None = Header(default=None)) -> StreamingResponse:
+    _require_auth(authorization)
+    if session_id not in sessions:
+        raise HTTPException(status_code=404, detail="unknown session")
+    stream_id = uuid.uuid4().hex
+    active_streams[stream_id] = time.time()
+
+    async def events():
+        try:
+            yield f"event: start\ndata: {json.dumps({'stream_id': stream_id, 'session_id': session_id})}\n\n"
+            for index in range(5):
+                await asyncio.sleep(0.05)
+                if session_id not in sessions:
+                    yield "event: close\ndata: {\"reason\":\"session_closed\"}\n\n"
+                    return
+                yield f"event: keepalive\ndata: {json.dumps({'index': index})}\n\n"
+            yield "event: done\ndata: {\"outcome\":\"ok\"}\n\n"
+        except asyncio.CancelledError:
+            logger.info("mcp stream detached", extra={"session_id": session_id, "stream_id": stream_id})
+            raise
+        except Exception as exc:
+            logger.exception("mcp stream failed", extra={"error": type(exc).__name__})
+            yield f"event: error\ndata: {json.dumps({'error': type(exc).__name__})}\n\n"
+        finally:
+            active_streams.pop(stream_id, None)
+
+    return StreamingResponse(events(), media_type="text/event-stream")

--- a/evals/python/mcp-ai-tool-demo/eval/qual/audit.json
+++ b/evals/python/mcp-ai-tool-demo/eval/qual/audit.json
@@ -1,0 +1,25 @@
+{
+  "skill": "otel-audit",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Scan the MCP-style AI tool gateway in ./service for OpenTelemetry and GenAI readiness gaps. Do not modify files."
+    },
+    {
+      "id": "mcp-readiness",
+      "task": "Produce an observability readiness review for the MCP-style AI tool gateway in ./service. Cover MCP method routing, tool execution, sessions, streams, provider calls, and incident-detection impact. Do not modify files."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for app.py, load_demo.py, pyproject.toml, and generated .observe output when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Identifies app.py, pyproject.toml, health, JSON-RPC /mcp, session listing, session close, and session stream endpoints.",
+    "Reports that the baseline service has no custom OpenTelemetry SDK setup, no GenAI semantic-convention spans or metrics, and no exporter/resource configuration beyond demo environment variables.",
+    "Maps GenAI and MCP gaps for JSON-RPC method outcome, auth result, session lifecycle, active streams, close reason, stream duration, send/write failure, tool execution, and provider/model calls.",
+    "Scopes session, stream, and backpressure signals to AI-owned MCP/tool pathways instead of treating unrelated generic runtime readiness as GenAI coverage.",
+    "Keeps privacy and cardinality safe by not recommending raw JSON-RPC payloads, tool arguments, sessions, users, tenants, requests, or traces as metric dimensions."
+  ]
+}

--- a/evals/python/mcp-ai-tool-demo/eval/qual/instrument.json
+++ b/evals/python/mcp-ai-tool-demo/eval/qual/instrument.json
@@ -1,0 +1,25 @@
+{
+  "skill": "otel-instrument",
+  "prompts": [
+    {
+      "id": "direct",
+      "task": "Instrument the MCP-style AI tool gateway in ./service for OpenTelemetry, MCP lifecycle, and GenAI readiness. Add safe app-owned signals and tests where practical."
+    },
+    {
+      "id": "audit-ledger",
+      "task": "Use the audit gap-ledger contract implied by the MCP-style AI tool gateway in ./service. Add instrumentation for patchable GenAI and session/stream lifecycle gaps and explicitly report any remaining signals."
+    }
+  ],
+  "judge_inputs": [
+    "Inspect ./service for changed files, tests, and generated .observe output when present.",
+    "Read ./last_message.md for the agent final response.",
+    "Read ./grade.json for run guard checks."
+  ],
+  "rubric": [
+    "Adds one reusable OpenTelemetry setup path and avoids duplicate SDK initialization.",
+    "Instruments FastAPI plus app-owned JSON-RPC method outcome, MCP session lifecycle, active streams, stream duration/outcome, close reason family, send/write failure, tool execution, and provider/model calls.",
+    "Uses OTel GenAI semantic-convention names where data is available, including execute_tool and model/provider attributes, without inventing unsafe high-cardinality dimensions.",
+    "Includes detector-ready metrics for tool error/latency, provider error/latency, active sessions or streams, and stream close/detach outcomes.",
+    "Adds or updates tests or compile checks and keeps raw JSON-RPC payloads, prompts, completions, sessions, users, tenants, requests, traces, and tool arguments out of metric dimensions."
+  ]
+}

--- a/evals/python/mcp-ai-tool-demo/load_demo.py
+++ b/evals/python/mcp-ai-tool-demo/load_demo.py
@@ -1,0 +1,77 @@
+import argparse
+import asyncio
+import random
+import time
+from typing import Any
+
+import httpx
+
+
+AUTH = {"Authorization": "Bearer demo-token"}
+
+
+async def rpc(client: httpx.AsyncClient, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    response = await client.post(
+        "/mcp",
+        headers=AUTH,
+        json={"jsonrpc": "2.0", "id": random.randint(1, 100000), "method": method, "params": params or {}},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def initialize(client: httpx.AsyncClient) -> str:
+    response = await rpc(client, "initialize")
+    return response["result"]["session_id"]
+
+
+async def call_tool(client: httpx.AsyncClient, session_id: str) -> None:
+    tool = random.choice(["summarize_metadata", "search_knowledge"])
+    arguments: dict[str, Any] = {"query": "summarize customer metadata health", "limit": random.randint(1, 5)}
+    if random.random() < 0.12:
+        arguments["tool_error"] = True
+    if random.random() < 0.08:
+        arguments["provider_error"] = True
+    await rpc(client, "tools/call", {"session_id": session_id, "name": tool, "arguments": arguments})
+
+
+async def stream_session(client: httpx.AsyncClient, session_id: str) -> None:
+    async with client.stream("GET", f"/mcp/sessions/{session_id}/stream", headers=AUTH) as response:
+        if response.status_code != 200:
+            return
+        async for _ in response.aiter_lines():
+            pass
+
+
+async def run_load(base_url: str, duration: int, concurrency: int) -> None:
+    deadline = time.monotonic() + duration
+    async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+        sessions = [await initialize(client) for _ in range(max(1, concurrency))]
+        await rpc(client, "tools/list")
+        while time.monotonic() < deadline:
+            tasks = []
+            for _ in range(concurrency):
+                session_id = random.choice(sessions)
+                if random.random() < 0.2:
+                    tasks.append(stream_session(client, session_id))
+                else:
+                    tasks.append(call_tool(client, session_id))
+            await asyncio.gather(*tasks, return_exceptions=True)
+            if random.random() < 0.1 and sessions:
+                session_id = sessions.pop(0)
+                await client.delete(f"/mcp/sessions/{session_id}")
+                sessions.append(await initialize(client))
+            await asyncio.sleep(0.2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8020")
+    parser.add_argument("--duration", type=int, default=60)
+    parser.add_argument("--concurrency", type=int, default=4)
+    args = parser.parse_args()
+    asyncio.run(run_load(args.base_url, args.duration, args.concurrency))
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/python/mcp-ai-tool-demo/pyproject.toml
+++ b/evals/python/mcp-ai-tool-demo/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "python-mcp-ai-tool-demo"
+version = "0.1.0"
+description = "MCP-style AI tool gateway app for OTel GenAI skill demos"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "httpx>=0.28",
+    "uvicorn[standard]>=0.34",
+]

--- a/evals/test_genai_skill_guidance.py
+++ b/evals/test_genai_skill_guidance.py
@@ -1,0 +1,1038 @@
+"""Deterministic checks for GenAI readiness skill guidance."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+GENAI_REF = SKILLS_DIR / "references" / "genai-readiness.md"
+SPLUNK_CONFIGURE = SKILLS_DIR / "splunk-configure" / "SKILL.md"
+SPLUNK_CONFIGURE_REFS = SKILLS_DIR / "splunk-configure" / "references"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"Expected file not found: {path}"
+    return path.read_text()
+
+
+def test_genai_reference_covers_otel_semconv_signals():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "gen_ai.operation.name",
+        "gen_ai.provider.name",
+        "gen_ai.request.model",
+        "gen_ai.response.model",
+        "gen_ai.client.operation.duration",
+        "gen_ai.client.token.usage",
+        "gen_ai.evaluation.result",
+        "gen_ai.evaluation.name",
+        "gen_ai.evaluation.score.value",
+        "gen_ai.evaluation.score.label",
+        "invoke_agent",
+        "invoke_workflow",
+        "plan",
+        "execute_tool",
+        "retrieval",
+        "search_memory",
+        "error.type",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_requires_nested_trace_shape_generically():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "service workflow span",
+        "agent/workflow span",
+        "tool execution span",
+        "LLM inference span",
+        "retrieval span",
+        "context propagation",
+        "service.name",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_requires_span_first_trace_explorer_contract():
+    text = _read(GENAI_REF)
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference_required_terms = [
+        "Obstudio GenAI Trace UI Contract",
+        "span-first",
+        "selected-trace summary",
+        "gen_ai.usage.input_tokens",
+        "gen_ai.usage.output_tokens",
+        "gen_ai.usage.total_tokens",
+        "chat span",
+        "workflow span",
+        "first_event_timeout",
+        "stream close reason family",
+    ]
+    instrument_required_terms = [
+        "local span-first trace explorers such as Obstudio",
+        "metrics alone are not enough",
+        "gen_ai.usage.input_tokens",
+        "gen_ai.usage.output_tokens",
+        "gen_ai.usage.total_tokens",
+        "first_event_timeout",
+        "send/write failure",
+    ]
+    missing = [term for term in reference_required_terms if term not in text]
+    assert not missing
+    missing = [term for term in instrument_required_terms if term not in instrument]
+    assert not missing
+
+
+def test_genai_skills_require_model_call_lifecycle_spans():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    required_terms = [
+        "LLM Inference Lifecycle Contract",
+        "model-call lifecycle",
+        "on_chat_model_start",
+        "on_chat_model_end",
+        "on_chat_model_error",
+        "final usage",
+        "chat",
+        "generate_content",
+        "text_completion",
+        "gen_ai.operation.name",
+        "gen_ai.request.model",
+        "gen_ai.response.model",
+        "workflow-level token accounting",
+        "remaining_signals",
+    ]
+    for text in (reference, audit, instrument):
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_genai_skills_require_single_canonical_span_source():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    shared_terms = [
+        "Single-Source GenAI Span Contract",
+        "framework/vendor",
+        "provider SDK hooks",
+        "auto-instrumentors",
+        "one canonical GenAI span source per logical operation",
+        "one GenAI node per logical operation",
+        "wrapper",
+        "expected LLM",
+        "tool counts",
+        "stable model/tool names",
+        "parent shape",
+    ]
+    for raw_text in (reference, audit, instrument):
+        text = " ".join(raw_text.split())
+        missing = [term for term in shared_terms if term not in text]
+        assert not missing
+
+    instrument_only_terms = [
+        "do not create duplicate app-owned",
+        "disable, opt out of, or suppress overlapping framework/vendor GenAI instrumentation",
+        "discovered runtime mechanism",
+        "Do not hard-code this decision to one framework",
+        "Keep HTTP/database/runtime auto-instrumentation",
+    ]
+    instrument_normalized = " ".join(instrument.split())
+    missing = [
+        term for term in instrument_only_terms if term not in instrument_normalized
+    ]
+    assert not missing
+
+
+def test_genai_skills_require_pre_bootstrap_suppression_for_app_owned_spans():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    shared_terms = [
+        "opentelemetry-instrument",
+        "auto-instrumentation bootstrap",
+        "launch environment",
+        "before the bootstrap",
+        "App module code that mutates environment variables",
+        "not sufficient proof",
+        "framework hooks may already be registered",
+        "Makefile targets",
+        "service runner scripts",
+        "Docker or Helm env",
+        "VS Code launch configs",
+        "generated env scripts",
+    ]
+    for raw_text in (reference, audit, instrument):
+        text = " ".join(raw_text.split())
+        missing = [term for term in shared_terms if term not in text]
+        assert not missing
+
+
+def test_genai_nested_reference_paths_resolve():
+    nested_reference = SKILLS_DIR / "otel-instrument" / "references" / "signal-mapping-guide.md"
+    text = _read(nested_reference)
+    required_path = "../../references/genai-readiness.md"
+    assert required_path in text
+    assert (nested_reference.parent / required_path).resolve() == GENAI_REF.resolve()
+
+    configure_template = SPLUNK_CONFIGURE_REFS / "terraform-templates.md"
+    configure_text = _read(configure_template)
+    configure_required_path = "detector-classification.md"
+    assert configure_required_path in configure_text
+    assert (configure_template.parent / configure_required_path).resolve() == (
+        SPLUNK_CONFIGURE_REFS / "detector-classification.md"
+    ).resolve()
+    assert "references/detector-classification.md" not in configure_text
+
+
+def test_genai_skills_preserve_stable_workflow_identity():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    shared_terms = [
+        "stable business workflow identity",
+        "constants",
+        "workflow registrations",
+        "telemetry event names",
+        "prior trace names",
+        "Do not invent names from HTTP routes",
+        "session-derived",
+        "assistant_v3_turn",
+        "assistant_v3_session_turn",
+        "POST /v2/assistant/sessions",
+    ]
+    for raw_text in (reference, audit, instrument):
+        text = " ".join(raw_text.split())
+        missing = [term for term in shared_terms if term not in text]
+        assert not missing
+
+
+def test_genai_skills_preserve_stable_agent_identity():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    shared_terms = [
+        "stable agent identity",
+        "framework agent names",
+        "agent factory names",
+        "registration names",
+        "callback owner names",
+        "prior trace names",
+        "DeepAgents",
+        "deepagents",
+        "assistant_v3_agent",
+        "generic service-derived",
+    ]
+    for raw_text in (reference, audit, instrument):
+        text = " ".join(raw_text.split())
+        missing = [term for term in shared_terms if term not in text]
+        assert not missing
+
+
+def test_genai_skills_require_parent_context_and_workflow_aggregates():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    required_terms = [
+        "owning workflow/agent context",
+        "generic HTTP root span",
+        "generic server span",
+        "siblings of the workflow",
+        "workflow -> chat",
+        "workflow -> execute_tool",
+        "parent-context",
+        "gen_ai.usage.input_tokens",
+        "assistant.llm.calls",
+        "assistant.tool.calls",
+        "most specific owning GenAI span",
+        "remaining_signals",
+    ]
+    for text in (reference, audit, instrument):
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_genai_skills_require_helper_span_context_capture():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    required_terms = [
+        "long-lived helper/setup spans",
+        "memory store",
+        "checkpointer",
+        "database session",
+        "stream-writer",
+        "helper spans must not become the parent",
+        "workflow/agent context before opening helper spans",
+        "event-derived `chat` and `execute_tool` spans",
+        "write aggregate counters to the workflow span",
+        "whichever current span is active",
+        "async generator",
+        "create_task",
+        "anext",
+        "task handoff",
+        "yield/task boundaries",
+        "span/context handle",
+        "callback/event translator",
+    ]
+    for raw_text in (reference, audit, instrument):
+        text = " ".join(raw_text.split())
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_genai_skills_require_immutable_context_handoff():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    required_terms = [
+        "immutable/frozen",
+        "do not mutate",
+        "Treat a carrier as immutable/frozen when source evidence shows",
+        "readonly declarations",
+        "record/value types",
+        "no mutation API",
+        "existing code constructs new copies",
+        "idiomatic copy/replacement",
+        "dataclasses.replace",
+        "attrs.evolve",
+        "model_copy(update=...)",
+        "Java records",
+        "TypeScript object spread",
+        "structuredClone",
+        "plain-data carriers",
+        "live OTel `Context` or `Span` handles",
+        "Readonly<T>",
+        "Go value copies",
+        "framework's request clone/with-context API",
+        "If no safe copy path exists",
+        "invocation-scoped sidecar context",
+        "cleared after cleanup",
+        "Do not key sidecar context by raw user, tenant, session, request, or trace IDs",
+        "explicit static proof",
+        "parent context is passed",
+        "original immutable input remains unchanged",
+        "FrozenInstanceError",
+    ]
+    for raw_text in (reference, audit, instrument):
+        text = " ".join(raw_text.split())
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_genai_reference_requires_incident_evidence_mode():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "Incident-Evidence Mode",
+        "incident class -> failure mechanism -> repo/service owner -> code surface -> signal -> MTTD impact -> remaining owner",
+        "failure mechanism",
+        "MTTD-improving",
+        "localization-only",
+        "provider/model gateway",
+        "tool/session/stream lifecycle including MCP when present",
+        "Do not call GenAI instrumentation complete",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_requires_current_semconv_source_contract():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "GenAI Semconv Source Contract",
+        "open-telemetry/semantic-conventions-genai",
+        "live official docs",
+        "bundled semconv snapshot",
+        "repo/branch-or-commit/docs/date/live-or-snapshot",
+        "model spans",
+        "agent spans",
+        "metrics docs",
+        "GenAI events",
+        "MCP docs",
+        "provider-specific docs only when that provider is detected",
+        "surface -> official operation -> required attrs -> recommended attrs ->",
+        "metrics/events -> implemented -> proven existing -> remaining",
+        "Local operation and metric lists are examples only",
+        "official docs win",
+        "privacy/cardinality rules remain enforced",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_requires_ai_pathway_surface_patterns():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "Required GenAI Surface Patterns",
+        "Provider/model gateway",
+        "Agent/workflow orchestration",
+        "Tool/function execution and AI-owned sessions/streams",
+        "RAG/retrieval",
+        "Token/context/cost pressure",
+        "Safety/policy",
+        "AI runtime state overlay",
+        "Model/config compatibility",
+        "AI-path readiness overlays",
+        "streaming first chunk",
+        "last-ingest age",
+        "expected-vs-running model or AI config state",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_covers_evaluation_quality_contract():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "Evaluation Quality Contract",
+        "gen_ai.evaluation.result",
+        "gen_ai.evaluation.name",
+        "gen_ai.evaluation.score.value",
+        "gen_ai.evaluation.score.label",
+        "gen_ai.evaluation.explanation",
+        "gen_ai.response.id",
+        "score distribution",
+        "pass/fail",
+        "evaluator",
+        "no-data",
+        "freshness",
+        "Do not mark evaluation quality complete",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_covers_content_governance_contract():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "Content Capture Governance Contract",
+        "gen_ai.input.messages",
+        "gen_ai.output.messages",
+        "gen_ai.system_instructions",
+        "gen_ai.retrieval.documents",
+        "gen_ai.retrieval.query.text",
+        "gen_ai.tool.definitions",
+        "gen_ai.tool.call.arguments",
+        "disabled",
+        "metadata-only",
+        "redacted",
+        "full-content",
+        "opt-in config",
+        "redaction/truncation hook",
+        "retention/access owner",
+        "Never",
+        "metric dimensions",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_covers_memory_framework_and_cost_contracts():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "Memory/context and AI runtime state overlay",
+        "create_memory_store",
+        "search_memory",
+        "create_memory",
+        "update_memory",
+        "upsert_memory",
+        "delete_memory",
+        "Framework Bridge Contract",
+        "LangChain",
+        "LangGraph",
+        "CrewAI",
+        "Strands",
+        "LlamaIndex",
+        "OpenInference",
+        "TraceLoop/OpenLLMetry",
+        "ADOT",
+        "semconv source of usage",
+        "accurate pricing map",
+        "owner-map the exact source",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_requires_tool_stream_auth_and_send_failure():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "authentication/authorization",
+        "invalid-token or permission failure outcome",
+        "active sessions/streams",
+        "close reason family",
+        "stream duration/outcome",
+        "send/write failure",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_blocks_mcp_high_cardinality_dimensions():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "MCP/JSON-RPC request IDs",
+        "raw request IDs",
+        "session IDs",
+        "tool arguments",
+        "not safe metric dimensions",
+        "stable tool or method names",
+        "unknown_method",
+        "unsupported_method",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_covers_incident_discovered_ai_pathways():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "prompt/response parsing failures",
+        "AI-derived data freshness",
+        "model/prompt/tool-schema compatibility",
+        "synthetic/canary workflow-check blind spots",
+        "Prompt/response assembly",
+        "AI-derived data freshness",
+        "evaluation, feedback, export",
+        "prompt/cache population",
+        "Model/config compatibility",
+        "AI-path readiness overlays",
+        "fallback target readiness",
+        "detector reliability evidence",
+        "missed, flapping, auto-resolved, or no-data alerts",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_audit_and_instrument_load_genai_reference():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    for text in (audit, instrument):
+        assert "../references/genai-readiness.md" in text
+        assert "GenAI" in text
+        assert "LLM" in text
+        assert "GenAI Semconv Source Contract" in text
+        assert "live-or-snapshot provenance" in text
+        assert "semconv closure matrix" in text
+
+
+def test_instrument_requires_genai_incident_gap_closure():
+    text = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "GenAI incident-evidence mode",
+        "AI pathway failure mechanism",
+        "provider/model gateway",
+        "tool/function execution",
+        "MCP when present",
+        "retrieval",
+        "streaming",
+        "token/context",
+        "prompt/response",
+        "safety/policy",
+        "AI-derived data",
+        "model/config rollout",
+        "AI-owned cache/session",
+        "GenAI Readiness Contract",
+        "surface -> required_signals -> implemented_signals -> tests",
+        "Do not call GenAI instrumentation complete",
+        "MTTD-improving",
+        "localization-only",
+        "remaining",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_readiness_contract_does_not_require_opaque_ids():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    configure = _read(SPLUNK_CONFIGURE)
+    required_audit_terms = [
+        "GenAI readiness contract",
+        "Do not require a separate",
+        "do not require opaque IDs such as `GR8`",
+        "surface`, `evidence`, `current_status`, `required_signals`",
+        "surface name, not an opaque ID",
+    ]
+    required_instrument_terms = [
+        "GenAI Readiness Contract",
+        "Parse each row by human-readable `surface`",
+        "Do not require opaque row IDs such as `GR8`",
+        "surface name in human-facing summaries",
+        "surface -> required_signals -> implemented_signals -> tests",
+    ]
+    assert not [term for term in required_audit_terms if term not in audit]
+    assert not [term for term in required_instrument_terms if term not in instrument]
+    assert "separate GenAI gap-contract section" in instrument
+    blocked_contract_terms = [
+        "| Gap ID |",
+        "`gap_id -> required_signals",
+        "Every GenAI-related `## Gaps` bullet must map back to a Gap ID",
+        "Use stable IDs such as",
+        "GenAI Gap Contract",
+    ]
+    for text in (audit, instrument, configure):
+        bad = [term for term in blocked_contract_terms if term in text]
+        assert not bad
+    assert "legacy GenAI gap-contract" in configure
+    assert "| Surface | Audit Status | Missing Signal |" in configure
+
+
+def test_audit_requires_single_deterministic_gap_section():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    normalized = " ".join(audit.split())
+    required_terms = [
+        "Deterministic gap section contract",
+        "one top-level gap section, named exactly `## Gaps`",
+        "Do not emit `## Gap Register`",
+        "`## Gaps and Recommendations`",
+        "`Gaps:`",
+        "or any GenAI-local gap subsection",
+        "record the contract in `## GenAI Readiness` table rows",
+        "point back to the human-readable readiness surface name",
+    ]
+    assert not [term for term in required_terms if term not in normalized]
+
+    forbidden_normalized_terms = [
+        "Add `## GenAI Readiness` rows and `## Gaps` entries",
+        "GenAI Gap Contract",
+    ]
+    assert not [term for term in forbidden_normalized_terms if term in normalized]
+
+    forbidden_headings = [
+        "\n## Gap Register\n",
+        "\n## Gaps and Recommendations\n",
+        "\nGaps:\n",
+    ]
+    assert not [term for term in forbidden_headings if term in audit]
+
+
+def test_assistant_v3_framework_bridge_eval_covers_duplicate_span_risk():
+    fixture = REPO_ROOT / "evals" / "python" / "assistant-v3-framework-bridge-demo"
+    files = [
+        fixture / "app.py",
+        fixture / "Makefile",
+        fixture / "pyproject.toml",
+        fixture / "eval" / "qual" / "audit.json",
+        fixture / "eval" / "qual" / "instrument.json",
+    ]
+    for file in files:
+        assert file.exists(), f"missing assistant_v3 framework fixture file: {file}"
+
+    combined = "\n".join(_read(file) for file in files)
+    required_terms = [
+        "assistant_v3_turn",
+        "deepagents",
+        "opentelemetry-instrument",
+        "langchain",
+        "splunk-otel-instrumentation-langchain",
+        "framework_shadow_nodes",
+        "simulate_framework_shadow_nodes",
+        "one canonical GenAI span source",
+        "before opentelemetry-instrument bootstraps",
+        "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS",
+        "POST /v2/assistant/sessions",
+        "must not become the GenAI workflow card",
+        "LangGraph",
+        "step nodes",
+    ]
+    assert not [term for term in required_terms if term not in combined]
+
+
+def test_instrument_requires_eval_trace_events_not_metrics_only():
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    reference = _read(GENAI_REF)
+    required_instrument_terms = [
+        "For evaluation quality surfaces",
+        "evaluator classes",
+        "scoring functions",
+        "LLM-as-judge",
+        "`EvalScore` models",
+        "faithfulness/similarity/expectation metrics",
+        "Metrics-only coverage does not satisfy selected-trace eval visibility",
+        "`gen_ai.evaluation.result` on the relevant workflow/evaluation span",
+        "`gen_ai.evaluation.score.value`",
+        "`gen_ai.evaluation.score.label`",
+        "span-level eval event",
+        "keep the evaluation quality surface partial",
+    ]
+    required_reference_terms = [
+        "counters/histograms without",
+        "`gen_ai.evaluation.result`",
+        "Metrics-only coverage does not satisfy selected-trace eval visibility",
+    ]
+    assert not [term for term in required_instrument_terms if term not in instrument]
+    assert not [term for term in required_reference_terms if term not in reference]
+
+
+def test_audit_requires_genai_incident_surface_mapping():
+    text = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    required_terms = [
+        "GenAI incident-evidence mode",
+        "failure mechanism",
+        "provider/model gateway",
+        "tool/function execution",
+        "MCP when present",
+        "retrieval/RAG",
+        "streaming",
+        "token/context",
+        "prompt/response",
+        "safety/policy",
+        "AI-derived data",
+        "model/config rollout",
+        "AI-owned cache/session",
+        "AI-path synthetic/canary checks",
+        "AI-derived data jobs",
+        "incident class -> failure mechanism -> repo/service owner -> code surface ->",
+        "MTTD-improving",
+        "localization-only",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_audit_and_instrument_cover_genai_deployment_and_data_job_failures():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "prompt/response assembly",
+        "AI-derived data",
+        "synthetic/canary",
+        "model/config compatibility",
+        "detector reliability evidence",
+        "missed, flapping, auto-resolved, or no-data alerts",
+        "$splunk-configure",
+        "token/context pressure",
+        "response parse failure",
+        "prompt/tool schema version",
+        "expected-vs-running model/config",
+    ]
+    for text in (audit, instrument):
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_genai_token_pressure_partial_closure_contract():
+    genai_reference = _read(GENAI_REF)
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "context budget percent",
+        "truncation rate",
+        "token-limit errors",
+        "prompt/tool schema size",
+        "LLM call count per turn",
+        "tool call count per turn",
+        "Partial: token usage and context window added",
+        "truncation, token-limit error, prompt/tool schema size, and LLM-call fanout remain missing",
+    ]
+    for text in (genai_reference, instrument):
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_instrument_requires_token_pressure_residuals_in_final_closure():
+    text = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "broadly asks for GenAI readiness",
+        "prompt/tool schema size or safe proxy",
+        "detector-ready proxy metric",
+        "schema JSON length bucket",
+        "schema field count",
+        "Span attributes like prompt template version",
+        "do not close prompt/tool schema size pressure",
+        "remaining_signals",
+        "For every GenAI instrumentation run, include a concise closure summary",
+        "Remaining signals: none",
+        "Final summaries, PR descriptions, and audit updates must not omit",
+        "LLM-call fanout",
+        "tool-call fanout",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_genai_reference_requires_schema_pressure_metric_or_remaining_signal():
+    text = _read(GENAI_REF)
+    required_terms = [
+        "Prompt/tool schema pressure is detector-ready only when it is implemented or",
+        "metric or equivalent detector source",
+        "schema JSON length bucket",
+        "schema field count",
+        "prompt template length bucket",
+        "Span attributes such as prompt template version",
+        "do not close prompt/tool schema size pressure",
+        "keep prompt/tool schema size in `remaining_signals`",
+        "Every GenAI instrumentation result should include a closure summary",
+        "Remaining signals: none",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_audit_requires_demo_clients_and_mcp_auth_outcomes():
+    text = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    required_terms = [
+        "Traffic and readiness clients",
+        "demo, load, eval, or replay scripts",
+        "load_demo.py",
+        "authentication/authorization result",
+        "invalid-token or permission failure outcome",
+        "send/write failure",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_audit_distinguishes_demo_env_from_complete_genai_telemetry_setup():
+    text = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    required_terms = [
+        "demo-only environment hints",
+        "OTEL_SERVICE_NAME",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "SDK setup",
+        "exporter setup",
+        "resource attributes",
+        "incomplete resource/exporter configuration",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_instrument_requires_mcp_safe_dimensions_send_failure_and_tests():
+    text = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "Never record JSON-RPC request IDs",
+        "known route/tool registration",
+        "unknown_method",
+        "send/write failure signal",
+        "GenAI spans alone do not satisfy detector-ready",
+        "tool-specific duration histogram",
+        "tool error/timeout counter",
+        "owner-map the missing source explicitly",
+        "focused pytest file",
+        "Do not rely on unrun compile targets",
+    ]
+    missing = [term for term in required_terms if term not in text]
+    assert not missing
+
+
+def test_audit_places_genai_readiness_after_red_without_incident_readiness():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    assert "Use this template for `.observe/otel.md`:" in audit
+    report_template = audit.split("Use this template for `.observe/otel.md`:")[1]
+    assert "Report requirements:" in report_template
+    report_template = report_template.split("Report requirements:")[0]
+    assert "## RED Signals" in report_template
+    assert "## GenAI Readiness" in report_template
+    red_index = report_template.index("## RED Signals")
+    genai_index = report_template.index("## GenAI Readiness")
+    assert red_index < genai_index
+    assert "## Incident Readiness" not in report_template
+
+
+def test_audit_requires_generic_instrumentation_delta_section():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    assert "Use this template for `.observe/otel.md`:" in audit
+    report_template = audit.split("Use this template for `.observe/otel.md`:")[1]
+    assert "Report requirements:" in report_template
+    report_template = report_template.split("Report requirements:")[0]
+
+    current_index = report_template.index("## Current Instrumentation")
+    delta_index = report_template.index("## Instrumentation Delta")
+    red_index = report_template.index("## RED Signals")
+    assert current_index < delta_index < red_index
+
+    required_terms = [
+        "Baseline audit: no previous instrumentation report found; no delta computed.",
+        "| Signal Type | Added | Modified | Deleted | Evidence |",
+        "| Traces/spans |",
+        "| Metrics |",
+        "| Logs/events |",
+        "| Runtime/config |",
+        "| Dependencies |",
+        "This section is generic across observability signals",
+    ]
+    missing = [term for term in required_terms if term not in audit]
+    assert not missing
+    assert "Only list a deleted signal when prior-report evidence" in " ".join(audit.split())
+
+
+def test_instrument_requires_generic_instrumentation_delta_update():
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_terms = [
+        "Generic Instrumentation Delta Contract",
+        "`## Instrumentation Delta`",
+        "This section is not GenAI-specific",
+        "Before editing, capture the baseline",
+        "| Signal Type | Added | Modified | Deleted | Evidence |",
+        "| Traces/spans | exact span names |",
+        "| Metrics | exact metric names |",
+        "| Logs/events | log bridges or span events |",
+        "| Runtime/config | service/exporter/env/startup settings |",
+        "| Dependencies | OTel packages |",
+        "Do not claim a deletion unless the previous report or git diff proves",
+        "The final response must summarize the same delta by signal type",
+    ]
+    missing = [term for term in required_terms if term not in instrument]
+    assert not missing
+
+
+def test_splunk_configure_generates_genai_readiness_categories():
+    skill = _read(SPLUNK_CONFIGURE)
+    classification = _read(SPLUNK_CONFIGURE_REFS / "detector-classification.md")
+    templates = _read(SPLUNK_CONFIGURE_REFS / "terraform-templates.md")
+    required_terms = [
+        "genai-latency",
+        "genai-token-pressure",
+        "genai-provider",
+        "genai-tool",
+        "genai-model-config",
+        "genai-workflow-fanout",
+        "genai-retrieval",
+        "genai-memory-context",
+        "genai-evaluation-quality",
+        "genai-content-governance",
+        "genai-cost",
+    ]
+    for text in (skill, classification, templates):
+        missing = [term for term in required_terms if term not in text]
+        assert not missing
+
+
+def test_splunk_configure_consumes_all_genai_readiness_rows():
+    skill = _read(SPLUNK_CONFIGURE)
+    required_terms = [
+        "GenAI Readiness",
+        "workflow trace shape",
+        "semantic-convention completeness",
+        "metrics and detectors",
+        "AI pathway surfaces",
+        "memory/context",
+        "evaluation quality",
+        "content governance",
+        "cost source or owner mapping",
+        "privacy/cardinality",
+        "Missing or partial GenAI areas become instrumentation prerequisites",
+    ]
+    missing = [term for term in required_terms if term not in skill]
+    assert not missing
+
+
+def test_splunk_configure_prioritizes_genai_before_generic_red():
+    classification = _read(SPLUNK_CONFIGURE_REFS / "detector-classification.md")
+    assert "Classify GenAI metrics before generic latency" in classification
+    assert "metric name starts with \"gen_ai.\"" in classification
+    assert "gen_ai.client.operation.duration" in classification
+
+
+def test_genai_classification_does_not_treat_generic_model_terms_as_genai():
+    classification = _read(SPLUNK_CONFIGURE_REFS / "detector-classification.md")
+    configure = _read(SPLUNK_CONFIGURE)
+    assert "Do not classify generic" in classification
+    for term in [
+        "`model`",
+        "`workflow`",
+        "`tool`",
+        "`config`",
+        "`canary`",
+        "`token`",
+        "`session`",
+        "`chat`",
+        "`memory`",
+        "`context`",
+        "`evaluation`",
+        "`evaluator`",
+        "`quality`",
+        "`cost`",
+        "`billing`",
+    ]:
+        assert term in classification
+        assert term in configure
+    assert "require explicit GenAI context" in classification
+    assert "The metric has GenAI context and the metric name contains one of:" in classification
+    assert "Those generic words require audit evidence" in classification
+
+
+def test_genai_audit_and_instrument_require_new_gap_closure_surfaces():
+    audit = _read(SKILLS_DIR / "otel-audit" / "SKILL.md")
+    instrument = _read(SKILLS_DIR / "otel-instrument" / "SKILL.md")
+    required_audit_terms = [
+        "memory/context",
+        "evaluation quality",
+        "content governance",
+        "framework bridge",
+        "cost ownership",
+        "gen_ai.evaluation.result",
+        "evaluation score distribution",
+        "content capture mode/redaction/access owner",
+        "owner-mapped billing source",
+    ]
+    required_instrument_terms = [
+        "memory/context operations",
+        "evaluation quality",
+        "content governance",
+        "framework bridge",
+        "app-computed cost",
+        "gen_ai.evaluation.result",
+        "gen_ai.evaluation.score.value",
+        "gen_ai.input.messages",
+        "gen_ai.retrieval.documents",
+        "gen_ai.tool.call.arguments",
+        "search_memory",
+        "accurate pricing map",
+        "owner-map the billing or",
+    ]
+    assert not [term for term in required_audit_terms if term not in audit]
+    assert not [term for term in required_instrument_terms if term not in instrument]
+
+
+def test_genai_guidance_stays_generic():
+    paths = [
+        GENAI_REF,
+        SKILLS_DIR / "otel-audit" / "SKILL.md",
+        SKILLS_DIR / "otel-instrument" / "SKILL.md",
+        SPLUNK_CONFIGURE,
+        SPLUNK_CONFIGURE_REFS / "detector-classification.md",
+        SPLUNK_CONFIGURE_REFS / "terraform-templates.md",
+    ]
+    # Keep skill guidance provider-neutral. Concrete provider names belong in
+    # app-specific audits or examples, not reusable skill instructions.
+    blocked_terms = [
+        "IR-",
+        "guildcore",
+        "Guildcore",
+        "guild.ai",
+        "sb-rest",
+        "signalboost",
+        "signalboost-rest",
+        "sbrest",
+        "metadata-server",
+        "matt-server",
+        "Matt",
+        "meatballs",
+        "Meatballs",
+        "AI Assistant",
+        "AI assistant",
+        "Azure OpenAI",
+        "Gemini",
+        "Vertex AI",
+        "Anthropic",
+        "Bedrock",
+        "eval or feedback",
+        "eval/feedback",
+        "prompt-book",
+        "checkout",
+        "missing report output",
+        "active-node",
+        "active node",
+        "Decision or delivery workflow",
+        "decision or delivery workflow",
+        "workflow delivery/evaluation",
+    ]
+    for path in paths:
+        text = _read(path)
+        bad = [term for term in blocked_terms if term in text]
+        assert not bad, f"{path} contains non-generic terms: {bad}"

--- a/evals/test_genai_skill_guidance.py
+++ b/evals/test_genai_skill_guidance.py
@@ -902,6 +902,25 @@ def test_splunk_configure_generates_genai_readiness_categories():
         assert not missing
 
 
+def test_splunk_configure_summary_lists_all_genai_display_categories():
+    skill = _read(SPLUNK_CONFIGURE)
+    required_display_terms = [
+        "GenAI Latency",
+        "GenAI Token Pressure",
+        "GenAI Provider",
+        "GenAI Tool",
+        "GenAI Model Config",
+        "GenAI Workflow Fanout",
+        "GenAI Retrieval",
+        "GenAI Memory Context",
+        "GenAI Evaluation Quality",
+        "GenAI Content Governance",
+        "GenAI Cost",
+    ]
+    for term in required_display_terms:
+        assert skill.count(term) >= 2
+
+
 def test_splunk_configure_consumes_all_genai_readiness_rows():
     skill = _read(SPLUNK_CONFIGURE)
     required_terms = [

--- a/examples/python/ai-assistant-demo/Makefile
+++ b/examples/python/ai-assistant-demo/Makefile
@@ -1,0 +1,18 @@
+.PHONY: sync dev load build test clean
+
+sync:
+	uv sync
+
+dev: sync
+	OTEL_SERVICE_NAME=ai-assistant-demo uv run uvicorn app:app --host 0.0.0.0 --port 8010 --reload
+
+load: sync
+	uv run python load_demo.py --base-url http://localhost:8010 --duration 60
+
+build: test
+
+test: sync
+	uv run python -m compileall app.py load_demo.py
+
+clean:
+	rm -rf .venv __pycache__ .pytest_cache .observe

--- a/examples/python/ai-assistant-demo/README.md
+++ b/examples/python/ai-assistant-demo/README.md
@@ -1,0 +1,53 @@
+# AI Assistant Demo
+
+Small FastAPI service that mimics the observability surfaces of an AI assistant:
+chat turns, streaming responses, provider calls, tool fanout, context pressure,
+and offline feedback export.
+
+The app is intentionally a baseline fixture. It has realistic code paths but no
+custom OpenTelemetry instrumentation. Use it to demonstrate the before/after
+effect of the OTel skills.
+
+## Run
+
+```sh
+cd examples/python/ai-assistant-demo
+make dev
+```
+
+In another terminal:
+
+```sh
+make load
+```
+
+The service listens on `http://localhost:8010`.
+
+## Demo Workflow
+
+1. Run the baseline app and load generator.
+2. Run `/otel-audit` on this directory and review the GenAI gaps.
+3. Run `/otel-instrument` on this directory.
+4. Run the instrumented app with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`.
+5. Run `make load` again and inspect Explorer for turn, provider, tool, stream,
+   context, and feedback export telemetry.
+
+## Eval Workflow
+
+The eval fixture definitions are checked into:
+
+```text
+evals/python/ai-assistant-demo/eval/qual/audit.json
+evals/python/ai-assistant-demo/eval/qual/instrument.json
+```
+
+Validate the eval fixture and render a report:
+
+```sh
+make -C evals eval-validation SKILL=skills/otel-audit EVAL_PATTERN='python/ai-assistant-demo/eval/qual/audit.json'
+make -C evals eval-validation SKILL=skills/otel-instrument EVAL_PATTERN='python/ai-assistant-demo/eval/qual/instrument.json'
+```
+
+This lets the example act as a before/after eval fixture: the baseline should
+show gaps, and the instrumented version should satisfy the rubric signal
+criteria.

--- a/examples/python/ai-assistant-demo/app.py
+++ b/examples/python/ai-assistant-demo/app.py
@@ -1,0 +1,192 @@
+import asyncio
+import json
+import logging
+import random
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("ai_assistant_demo")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="AI Assistant Demo")
+
+CONTEXT_LIMIT_TOKENS = 4096
+TOKEN_LIMIT_ERROR_THRESHOLD = 3800
+active_streams: dict[str, float] = {}
+feedback_queue: list[dict[str, Any]] = []
+
+
+class ChatRequest(BaseModel):
+    prompt: str = Field(min_length=1)
+    session_id: str = "demo-session"
+    tools: list[str] = Field(default_factory=lambda: ["search_docs", "lookup_customer"])
+    stream: bool = False
+
+
+class FeedbackRequest(BaseModel):
+    session_id: str
+    rating: int = Field(ge=1, le=5)
+    comment: str = ""
+
+
+@dataclass
+class ProviderResult:
+    text: str
+    input_tokens: int
+    output_tokens: int
+    finish_reason: str
+    truncated: bool
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text.split()) * 2)
+
+
+def _context_usage(prompt: str, tool_results: list[dict[str, Any]]) -> tuple[int, float]:
+    prompt_tokens = _estimate_tokens(prompt)
+    tool_tokens = sum(_estimate_tokens(json.dumps(result)) for result in tool_results)
+    used = prompt_tokens + tool_tokens + 256
+    return used, min(1.0, used / CONTEXT_LIMIT_TOKENS)
+
+
+async def run_tool(name: str, prompt: str) -> dict[str, Any]:
+    started = time.perf_counter()
+    await asyncio.sleep(random.uniform(0.02, 0.08))
+    if "tool_error" in prompt and name == "lookup_customer":
+        raise RuntimeError("lookup dependency failed")
+    if name == "search_docs":
+        result = {"tool": name, "matches": 3, "top_score": 0.91}
+    elif name == "lookup_customer":
+        result = {"tool": name, "tier": "enterprise", "region": "us0"}
+    else:
+        result = {"tool": name, "status": "unknown_tool"}
+    result["duration_ms"] = round((time.perf_counter() - started) * 1000, 2)
+    return result
+
+
+async def call_provider(prompt: str, tool_results: list[dict[str, Any]]) -> ProviderResult:
+    context_tokens, usage = _context_usage(prompt, tool_results)
+    await asyncio.sleep(random.uniform(0.05, 0.16))
+    if "provider_error" in prompt:
+        raise RuntimeError("provider unavailable")
+    if context_tokens > TOKEN_LIMIT_ERROR_THRESHOLD or "too_long" in prompt:
+        raise HTTPException(status_code=413, detail="context token limit exceeded")
+    truncated = usage > 0.75 or "truncate" in prompt
+    output = "I found relevant metadata, checked tools, and prepared a short answer."
+    if truncated:
+        output = output[:48]
+    return ProviderResult(
+        text=output,
+        input_tokens=context_tokens,
+        output_tokens=_estimate_tokens(output),
+        finish_reason="length" if truncated else "stop",
+        truncated=truncated,
+    )
+
+
+async def build_turn(request: ChatRequest) -> dict[str, Any]:
+    started = time.perf_counter()
+    tool_results = []
+    tool_errors = []
+    for tool_name in request.tools:
+        try:
+            tool_results.append(await run_tool(tool_name, request.prompt))
+        except Exception as exc:
+            logger.warning("tool failed", extra={"tool": tool_name, "error": type(exc).__name__})
+            tool_errors.append({"tool": tool_name, "error": type(exc).__name__})
+
+    provider = await call_provider(request.prompt, tool_results)
+    context_tokens, context_budget = _context_usage(request.prompt, tool_results)
+    return {
+        "session_id": request.session_id,
+        "message_id": uuid.uuid4().hex,
+        "answer": provider.text,
+        "provider": "demo-provider",
+        "model": "demo-gpt-4o-mini",
+        "finish_reason": provider.finish_reason,
+        "truncated": provider.truncated,
+        "input_tokens": provider.input_tokens,
+        "output_tokens": provider.output_tokens,
+        "context_tokens": context_tokens,
+        "context_budget": round(context_budget, 3),
+        "tool_call_count": len(request.tools),
+        "tool_error_count": len(tool_errors),
+        "tool_results": tool_results,
+        "tool_errors": tool_errors,
+        "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+    }
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/v1/chat")
+async def chat(request: ChatRequest) -> dict[str, Any]:
+    if request.stream:
+        raise HTTPException(status_code=400, detail="use /v1/chat/stream for streaming")
+    return await build_turn(request)
+
+
+@app.post("/v1/chat/stream")
+async def chat_stream(request: ChatRequest) -> StreamingResponse:
+    stream_id = uuid.uuid4().hex
+    active_streams[stream_id] = time.time()
+
+    async def events():
+        try:
+            yield f"event: connected\ndata: {json.dumps({'stream_id': stream_id})}\n\n"
+            turn = await build_turn(request)
+            words = turn["answer"].split()
+            for index, word in enumerate(words):
+                await asyncio.sleep(0.03)
+                yield f"event: token\ndata: {json.dumps({'index': index, 'text': word})}\n\n"
+            yield f"event: done\ndata: {json.dumps(turn)}\n\n"
+        except asyncio.CancelledError:
+            logger.info("stream detached", extra={"stream_id": stream_id})
+            raise
+        except Exception as exc:
+            logger.exception("stream failed", extra={"stream_id": stream_id, "error": type(exc).__name__})
+            yield f"event: error\ndata: {json.dumps({'error': type(exc).__name__})}\n\n"
+        finally:
+            active_streams.pop(stream_id, None)
+
+    return StreamingResponse(events(), media_type="text/event-stream")
+
+
+@app.get("/v1/streams")
+async def streams() -> dict[str, Any]:
+    now = time.time()
+    oldest_age = max((now - started for started in active_streams.values()), default=0.0)
+    return {"active": len(active_streams), "oldest_age_seconds": round(oldest_age, 3)}
+
+
+@app.post("/v1/feedback")
+async def feedback(request: FeedbackRequest) -> dict[str, Any]:
+    record = request.model_dump()
+    record["received_at"] = time.time()
+    feedback_queue.append(record)
+    return {"queued": len(feedback_queue)}
+
+
+@app.post("/v1/feedback/export")
+async def export_feedback() -> dict[str, Any]:
+    started = time.perf_counter()
+    await asyncio.sleep(random.uniform(0.03, 0.12))
+    if random.random() < 0.08:
+        logger.error("feedback export destination failed")
+        raise HTTPException(status_code=502, detail="feedback destination failed")
+    exported = len(feedback_queue)
+    feedback_queue.clear()
+    return {
+        "records_exported": exported,
+        "destination": "demo-warehouse",
+        "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+    }

--- a/examples/python/ai-assistant-demo/load_demo.py
+++ b/examples/python/ai-assistant-demo/load_demo.py
@@ -1,0 +1,87 @@
+import argparse
+import asyncio
+import random
+import time
+
+import httpx
+
+
+PROMPTS = [
+    "summarize metadata health for workspace alpha",
+    "search docs and lookup customer routing",
+    "truncate this response because the context is large",
+    "tool_error while looking up the customer profile",
+    "too_long " + "metadata " * 1500,
+]
+
+
+async def post_chat(client: httpx.AsyncClient, prompt: str) -> None:
+    response = await client.post(
+        "/v1/chat",
+        json={
+            "session_id": f"demo-{random.randint(1, 5)}",
+            "prompt": prompt,
+            "tools": ["search_docs", "lookup_customer"],
+        },
+    )
+    if response.status_code not in {200, 413}:
+        response.raise_for_status()
+
+
+async def post_stream(client: httpx.AsyncClient, prompt: str) -> None:
+    async with client.stream(
+        "POST",
+        "/v1/chat/stream",
+        json={
+            "session_id": f"stream-{random.randint(1, 3)}",
+            "prompt": prompt,
+            "tools": ["search_docs"],
+        },
+    ) as response:
+        if response.status_code != 200:
+            return
+        async for _ in response.aiter_lines():
+            pass
+
+
+async def post_feedback(client: httpx.AsyncClient) -> None:
+    await client.post(
+        "/v1/feedback",
+        json={
+            "session_id": f"demo-{random.randint(1, 5)}",
+            "rating": random.randint(1, 5),
+            "comment": "demo feedback",
+        },
+    )
+    if random.random() < 0.25:
+        await client.post("/v1/feedback/export")
+
+
+async def run_load(base_url: str, duration: int, concurrency: int) -> None:
+    deadline = time.monotonic() + duration
+    async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+        while time.monotonic() < deadline:
+            tasks = []
+            for _ in range(concurrency):
+                prompt = random.choice(PROMPTS)
+                if random.random() < 0.2:
+                    tasks.append(post_stream(client, prompt))
+                elif random.random() < 0.3:
+                    tasks.append(post_feedback(client))
+                else:
+                    tasks.append(post_chat(client, prompt))
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await asyncio.sleep(0.2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8010")
+    parser.add_argument("--duration", type=int, default=60)
+    parser.add_argument("--concurrency", type=int, default=4)
+    args = parser.parse_args()
+    asyncio.run(run_load(args.base_url, args.duration, args.concurrency))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/ai-assistant-demo/pyproject.toml
+++ b/examples/python/ai-assistant-demo/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "python-ai-assistant-demo"
+version = "0.1.0"
+description = "AI assistant-like FastAPI app for OTel GenAI skill demos"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "httpx>=0.28",
+    "uvicorn[standard]>=0.34",
+]

--- a/examples/python/mcp-ai-tool-demo/Makefile
+++ b/examples/python/mcp-ai-tool-demo/Makefile
@@ -1,0 +1,18 @@
+.PHONY: sync dev load build test clean
+
+sync:
+	uv sync
+
+dev: sync
+	OTEL_SERVICE_NAME=mcp-ai-tool-demo uv run uvicorn app:app --host 0.0.0.0 --port 8020 --reload
+
+load: sync
+	uv run python load_demo.py --base-url http://localhost:8020 --duration 60
+
+build: test
+
+test: sync
+	uv run python -m compileall app.py load_demo.py
+
+clean:
+	rm -rf .venv __pycache__ .pytest_cache .observe

--- a/examples/python/mcp-ai-tool-demo/README.md
+++ b/examples/python/mcp-ai-tool-demo/README.md
@@ -1,0 +1,49 @@
+# MCP AI Tool Demo
+
+Small FastAPI service that mimics an MCP-style AI tool gateway. It exposes
+JSON-RPC methods, tool execution, session lifecycle, streaming keepalives,
+provider calls, and tool fanout without custom OpenTelemetry instrumentation.
+
+Use it as a before/after demo for the GenAI readiness skills. The baseline app
+has the code surfaces the skills should audit and patch: MCP method routing,
+tool execution, long-lived streams, provider/model calls, and session state.
+
+## Run
+
+```sh
+cd examples/python/mcp-ai-tool-demo
+make dev
+```
+
+In another terminal:
+
+```sh
+make load
+```
+
+The service listens on `http://localhost:8020`.
+
+## Demo Workflow
+
+1. Run the baseline app and load generator.
+2. Run `/otel-audit` on this directory and review MCP and GenAI pathway gaps.
+3. Run `/otel-instrument` on this directory.
+4. Run the instrumented app with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`.
+5. Run `make load` again and inspect Explorer for MCP method, session, stream,
+   provider, tool, and context-pressure telemetry.
+
+## Eval Workflow
+
+The eval fixture definitions are checked into:
+
+```text
+evals/python/mcp-ai-tool-demo/eval/qual/audit.json
+evals/python/mcp-ai-tool-demo/eval/qual/instrument.json
+```
+
+Validate the eval fixture and render a report:
+
+```sh
+make -C evals eval-validation SKILL=skills/otel-audit EVAL_PATTERN='python/mcp-ai-tool-demo/eval/qual/audit.json'
+make -C evals eval-validation SKILL=skills/otel-instrument EVAL_PATTERN='python/mcp-ai-tool-demo/eval/qual/instrument.json'
+```

--- a/examples/python/mcp-ai-tool-demo/app.py
+++ b/examples/python/mcp-ai-tool-demo/app.py
@@ -1,0 +1,198 @@
+import asyncio
+import json
+import logging
+import random
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("mcp_ai_tool_demo")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="MCP AI Tool Demo")
+
+sessions: dict[str, dict[str, Any]] = {}
+active_streams: dict[str, float] = {}
+
+
+class JsonRpcRequest(BaseModel):
+    jsonrpc: str = "2.0"
+    id: str | int | None = None
+    method: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+@dataclass
+class ProviderResult:
+    text: str
+    input_tokens: int
+    output_tokens: int
+    finish_reason: str
+
+
+def _require_auth(authorization: str | None) -> None:
+    if authorization != "Bearer demo-token":
+        raise HTTPException(status_code=401, detail="invalid demo token")
+
+
+def _estimate_tokens(payload: Any) -> int:
+    return max(1, len(json.dumps(payload).split()) * 2)
+
+
+def _response(request: JsonRpcRequest, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request.id, "result": result}
+
+
+def _error(request: JsonRpcRequest, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request.id, "error": {"code": code, "message": message}}
+
+
+async def _call_provider(tool_name: str, arguments: dict[str, Any]) -> ProviderResult:
+    await asyncio.sleep(random.uniform(0.04, 0.12))
+    if arguments.get("provider_error"):
+        raise RuntimeError("provider unavailable")
+    input_tokens = _estimate_tokens(arguments) + 64
+    text = f"{tool_name} completed with {random.randint(2, 5)} findings"
+    return ProviderResult(
+        text=text,
+        input_tokens=input_tokens,
+        output_tokens=_estimate_tokens(text),
+        finish_reason="stop",
+    )
+
+
+async def _execute_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    started = time.perf_counter()
+    await asyncio.sleep(random.uniform(0.02, 0.08))
+    if name not in {"summarize_metadata", "search_knowledge"}:
+        raise ValueError("unknown tool")
+    if arguments.get("tool_error"):
+        raise RuntimeError("tool dependency failed")
+    provider = await _call_provider(name, arguments)
+    return {
+        "tool": name,
+        "content": provider.text,
+        "model": "demo-tool-model",
+        "finish_reason": provider.finish_reason,
+        "input_tokens": provider.input_tokens,
+        "output_tokens": provider.output_tokens,
+        "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+    }
+
+
+async def _handle_initialize(request: JsonRpcRequest) -> dict[str, Any]:
+    session_id = uuid.uuid4().hex
+    sessions[session_id] = {
+        "created_at": time.time(),
+        "authenticated": True,
+        "method_count": 1,
+        "tool_call_count": 0,
+    }
+    return _response(
+        request,
+        {
+            "session_id": session_id,
+            "server": "mcp-ai-tool-demo",
+            "capabilities": {"tools": True, "streaming": True},
+        },
+    )
+
+
+async def _handle_tools_list(request: JsonRpcRequest) -> dict[str, Any]:
+    return _response(
+        request,
+        {
+            "tools": [
+                {"name": "summarize_metadata", "input_schema": {"type": "object"}},
+                {"name": "search_knowledge", "input_schema": {"type": "object"}},
+            ]
+        },
+    )
+
+
+async def _handle_tools_call(request: JsonRpcRequest) -> dict[str, Any]:
+    session_id = request.params.get("session_id")
+    if session_id not in sessions:
+        return _error(request, -32001, "unknown session")
+    name = str(request.params.get("name", ""))
+    arguments = dict(request.params.get("arguments", {}))
+    sessions[session_id]["method_count"] += 1
+    sessions[session_id]["tool_call_count"] += 1
+    try:
+        result = await _execute_tool(name, arguments)
+    except ValueError as exc:
+        return _error(request, -32602, str(exc))
+    except Exception as exc:
+        logger.warning("tool call failed", extra={"tool": name, "error": type(exc).__name__})
+        return _error(request, -32002, type(exc).__name__)
+    return _response(request, result)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/mcp")
+async def mcp_rpc(request: Request, authorization: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_auth(authorization)
+    payload = JsonRpcRequest.model_validate(await request.json())
+    if payload.method == "initialize":
+        return await _handle_initialize(payload)
+    if payload.method == "tools/list":
+        return await _handle_tools_list(payload)
+    if payload.method == "tools/call":
+        return await _handle_tools_call(payload)
+    return _error(payload, -32601, "method not found")
+
+
+@app.get("/mcp/sessions")
+async def list_sessions() -> dict[str, Any]:
+    now = time.time()
+    oldest_age = max((now - item["created_at"] for item in sessions.values()), default=0.0)
+    return {
+        "active_sessions": len(sessions),
+        "active_streams": len(active_streams),
+        "oldest_session_age_seconds": round(oldest_age, 3),
+    }
+
+
+@app.delete("/mcp/sessions/{session_id}")
+async def close_session(session_id: str) -> dict[str, Any]:
+    existed = sessions.pop(session_id, None) is not None
+    return {"session_id": session_id, "closed": existed}
+
+
+@app.get("/mcp/sessions/{session_id}/stream")
+async def session_stream(session_id: str, authorization: str | None = Header(default=None)) -> StreamingResponse:
+    _require_auth(authorization)
+    if session_id not in sessions:
+        raise HTTPException(status_code=404, detail="unknown session")
+    stream_id = uuid.uuid4().hex
+    active_streams[stream_id] = time.time()
+
+    async def events():
+        try:
+            yield f"event: start\ndata: {json.dumps({'stream_id': stream_id, 'session_id': session_id})}\n\n"
+            for index in range(5):
+                await asyncio.sleep(0.05)
+                if session_id not in sessions:
+                    yield "event: close\ndata: {\"reason\":\"session_closed\"}\n\n"
+                    return
+                yield f"event: keepalive\ndata: {json.dumps({'index': index})}\n\n"
+            yield "event: done\ndata: {\"outcome\":\"ok\"}\n\n"
+        except asyncio.CancelledError:
+            logger.info("mcp stream detached", extra={"session_id": session_id, "stream_id": stream_id})
+            raise
+        except Exception as exc:
+            logger.exception("mcp stream failed", extra={"error": type(exc).__name__})
+            yield f"event: error\ndata: {json.dumps({'error': type(exc).__name__})}\n\n"
+        finally:
+            active_streams.pop(stream_id, None)
+
+    return StreamingResponse(events(), media_type="text/event-stream")

--- a/examples/python/mcp-ai-tool-demo/load_demo.py
+++ b/examples/python/mcp-ai-tool-demo/load_demo.py
@@ -1,0 +1,77 @@
+import argparse
+import asyncio
+import random
+import time
+from typing import Any
+
+import httpx
+
+
+AUTH = {"Authorization": "Bearer demo-token"}
+
+
+async def rpc(client: httpx.AsyncClient, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    response = await client.post(
+        "/mcp",
+        headers=AUTH,
+        json={"jsonrpc": "2.0", "id": random.randint(1, 100000), "method": method, "params": params or {}},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def initialize(client: httpx.AsyncClient) -> str:
+    response = await rpc(client, "initialize")
+    return response["result"]["session_id"]
+
+
+async def call_tool(client: httpx.AsyncClient, session_id: str) -> None:
+    tool = random.choice(["summarize_metadata", "search_knowledge"])
+    arguments: dict[str, Any] = {"query": "summarize customer metadata health", "limit": random.randint(1, 5)}
+    if random.random() < 0.12:
+        arguments["tool_error"] = True
+    if random.random() < 0.08:
+        arguments["provider_error"] = True
+    await rpc(client, "tools/call", {"session_id": session_id, "name": tool, "arguments": arguments})
+
+
+async def stream_session(client: httpx.AsyncClient, session_id: str) -> None:
+    async with client.stream("GET", f"/mcp/sessions/{session_id}/stream", headers=AUTH) as response:
+        if response.status_code != 200:
+            return
+        async for _ in response.aiter_lines():
+            pass
+
+
+async def run_load(base_url: str, duration: int, concurrency: int) -> None:
+    deadline = time.monotonic() + duration
+    async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+        sessions = [await initialize(client) for _ in range(max(1, concurrency))]
+        await rpc(client, "tools/list")
+        while time.monotonic() < deadline:
+            tasks = []
+            for _ in range(concurrency):
+                session_id = random.choice(sessions)
+                if random.random() < 0.2:
+                    tasks.append(stream_session(client, session_id))
+                else:
+                    tasks.append(call_tool(client, session_id))
+            await asyncio.gather(*tasks, return_exceptions=True)
+            if random.random() < 0.1 and sessions:
+                session_id = sessions.pop(0)
+                await client.delete(f"/mcp/sessions/{session_id}")
+                sessions.append(await initialize(client))
+            await asyncio.sleep(0.2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8020")
+    parser.add_argument("--duration", type=int, default=60)
+    parser.add_argument("--concurrency", type=int, default=4)
+    args = parser.parse_args()
+    asyncio.run(run_load(args.base_url, args.duration, args.concurrency))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/mcp-ai-tool-demo/pyproject.toml
+++ b/examples/python/mcp-ai-tool-demo/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "python-mcp-ai-tool-demo"
+version = "0.1.0"
+description = "MCP-style AI tool gateway app for OTel GenAI skill demos"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "httpx>=0.28",
+    "uvicorn[standard]>=0.34",
+]

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -806,15 +807,15 @@ func TestInstallSmokeInstallsBinaryAndAcceptsOTLP(t *testing.T) {
 		t.Fatalf("mkdir home dir: %v", err)
 	}
 
-	// Stage skills before building to avoid a race with internal/integration's
-	// TestMain, which also calls StageEmbeddedSkills on the shared _skills dir.
 	repoRoot := filepath.Dir(observerRoot)
-	if err := buildutil.StageEmbeddedSkills(repoRoot, observerRoot); err != nil {
+	isolatedObserverRoot := copySmokeRepoForBuild(t, repoRoot, observerRoot, filepath.Join(tempRoot, "source"))
+	isolatedRepoRoot := filepath.Dir(isolatedObserverRoot)
+	if err := buildutil.StageEmbeddedSkills(isolatedRepoRoot, isolatedObserverRoot); err != nil {
 		t.Fatalf("stage embedded skills: %v", err)
 	}
 
 	build := exec.Command("go", "build", "-o", bundledBinary, "./cmd/obstudio")
-	build.Dir = observerRoot
+	build.Dir = isolatedObserverRoot
 	if output, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("build smoke obstudio binary: %v\n%s", err, strings.TrimSpace(string(output)))
 	}
@@ -849,13 +850,18 @@ func TestInstallSmokeInstallsBinaryAndAcceptsOTLP(t *testing.T) {
 	for _, want := range []string{
 		codexManagedBlockStart,
 		"[mcp_servers.obstudio]",
-		fmt.Sprintf("command = %q", installedBinary),
-		"args = []",
+		"enabled = true",
 		codexManagedBlockEnd,
 	} {
 		if !strings.Contains(configText, want) {
 			t.Fatalf("expected generated codex config to contain %q, got:\n%s", want, configText)
 		}
+	}
+	hasURLConfig := strings.Contains(configText, `url = "http://127.0.0.1:3000/mcp"`)
+	hasCommandConfig := strings.Contains(configText, fmt.Sprintf("command = %q", installedBinary)) &&
+		strings.Contains(configText, "args = []")
+	if !hasURLConfig && !hasCommandConfig {
+		t.Fatalf("expected generated codex config to contain either local URL or installed command, got:\n%s", configText)
 	}
 
 	observerPort := pickSmokePort(t)
@@ -955,6 +961,62 @@ func observerModuleRoot(t *testing.T) string {
 		t.Fatal("resolve install_test.go path")
 	}
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func copySmokeRepoForBuild(t *testing.T, repoRoot, observerRoot, dstRoot string) string {
+	t.Helper()
+
+	isolatedObserverRoot := filepath.Join(dstRoot, "observer")
+	copySmokeDir(t, observerRoot, isolatedObserverRoot, func(rel string, d fs.DirEntry) bool {
+		return d.IsDir() && (rel == filepath.Join("cmd", "obstudio", "_skills") || rel == filepath.Join("client", "node_modules"))
+	})
+	copySmokeDir(t, filepath.Join(repoRoot, "skills"), filepath.Join(dstRoot, "skills"), nil)
+
+	examplesSrc := filepath.Join(repoRoot, "docs", "examples.md")
+	if _, err := os.Stat(examplesSrc); err == nil {
+		if err := copyFile(examplesSrc, filepath.Join(dstRoot, "docs", "examples.md")); err != nil {
+			t.Fatalf("copy examples.md: %v", err)
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat examples.md: %v", err)
+	}
+
+	return isolatedObserverRoot
+}
+
+func copySmokeDir(t *testing.T, src, dst string, skip func(string, fs.DirEntry) bool) {
+	t.Helper()
+
+	if err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dst, 0o755)
+		}
+		if skip != nil && skip(rel, d) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		return copyFile(path, target)
+	}); err != nil {
+		t.Fatalf("copy %s to %s: %v", src, dst, err)
+	}
 }
 
 func smokeBinaryName() string {

--- a/skills/otel-audit/SKILL.md
+++ b/skills/otel-audit/SKILL.md
@@ -5,12 +5,13 @@ description: >-
   on observability coverage gaps. Read-only -- does not modify code.
   Use when the user types $otel-audit, asks about observability gaps,
   wants to assess instrumentation coverage, says "what signals am I
-  missing", "scan this service for observability", or asks about
-  "observability readiness". Do NOT use for implementing code changes --
-  use $otel-instrument instead.
+  missing", "scan this service for observability", asks about
+  "observability readiness", or asks whether GenAI/LLM workflows follow
+  OpenTelemetry semantic conventions. Do NOT use for implementing code
+  changes -- use $otel-instrument instead.
 metadata:
   author: otel-studio
-  version: 0.6.0
+  version: 0.6.1
   category: observability
 ---
 
@@ -29,6 +30,9 @@ is modified.
 - Checking what auto-instrumentation is already wired up
 - Identifying dependencies that lack matching OTel instrumentation
 - Quick health check of an existing OTel setup
+- Assessing GenAI/LLM, agent, workflow, tool/function calling, MCP,
+  retrieval/RAG, or model-gateway instrumentation against OpenTelemetry GenAI
+  semantic conventions
 **When NOT to use:** If you want to add instrumentation, use `$otel-instrument`.
 
 ## Process
@@ -47,10 +51,26 @@ Scan the repository to determine language, framework, and existing instrumentati
 2. Identify entry points (`main`, `cmd/`, `app.py`, `index.ts`, etc.)
 3. Enumerate all HTTP routes with method and path pattern (e.g. `GET /tasks`, `POST /tasks`, `GET /tasks/{id}`). List them explicitly in the report.
 4. Use the Auto-Instrumentation Library Map below to identify which packages should be present for each detected dependency.
-5. Record exact evidence paths that should appear in the report:
+5. Detect GenAI/LLM ownership: provider clients/model gateways, agents or
+  workflows, tool/function dispatch, MCP when present, retrieval/RAG,
+  model/deployment config, fallback/readiness checks, token accounting, call
+  counts, prompt/response assembly, AI-derived data jobs, AI-path synthetic/canary checks, or usage logging. When any are present, load
+  `../references/genai-readiness.md`.
+  Follow its GenAI Semconv Source Contract before scoring GenAI coverage:
+  reconcile detected AI surfaces with official semconv docs when available,
+  record live-or-snapshot provenance, and build a semconv closure matrix.
+  When GenAI incidents, postmortems, alerts, tickets, or failure examples are
+  part of the request, use GenAI incident-evidence mode and map each failure
+  mechanism to provider/model gateway, workflow, tool/function execution or
+  AI-owned session/stream including MCP when present, retrieval/RAG, streaming,
+  token/context, prompt/response parser, safety/policy, AI-derived data,
+  model/config rollout, or AI-owned cache/session evidence.
+6. Record exact evidence paths that should appear in the report:
   - Dependency manifest: `go.mod`, `package.json`, `pyproject.toml`, `pom.xml`, etc.
   - Process entry point: `main.go`, `cmd/.../main.go`, `app.py`, `app.js`, `TasksApplication.java`, etc.
   - Route source: router/controller files such as `TaskController.java`, `app.py`, `app.js`, or `kvstore/http.go`.
+  - Traffic and readiness clients when they exercise a GenAI path: demo, load, eval, or replay scripts, plus AI-path synthetic or canary scripts such as `load_demo.py`,
+    `smoke.py`, `scripts/check-*`, or `tests/e2e/*`.
   - Runtime/startup files when present: `Dockerfile`, `docker-compose.yml`, `Makefile`, `package.json` scripts, launch configs, worker files.
 
 ### Step 2 -- Instrumentation Assessment
@@ -108,6 +128,26 @@ for Python, `@opentelemetry/instrumentation-winston` /
 - Trace-context injection into log records (`trace_id`, `span_id` fields).
 - `span.AddEvent()` / `span.add_event()` calls used as structured log events.
 
+**Instrumentation delta** -- compare the current scan with the previous
+`.observe/otel.md` report when it exists. This is a generic observability
+change log, not a GenAI-only section. Before overwriting the report, parse the
+prior `## Current Instrumentation` and `## Instrumentation Delta` sections when
+available, then compare them to the current source inventory and changed files.
+Classify each signal-level change as:
+
+- **Added** -- a new trace/span, metric, log bridge/event, runtime/exporter
+  setting, or OTel dependency now exists.
+- **Modified** -- the signal still exists but its name, source path, kind,
+  attributes/dimensions, unit, parentage, status/error behavior, exporter
+  configuration, or semantic meaning changed.
+- **Deleted** -- a previously reported signal source, OTel dependency, runtime
+  setting, or log/trace/metric integration was removed. Do not infer deletion
+  from uncertainty; require prior-report evidence plus current source or diff
+  evidence that the signal source is gone.
+
+Use exact signal names and source paths where possible. If no prior report
+exists, emit a baseline statement instead of fabricating a delta.
+
 **Dependencies without instrumentation** -- for each dependency detected in Step 1:
 
 - Check if a matching auto-instrumentation package is installed
@@ -127,6 +167,179 @@ Status: `covered` / `partial` / `missing`.
 percentiles? (e.g. `http.server.request.duration` histogram, or span
 duration from auto-instrumentation.)
 Status: `covered` / `partial` / `missing`.
+
+**GenAI readiness assessment** -- when GenAI/LLM evidence exists, use
+`../references/genai-readiness.md` to check baseline trace continuity,
+OpenTelemetry GenAI spans, semconv completeness, GenAI metrics, and
+privacy/cardinality controls. Add or update `## GenAI Readiness` rows for
+missing workflow, provider/model gateway, model/config rollout,
+tool/function execution or AI-owned session/stream lifecycle including MCP when
+present, token/context pressure, retrieval/RAG, streaming response lifecycle,
+fallback/failover, prompt/response assembly, safety/policy outcome,
+AI-derived data freshness, memory/context, evaluation quality, framework bridge
+coverage, content governance, cost ownership, or AI-owned cache/session state
+signals. For
+code-owned GenAI pathway gaps, explicitly check for token/context pressure,
+response parse failure, AI-derived data freshness, prompt/tool schema version,
+LLM-call count, tool-call count, authentication/authorization result,
+invalid-token or permission failure outcome, active AI-owned streams or
+sessions, close reason family, stream duration/outcome, send/write failure,
+memory hit/miss or stale/missing context, `gen_ai.evaluation.result` coverage,
+evaluation score distribution, content capture mode/redaction/access owner, and
+app-owned cost or owner-mapped billing source when those values are observable.
+For LLM/model-call coverage, apply the `LLM Inference Lifecycle Contract`:
+audit the real lifecycle hook or client call site, not only the outer workflow
+and final usage aggregation. In LangChain, LangGraph, DeepAgents, callback, or
+event-stream based systems, look for `on_chat_model_start`,
+`on_chat_model_end`, `on_chat_model_error`, or an equivalent model-call
+callback. In direct provider SDK or model-gateway code, look for a span wrapping
+the provider request or streaming generator. If token/model attributes are
+present only on a workflow span, final usage event, turn-finalization path, or
+other workflow-level token accounting, but no `chat`, `generate_content`,
+`text_completion`, or equivalent inference span exists with
+`gen_ai.operation.name`, `gen_ai.request.model`, and `gen_ai.response.model`
+when known, mark trace and semconv coverage `partial`; do not mark LLM coverage
+as `covered`. Keep the missing model-call lifecycle span and attributes in
+`remaining_signals`.
+Apply the `Single-Source GenAI Span Contract` from the GenAI readiness
+reference before deciding trace coverage. Inventory framework/vendor bridges,
+provider SDK hooks, callbacks, middleware, and auto-instrumentors that can emit
+GenAI spans, then compare them with app-owned spans for the same logical
+workflow, agent, chat/model call, tool call, retrieval, memory, or evaluation
+operation. Mark trace and semconv coverage `partial` when a representative
+trace or source proof shows both framework/vendor and app-owned spans for the
+same logical operation, wrapper spans such as middleware or step execution being
+counted as tools, duplicate model/tool call counts, divergent parentage, or
+aggregate attributes written to the wrong canonical span. Required closure
+evidence is one canonical GenAI span source per logical operation. A
+representative trace must show one GenAI node per logical operation, expected
+LLM and tool counts, stable model/tool names, correct workflow/agent parent
+shape, and no wrapper-only spans counted as GenAI work.
+Audit workflow naming as part of this proof. GenAI workflow names must preserve
+the application's stable business workflow identity from constants, handlers,
+workflow registrations, telemetry event names, docs, or prior trace names. Mark
+workflow coverage `partial` when instrumentation invents names from HTTP
+routes, request resources, session/storage concepts, or transport labels. For
+example, `assistant_v3_turn` must not become `assistant_v3_session_turn` or
+`POST /v2/assistant/sessions`.
+Do not invent names from HTTP routes or session-derived labels.
+Audit agent naming with the same rule. GenAI agent names must preserve the
+application's stable agent identity from framework agent names, agent factory
+names, classes, registration names, callback owner names, docs, or prior trace
+names. Mark agent coverage `partial` when instrumentation invents generic
+service-derived names. For example, a DeepAgents-backed agent should be
+`deepagents`, not `assistant_v3_agent`, `assistant`, or `agent`.
+Keep duplicate-span remediation in `remaining_signals` unless the audit proves
+either the framework/vendor bridge is canonical and app duplicates are absent,
+or app-owned spans are
+canonical and overlapping framework/vendor GenAI instrumentation is disabled,
+opted out, or suppressed by the app's discovered runtime mechanism.
+When app-owned spans are canonical and the process uses preload, agent,
+`opentelemetry-instrument`, `NODE_OPTIONS --require`, or another
+auto-instrumentation bootstrap, audit the launch environment and startup
+surfaces that run before the bootstrap. Mark duplicate-span remediation
+`partial` if the only proof is App module code that mutates environment
+variables after import, because that is not sufficient proof and framework
+hooks may already be registered. Accept proof from Makefile
+targets, service runner scripts, Docker or Helm env, VS Code launch configs,
+procfiles, systemd units, shell env generators, or the exact documented run
+command. Also accept generated env scripts when they are sourced before the
+bootstrap.
+Also audit parent-context proof for event-derived spans. In representative trace
+evidence or tests, chat/model and tool spans must preserve the owning workflow/agent context
+and prove a trace shape such as `workflow -> chat`, `workflow -> execute_tool`,
+and follow-up `workflow -> chat` or `agent -> chat` edges. If they appear as
+siblings of the workflow under a generic HTTP root span or generic server span,
+mark the trace shape `partial` and keep parent-context propagation in
+`remaining_signals`. Also check long-lived helper/setup spans such as memory
+store, checkpointer, database session, stream-writer, or resource setup spans.
+If callback-created chat/tool spans are parented to those helper spans instead
+of the owning workflow/agent span, mark the trace shape `partial`; the
+instrumentation must capture/re-enter the workflow/agent context before opening
+helper spans and must not rely on whichever current span is active during
+callback cleanup. Use this rule for memory store, checkpointer, database
+session, stream-writer, or resource setup paths: helper spans must not become
+the parent; capture the workflow/agent context before opening helper spans,
+start event-derived `chat` and `execute_tool` spans with that captured context,
+and write aggregate counters to the workflow span, not to whichever current span
+is active. For async generator, SSE, WebSocket, ping-loop, or timeout
+wrapper paths, check whether the stream is advanced with `create_task`, `wait`,
+`anext`, or equivalent task handoff. If an OpenTelemetry current-span context
+manager is kept open across those yield/task boundaries, mark the trace shape
+`partial`; require an explicit workflow span/context handle that is passed into
+the callback/event translator and ended manually. Also check whether that
+workflow/agent context is carried through a request, turn input, event payload,
+callback state, or config object that may be immutable/frozen. If the
+instrumentation does not prove that app code will avoid mutating immutable,
+frozen, or framework-owned carriers, keep parent-context propagation `partial`;
+do not mutate those carriers in place. Treat a carrier as immutable/frozen when
+source evidence shows frozen or readonly declarations, record/value types, no
+mutation API, framework request immutability patterns, or existing code
+constructs new copies instead of mutating.
+Accept app-idiomatic copy/replacement proof such as Python
+`dataclasses.replace`, `attrs.evolve`, pydantic `model_copy(update=...)` or v1
+`copy(update=...)`; Java records, builders, or copy constructors; TypeScript
+object spread, explicit `Readonly<T>` replacements, or `structuredClone` only
+for plain-data carriers and never for live OTel `Context` or `Span` handles; Go
+value copies with explicit field replacement; or the framework's request
+clone/with-context API. If no safe copy path exists, require a separate
+invocation-scoped sidecar context: a local object, context variable,
+request-scoped map, or callback state keyed to the invocation lifecycle and
+cleared after cleanup. Do not key sidecar context by raw user, tenant, session,
+request, or trace IDs. Require a test or explicit static proof that the parent context is
+passed downstream and the original immutable input remains unchanged; Python
+tests should guard against `FrozenInstanceError` where frozen dataclasses or
+models exist. Audit aggregate placement separately: if
+`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`,
+`gen_ai.usage.total_tokens`, `assistant.llm.calls`, or `assistant.tool.calls`
+are written only to a generic HTTP root span, report misplaced aggregate GenAI
+attributes and require moving them to the workflow span or most specific owning GenAI span.
+A generic HTTP root span should not be the evidence for a GenAI flow card unless
+it has an explicit GenAI workflow operation.
+If incident evidence depends on missed, flapping, auto-resolved, or no-data alerts, record detector reliability evidence
+as a `$splunk-configure` handoff instead of an app-owned GenAI instrumentation
+prerequisite.
+
+For GenAI services and demos, distinguish demo-only environment hints from
+complete telemetry wiring. If a Makefile, README, script, or example command
+sets only `OTEL_SERVICE_NAME` or `OTEL_EXPORTER_OTLP_ENDPOINT`, but the service
+has no SDK setup, exporter setup, resource attributes, or framework
+instrumentation, report that as incomplete resource/exporter configuration
+rather than covered setup.
+
+**GenAI readiness contract** -- the `## GenAI Readiness` table is the
+instrumentation contract, not background context. Do not require a separate
+GenAI gap-contract section and do not require opaque IDs such as `GR8` or `G1`.
+For every GenAI readiness gap, create or update a structured surface row with:
+`surface`, `evidence`, `current_status`, `required_signals`,
+`owner/source_files`, and `acceptance_criteria`. If an existing audit already
+has an ID column, treat it only as an optional source-row reference; use the
+surface name in human-facing summaries and closure handoffs. Split a surface
+when required signals have different owners or acceptance criteria. Required
+signals must be concrete signal names or signal intents, not vague area labels.
+Use owner values that map directly to instrumentation outcomes: `App-owned +
+patchable`, `App-owned but unsafe/too large`, `Provider/platform-owned`, or
+`Already covered`.
+
+Status must be computed against every required signal:
+
+| Ledger result | Rule |
+|---|---|
+| `covered` | Every required GenAI signal is proven existing with source path and signal name. |
+| `partial` | Some required GenAI signals exist, but remaining required signals are named. |
+| `missing` | No required app-owned GenAI signal exists. |
+| `owner-mapped` | The repo cannot accurately observe the signal and the provider/platform/deployment owner plus exact missing source is named. |
+
+Do not collapse a partial GenAI gap into `covered` because one metric or span
+exists. The GenAI Readiness surface row is the source of truth for
+`$otel-instrument` and `$splunk-configure`.
+
+**Deterministic gap section contract** -- the audit report must contain at most
+one top-level gap section, named exactly `## Gaps`. Do not emit `## Gap
+Register`, `## Gaps and Recommendations`, `Gaps:`, or any GenAI-local gap
+subsection. For GenAI issues, record the contract in `## GenAI Readiness` table
+rows and add only concise references in `## Gaps` that point back to the
+human-readable readiness surface name.
 
 **Anti-patterns** -- flag any of these:
 
@@ -220,6 +433,23 @@ If no OTel log integrations are found, write: "No OTel log instrumentation detec
 If no OTel packages or setup are found across all three signal types, include
 the phrase: "OpenTelemetry instrumentation is missing."
 
+## Instrumentation Delta
+
+Compare this scan with the previous `.observe/otel.md` when one existed.
+This section is generic across observability signals; include it even when no
+GenAI code is present.
+
+If no previous report exists, write:
+"Baseline audit: no previous instrumentation report found; no delta computed."
+
+| Signal Type | Added | Modified | Deleted | Evidence |
+|-------------|-------|----------|---------|----------|
+| Traces/spans | {exact span names or "None"} | {exact span names/changes or "None"} | {exact span names or "None"} | {source paths, prior report, or diff evidence} |
+| Metrics | {exact metric names or "None"} | {exact metric names/changes or "None"} | {exact metric names or "None"} | {source paths, prior report, or diff evidence} |
+| Logs/events | {log bridge/event names or "None"} | {changed fields/correlation behavior or "None"} | {removed integrations/events or "None"} | {source paths, prior report, or diff evidence} |
+| Runtime/config | {service.name/exporter/env/startup additions or "None"} | {changed service/exporter/startup settings or "None"} | {removed settings or "None"} | {source paths, prior report, or diff evidence} |
+| Dependencies | {OTel package additions or "None"} | {version/package changes or "None"} | {removed OTel packages or "None"} | {manifest paths or lockfile evidence} |
+
 ## RED Signals
 
 | Signal | Status | Detail |
@@ -234,10 +464,24 @@ Status values:
   exist but no histogram for percentile breakdown).
 - **missing** -- no data source provides this signal.
 
+## GenAI Readiness
+
+Include only when GenAI/LLM ownership evidence exists.
+
+| Surface | Status | Evidence | Required Signals | Owner / Source Files | Acceptance Criteria | Detection/Localization Impact |
+|---------|--------|----------|------------------|----------------------|---------------------|-------------------------------|
+| Trace and semconv | {covered / partial / missing} | {workflow, agent, tool, chat, retrieval spans and gen_ai attrs; model-call lifecycle hook evidence} | {missing parent/child span, propagation, request model, provider, tool name, chat/model lifecycle span, or error type} | {owner and file/path evidence} | {code + tests, proof path + signal name, or exact external owner/source} | {model/provider/tool issues remain slow to localize} |
+| Metrics and detectors | {covered / partial / missing} | {gen_ai metrics or service-owned counters/histograms} | {missing latency/token/fanout/readiness/fallback metric} | {owner and file/path evidence} | {code + tests, proof path + signal name, or exact external owner/source} | {alert cannot fire before manual trace search} |
+| AI pathway surfaces | {covered / partial / missing} | {provider/model gateway, workflow, tool/function execution or AI-owned session/stream lifecycle including MCP when present, retrieval/RAG, streaming, token/context, prompt/response parser, safety/policy, AI-derived data, model/config rollout, or AI-owned cache/session signals} | {missing outcome, latency, error class, duration, count, freshness, fallback, rejection, version, parse, prompt/tool schema, or model/config compatibility signal} | {owner and file/path evidence} | {code + tests, proof path + signal name, or exact external owner/source} | {AI pathway incidents cannot be detected or routed by failure mechanism} |
+| Memory/context | {covered / partial / missing} | {memory/context spans, hit/miss, stale/missing context, source/version, auth failure} | {missing memory operation span or detector-ready stale/miss signal} | {owner and file/path evidence} | {code + tests, proof path + signal name, or exact external owner/source} | {bad context may look like model quality failure} |
+| Evaluation quality | {covered / partial / missing} | {`gen_ai.evaluation.result`, score value/label, evaluator errors, sample/freshness metrics} | {missing quality event, score distribution, failure count, or no-data signal} | {owner and file/path evidence} | {code + tests, proof path + signal name, or exact external owner/source} | {hallucination, toxicity, factuality, or instruction-following regressions need manual review} |
+| Framework bridge/content/cost | {covered / partial / missing / owner-mapped} | {framework OTel bridge evidence, content capture mode/redaction/access owner, token-to-cost or billing source} | {unproven bridge, unsafe content capture, missing cost source, or provider/platform owner missing} | {owner and file/path evidence} | {code + tests, proof path + signal name, or exact external owner/source} | {duplicate/missing spans, unsafe telemetry, or cost incidents remain hard to explain} |
+| Privacy/cardinality | {covered / partial / missing} | {content capture and attribute policy evidence} | {raw content or high-cardinality dimension risk} | {owner and file/path evidence} | {code + tests, proof path + signal name, or exact external owner/source} | {telemetry may be unsafe or unusable for alert grouping} |
+
 ## Gaps
 - {remaining non-RED gaps: missing auto-instrumentation packages, missing
   context propagation, missing OTLP exporter configuration, missing
-  service.name resource, etc.}
+  service.name resource, GenAI signals, etc.}
 - If no gaps remain, write: "No additional gaps detected."
 
 ## Anti-Patterns
@@ -249,11 +493,55 @@ Status values:
   $otel-instrument for custom business metrics"}
 
 ---
-*Generated by obstudio v0.6.0 otel-audit on {YYYY-MM-DD HH:MM UTC}*
+*Generated by obstudio v0.6.1 otel-audit on {YYYY-MM-DD HH:MM UTC}*
 ```
 
 Report requirements:
 
+- Always include top-level `## Instrumentation Delta` after
+  `## Current Instrumentation` and before `## RED Signals`.
+- Keep `## Instrumentation Delta` generic, not GenAI-specific. It must cover
+  traces/spans, metrics, logs/events, runtime/config, and dependencies.
+- Use exact signal names and source paths in the delta. Use `None` for empty
+  cells. Use the baseline sentence when no previous report exists. Only list a
+  deleted signal when prior-report evidence and current source/diff evidence
+  show the signal source was removed.
+- If GenAI/LLM code is detected, include `## GenAI Readiness` after
+  `## RED Signals`; omit it otherwise.
+- The report must have at most one top-level gap section, named exactly
+  `## Gaps`. Do not emit `## Gap Register`, `## Gaps and Recommendations`,
+  `Gaps:`, or a GenAI-local gap subsection.
+- If GenAI readiness gaps exist, put the required signals, owner/source files,
+  and acceptance criteria directly in the `## GenAI Readiness` surface rows.
+  Every GenAI-related `## Gaps` bullet must refer back to the human-readable
+  surface name, not an opaque ID such as `GR8`.
+- Keep GenAI readiness generic: no organization-specific service names,
+  incident IDs, customer names, realms, or provider account names.
+- Prefer OTel GenAI semantic conventions. Treat missing
+  `gen_ai.request.model` as a gap when the requested model is available.
+- For GenAI incident-evidence requests, include the generic coverage mapping
+  `incident class -> failure mechanism -> repo/service owner -> code surface ->
+  signal -> MTTD impact -> remaining owner`. Mark each gap as
+  `MTTD-improving`, `localization-only`, `provider/platform-owned`, or
+  `unknown owner`.
+- Treat missing provider/model gateway health, workflow outcome,
+  tool/function execution or AI-owned session/stream lifecycle including MCP
+  when present, retrieval/RAG freshness or quality, streaming lifecycle,
+  token/context pressure, prompt/response build or parse outcome,
+  safety/policy outcome, AI-derived data freshness, model/config rollout, and
+  AI-owned cache/session state as GenAI gaps only when code or runtime evidence
+  shows the service owns that AI pathway surface.
+- When those GenAI surfaces are owned, name concrete detector-ready signals such
+  as token/context budget percent, truncation rate, token-limit errors,
+  prompt/tool schema size, LLM call count, tool call count, response parse
+  failure, AI-derived data freshness, prompt/tool schema version,
+  model/config readiness, and expected-vs-running model/config state instead
+  of reporting a vague GenAI gap. Put missed, flapping, auto-resolved, or
+  no-data alert evidence into the `$splunk-configure` detector reliability
+  handoff.
+- IDs for users, accounts, tenants, sessions, tasks, conversations, requests,
+  and traces may help trace drilldown, but must not be metric dimensions or
+  detector group-by keys.
 - If instrumentation is incomplete, always include the exact token `$otel-instrument` in the recommendation.
 - If OpenTelemetry is absent, include both words `OpenTelemetry` and `missing`.
 - Name the concrete files that support findings; do not only refer to "the service" or "./service".

--- a/skills/otel-instrument/SKILL.md
+++ b/skills/otel-instrument/SKILL.md
@@ -6,10 +6,11 @@ description: >-
   asks to "add OTel", "add tracing", "add metrics", "implement observability",
   "wire up telemetry", "instrument this service", or asks to add a specific
   custom signal like "add a metric to track queue depth", "add a span for
-  payment processing", "track error rate for X".
+  payment processing", "track error rate for X", or asks to instrument
+  GenAI/LLM workflows with OpenTelemetry semantic conventions.
 metadata:
   author: otel-studio
-  version: 0.1.1
+  version: 0.1.2
   category: observability
 ---
 
@@ -28,6 +29,22 @@ Before editing anything, ground the plan with repo evidence:
 - Confirm the language and framework from actual dependency or source files
 - Confirm the target process from the repo's real start surface: `docker-compose.yml`, Kubernetes manifests, `package.json` scripts, `Makefile`, `Procfile`, PM2 configs, Supervisor configs, systemd units, launchd plists, PowerShell scripts, or a plain shell command
 - Confirm existing telemetry indicators or record `none found`
+- Detect GenAI/LLM ownership. Search dependencies, config, and source for
+  provider clients, model gateways, agent/workflow orchestration, tool/function
+  dispatch, MCP when present, retrieval/RAG, model/deployment config, fallback,
+  token usage, prompt/response assembly, AI-derived data jobs, AI-path
+  synthetic/canary checks, and usage logging. When present, load
+  `../references/genai-readiness.md`.
+  Follow its GenAI Semconv Source Contract before editing: reconcile detected
+  AI surfaces with official semconv docs when available, record
+  live-or-snapshot provenance, and build a semconv closure matrix.
+- When GenAI incidents, postmortems, tickets, alerts, or failure examples are
+  part of the request, use GenAI incident-evidence mode from
+  `../references/genai-readiness.md`: map each AI pathway failure mechanism to
+  the owning provider/model gateway, workflow, tool/function execution or
+  AI-owned session/stream including MCP when present, retrieval/RAG, streaming,
+  token/context, prompt/response parser, safety/policy, AI-derived data,
+  model/config rollout, or AI-owned state surface before editing.
 - For Java projects, build a trace wiring inventory per `./references/languages/java.md` (Preflight section) and classify as `auto-only`, `custom-with-provider`, `custom-provider-external`, or `missing` before editing.
 - Confirm the planned `service.name` source and `deployment.environment` source
 - Distinguish between application repos and tooling repos such as CLIs, MCP servers, workers, libraries, installers, and build tools. Instrument the executable path users or operators actually run today. Do not invent a web app, Docker path, or entrypoint that is not present.
@@ -43,6 +60,15 @@ Do not proceed until you can state all of these clearly:
 - environment dimension
 - incremental addition vs new scaffold
 - for Java, trace source of truth (see `./references/languages/java.md` Preflight section)
+- GenAI workflow surfaces and the GenAI semantic-convention plus service-owned
+  readiness signals to add, when the repo owns LLM, agent, tool/function, MCP,
+  retrieval, streaming, model/config, token/context, prompt/response,
+  safety/policy, AI-derived data, memory/context, evaluation quality, content
+  capture, framework bridge, app-computed cost, or AI-owned state code
+- GenAI incident coverage when GenAI incidents or AI pathway failures are
+  supplied: failure mechanism, provider/model/tool/retrieval/config/prompt/
+  AI-derived-data owner, signal to add or prove, expected MTTD/localization
+  impact, and remaining non-code or dependency owner
 
 ### Fast Path: Targeted Custom Signal
 
@@ -57,6 +83,184 @@ preflight scan finds OTel SDK already initialized:
 
 If the preflight scan finds no OTel SDK, tell the user auto-instrumentation
 needs to be set up first and continue with the full workflow (Steps 2-3).
+
+### Audit-Driven GenAI Readiness
+
+#### GenAI Readiness Contract
+
+If `.observe/otel.md` contains `## GenAI Readiness`, use that table as the
+source of truth. The audit output is a contract, not background context.
+Parse each row by human-readable `surface` plus `required_signals`,
+`owner/source_files`, and `acceptance_criteria`. Do not require opaque row IDs such as `GR8`
+or `G1`; if an older audit has an ID column, keep it only as an optional
+source-row reference and use the surface name in human-facing summaries. If an
+older audit contains a separate GenAI gap-contract section, treat it as legacy
+input and normalize it into surface rows before editing code.
+
+Reconcile every GenAI audit gap to a required instrumentation result:
+
+| Audit Gap | Required Instrumentation Result |
+|---|---|
+| App-owned + patchable | Code added + tests |
+| App-owned but unsafe/too large | Explicitly split into named follow-up batch |
+| Provider/platform-owned | Owner mapped with exact missing source |
+| Already covered | Proven with source path and signal name |
+
+For each surface row, produce and maintain a closure matrix:
+`surface -> required_signals -> implemented_signals -> tests ->
+remaining_signals -> status`. The final gate is strict: the instrumentation
+pass cannot say `covered`, `fixed`, `closed`, or `complete` unless every
+required GenAI signal is either implemented with tests, proven existing with
+source path and signal name, or explicitly owner-mapped with the exact missing
+source. Optimize for honesty over broad progress. Partial closure is acceptable;
+silent partial closure is the bug.
+
+For every GenAI instrumentation run, include a concise closure summary in the
+final response. It must name remaining GenAI signals, or say `Remaining signals: none`
+only when the closure matrix has no partial rows. Do not use unqualified
+phrases such as `expected coverage`, `covered`, or `complete` for a GenAI surface
+unless the related row is fully closed by the matrix.
+
+If `.observe/otel.md` contains `## GenAI Readiness` rows with `partial` or
+`missing` status and the user asked to instrument, treat those rows as an
+approved request for custom GenAI readiness instrumentation. Do not stop after
+auto-instrumentation and do not ask the Step 4 custom-instrumentation question
+for GenAI gaps that the repo clearly owns.
+
+### Generic Instrumentation Delta Contract
+
+For every instrumentation run, maintain a generic `## Instrumentation Delta`
+section in `.observe/otel.md` when that report exists or when the run creates
+one. This section is not GenAI-specific.
+
+Before editing, capture the baseline from the existing `.observe/otel.md`
+`## Current Instrumentation` and `## Instrumentation Delta` sections when
+present, plus the source files and manifests that define OTel setup. After
+editing, update the delta with signal-level changes:
+
+| Signal Type | Added | Modified | Deleted | Evidence |
+|-------------|-------|----------|---------|----------|
+| Traces/spans | exact span names | name/source/kind/attribute/parentage/status changes | removed span sources | source path + test/runtime proof |
+| Metrics | exact metric names | unit/instrument/dimension/export changes | removed metric instruments | source path + test/runtime proof |
+| Logs/events | log bridges or span events | correlation field/event payload changes | removed log bridges/events | source path + test/runtime proof |
+| Runtime/config | service/exporter/env/startup settings | changed service/exporter/startup settings | removed settings | startup/config path |
+| Dependencies | OTel packages | version/package changes | removed OTel packages | manifest/lockfile path |
+
+If no prior report exists, add the baseline sentence exactly:
+`Baseline audit: no previous instrumentation report found; no delta computed.`
+Do not claim a deletion unless the previous report or git diff proves the
+signal existed and the current source proves it was removed. Use `None` for
+empty cells. The final response must summarize the same delta by signal type
+and must distinguish added, modified, deleted, and unchanged signals.
+
+When the user asks broadly to apply GenAI readiness skills, improve GenAI MTTD,
+or fix found GenAI gaps, treat the scope as **all discovered app-owned GenAI
+gaps**. Do not select one representative or highest-value gap unless the user
+explicitly narrows the scope to that gap.
+
+Close code-evidenced AI pathway surfaces from `../references/genai-readiness.md`:
+provider/model gateway, agent/workflow orchestration, tool/function execution
+or AI-owned session/stream lifecycle including MCP when present, retrieval/RAG,
+streaming response lifecycle, token/context pressure, safety/policy outcome,
+prompt/response assembly, AI-derived data freshness, memory/context operations,
+evaluation quality, content governance, framework bridge configuration,
+app-computed cost, model/config rollout, and AI-owned cache/session state.
+
+For evaluation quality surfaces, code evidence such as evaluator classes,
+scoring functions, LLM-as-judge calls, feedback processors, `EvalScore` models,
+faithfulness/similarity/expectation metrics, pass/fail labels, or quality
+report exporters is enough to require eval instrumentation.
+Metrics-only coverage does not satisfy selected-trace eval visibility. Add or prove
+`gen_ai.evaluation.result` on the relevant workflow/evaluation span with
+`gen_ai.evaluation.name`, `gen_ai.evaluation.score.value` when numeric scores
+exist, `gen_ai.evaluation.score.label` when labels/verdicts exist, and safe
+parent linkage. Also add or prove detector-ready score distribution, pass/fail
+or violation count, sample count/rate, evaluator duration/error/no-data, and
+freshness by low-cardinality workflow/model/evaluation name. If the service
+only emits eval counters, histograms, logs, or report files, keep the evaluation quality surface partial
+and name the missing span-level eval event and remaining detector metrics.
+
+For MCP, JSON-RPC, and tool dispatch, normalize request metadata before adding
+attributes or metric dimensions. Never record JSON-RPC request IDs, raw request
+IDs, session IDs, trace IDs, user/account/tenant IDs, raw tool arguments, raw
+payloads, prompts, completions, or retrieved content as metric dimensions.
+Use stable method names only from an allowlist or from known route/tool registration; otherwise record a low-cardinality method family such as
+`known_tool`, `unknown_method`, `invalid_request`, or `unsupported_method`.
+
+Prefer detector-ready metrics and span attributes for outcome, duration,
+timeout, retry, rate-limit, fallback, active AI-owned sessions/streams, close
+reason family, send/write failure, freshness, empty/low-confidence retrieval,
+token budget, prompt build failure, response parse failure, AI-derived data
+freshness, prompt/tool schema version, model/config readiness,
+model/config compatibility, expected-vs-running model/config state, truncation,
+rejection, LLM-call fanout, tool-call fanout, evaluation score/outcome,
+memory hit/miss or staleness, content capture mode/redaction, app-owned cost
+source, and version dimensions when the service can observe them accurately.
+Use OTel GenAI semconv names when possible: `gen_ai.evaluation.result`,
+`gen_ai.evaluation.name`, `gen_ai.evaluation.score.value`,
+`gen_ai.evaluation.score.label`, safe `gen_ai.evaluation.explanation`, memory
+operation names such as `search_memory`, `create_memory`, `update_memory`,
+`upsert_memory`, and `delete_memory`, and opt-in content attributes such as
+`gen_ai.input.messages`, `gen_ai.output.messages`,
+`gen_ai.system_instructions`, `gen_ai.retrieval.documents`,
+`gen_ai.retrieval.query.text`, `gen_ai.tool.definitions`, and
+`gen_ai.tool.call.arguments`. Treat framework bridges as covered only when
+OTel-compatible GenAI semconv output and privacy settings are proven. Treat cost
+as custom app-owned instrumentation only when the app owns an accurate pricing map; otherwise owner-map the billing or provider source. Generic non-AI runtime,
+platform, or job surfaces are out of scope for this GenAI section unless source
+evidence shows they carry or block the AI pathway.
+If GenAI incident evidence depends on missed, flapping, auto-resolved, or no-data alerts, record detector reliability evidence as a `$splunk-configure`
+handoff instead of adding app metrics for alert lifecycle behavior.
+
+For AI-owned streaming generators, WebSocket/SSE handlers, callback bridges,
+or protocol send loops, do not call stream lifecycle coverage complete without
+a send/write failure signal. Add a counter, span event, or low-cardinality
+outcome attribute for send/write failure when app code can observe it; otherwise
+owner-map the missing source explicitly to the framework/server/platform.
+
+For token/context pressure gaps, `gen_ai.client.token.usage` plus a
+context-window usage gauge does not close a broader token-pressure gap unless
+the audit contract only requires those two signals. If `required_signals`
+include context budget percent, truncation rate, token-limit errors,
+prompt/tool schema size, LLM call count per turn, or tool call count per turn,
+mark the row partial until each signal is implemented, proven, or owner-mapped.
+When the user broadly asks for GenAI readiness without a preexisting audit
+contract, treat token/context pressure as requiring the same concrete signal
+check: token usage, context budget percent, truncation, token-limit errors,
+prompt/tool schema size or safe proxy, LLM-call count, and tool-call count when
+the app can observe them.
+Use this exact style when only token and context-window usage were added:
+`Partial: token usage and context window added; truncation, token-limit error, prompt/tool schema size, and LLM-call fanout remain missing.`
+
+If prompt/tool schema size cannot be measured safely, add a low-cardinality
+detector-ready proxy metric such as schema JSON length bucket, schema field count,
+prompt template length bucket, or tool count when the app can observe it.
+Span attributes like prompt template version, schema version, or one-off schema
+metadata help traces but do not close prompt/tool schema size pressure by themselves. If no safe metric or detector-ready existing signal exists, the
+closure matrix and final response must keep prompt/tool schema size in
+`remaining_signals` with the owner and missing source. Do the same for LLM-call
+and tool-call fanout: implement per-workflow counts when observable, prove an
+existing signal, or keep them explicitly partial.
+
+Final summaries, PR descriptions, and audit updates must not omit residual
+truncation, token-limit, prompt/tool schema size, LLM-call fanout, or
+tool-call fanout gaps when they were in the audit contract or when broad GenAI
+readiness instrumentation discovered the token/context surface.
+
+For tool/function execution, GenAI spans alone do not satisfy detector-ready
+tool coverage. When app code observes tool execution, add or prove a
+tool-specific duration histogram and tool error/timeout counter using a stable
+tool name and low-cardinality failure class. If only spans are safe, keep tool
+latency/error metrics in `remaining_signals` and do not claim detector-ready
+tool coverage.
+
+Do not call GenAI instrumentation complete when an app-owned provider/model,
+workflow, tool/function execution or AI-owned session/stream including MCP when
+present, retrieval, streaming, token/context, safety/policy, prompt/response,
+AI-derived data, memory/context, evaluation quality, content governance,
+framework bridge, app-computed cost, model/config rollout, or AI-owned
+cache/session surface remains only listed as a follow-up, unless the user
+explicitly narrowed scope.
 
 ### 2. Dependencies
 
@@ -98,6 +302,156 @@ Apply auto-instrumentation first, then add manual spans for key business operati
 - For local, Docker, and eval-style runtime checks, configure metric export to flush quickly. When constructing a metric reader manually, use the language equivalent of `OTEL_METRIC_EXPORT_INTERVAL` with a safe local default of `1000` ms and `OTEL_METRIC_EXPORT_TIMEOUT` with a safe local default of `500` ms instead of relying on SDK defaults.
 - Strictly adhere to OTel [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) for span and metric naming and attributes for domains where such semantic conventions are defined.
 - For domains where OTel semantic conventions exist, emit required spans and metrics only, with required attributes only. Do not emit spans or metrics that are marked optional, do not include attributes that are marked optional. Do not invent custom spans, metrics or attributes in domains where OTel semantic conventions exist.
+- For GenAI/LLM code, follow `../references/genai-readiness.md`: create
+  baseline distributed tracing plus OTel GenAI spans for inference,
+  `invoke_agent`, `invoke_workflow`, `plan`, `execute_tool`, `retrieval`, and
+  memory operations where code evidence exists; emit
+  `gen_ai.client.operation.duration` and
+  `gen_ai.client.token.usage` when the data is available; use stable tool names;
+  add low-cardinality `error.type`; and avoid raw prompt, completion, retrieved
+  content, memory record, tool argument, evaluation explanation, user, tenant,
+  session, task, request, trace, or raw URL values in metric dimensions.
+- For GenAI/LLM code, apply the `Single-Source GenAI Span Contract` before
+  adding manual spans. Inventory framework/vendor bridges, provider SDK hooks,
+  callbacks, middleware, auto-instrumentors, and existing app spans that can
+  emit GenAI telemetry. Choose one canonical GenAI span source per logical
+  operation: workflow, agent, model call, tool call, retrieval, memory operation, or
+  evaluation result. If a framework/vendor bridge already emits correct GenAI
+  semconv spans with lifecycle, privacy, model/tool attributes, and parent
+  context, keep that bridge and add only missing workflow/agent context,
+  aggregates, metrics, or owner mappings; do not create duplicate app-owned
+  `chat` or `execute_tool` spans for those same operations. If app-owned spans
+  are the canonical source, emit the complete app-owned span set and disable,
+  opt out of, or suppress overlapping framework/vendor GenAI instrumentation
+  using the discovered runtime mechanism, such as instrumentor names, bridge
+  settings, callback configuration, or provider-hook opt-out flags. Do not
+  hard-code this decision to one framework. Keep HTTP/database/runtime
+  auto-instrumentation when it does not create duplicate GenAI nodes.
+  When the process uses preload, agent, `opentelemetry-instrument`,
+  `NODE_OPTIONS --require`, or another auto-instrumentation bootstrap, apply
+  the suppression in the launch environment before the bootstrap runs. Update
+  the actual startup surfaces the repo uses, such as Makefile targets, service
+  runner scripts, Docker or Helm env, VS Code launch configs, procfiles,
+  systemd units, shell env generators, or generated env scripts. App module
+  code that mutates environment variables after import is only defense in depth
+  and is not sufficient proof because framework hooks may already be
+  registered.
+  Verification or static proof must show one GenAI node per logical operation,
+  no wrapper-only spans counted as tools, expected LLM/tool counts, stable
+  model/tool names, and workflow/agent parent shape such as
+  `invoke_workflow -> invoke_agent -> chat/execute_tool`. Required proof should
+  name stable model/tool names explicitly.
+- Preserve existing application stable business workflow identity when setting
+  `gen_ai.workflow.name` and workflow span names. Prefer constants, function or
+  handler names, workflow registrations, telemetry event names, docs, or prior
+  trace names. Do not derive GenAI workflow names from HTTP routes, request
+  resources, session/storage tables, or transport labels. If source evidence
+  shows a workflow is named `assistant_v3_turn`, keep `assistant_v3_turn`;
+  never rename it to `assistant_v3_session_turn`, `POST /v2/assistant/sessions`,
+  or another route/session-derived value. If the app has no stable workflow
+  identity, keep the HTTP route as the HTTP span and mark GenAI workflow
+  coverage partial instead of inventing a low-cardinality workflow name.
+  Do not invent names from HTTP routes or session-derived labels.
+- Preserve existing application stable agent identity when setting
+  `gen_ai.agent.name` and agent span names. Prefer framework agent names, agent
+  factory names, class names, registration names, callback owner names, docs, or
+  prior trace names. If source evidence shows a DeepAgents-backed agent, use the
+  discovered stable agent identity such as `deepagents`; never rename it to
+  `assistant_v3_agent`, `assistant`, `agent`, or another generic service-derived
+  wrapper name. If the app has no stable agent identity, keep agent coverage
+  partial instead of inventing one.
+- For app-owned LLM/model calls, apply the `LLM Inference Lifecycle Contract`.
+  Do not satisfy inference coverage with workflow-level token accounting,
+  final usage events, token usage, or model names only on the workflow span.
+  Add or prove a real model-call lifecycle span at the provider request
+  boundary: start before the call or stream starts, end after the
+  response/terminal stream event, and end with error status for exceptions,
+  cancellations, provider timeouts, or stream-close failures. In LangChain,
+  LangGraph, DeepAgents, callback, or event-stream based systems, hook
+  `on_chat_model_start`, `on_chat_model_end`, and `on_chat_model_error` or the
+  equivalent lifecycle callbacks. In direct SDK/model-gateway code, wrap the
+  provider call or streaming generator. The span must carry
+  `gen_ai.operation.name` such as `chat`, `generate_content`, or
+  `text_completion`, `gen_ai.provider.name`, `gen_ai.request.model` when known,
+  `gen_ai.response.model` when known, and token usage on that inference span
+  when provider usage is available.
+- Preserve the owning workflow/agent context for event-derived GenAI spans. In
+  callback, stream, LangChain, LangGraph, or DeepAgents integrations, capture
+  the workflow/agent context and use it when starting chat/model and tool
+  spans. Do not let callback-created `chat` or `execute_tool` spans attach to a
+  generic HTTP root span as siblings of the workflow. A representative trace
+  should prove a shape such as `workflow -> chat`, `workflow -> execute_tool`,
+  and follow-up `workflow -> chat` or `agent -> chat` edges.
+- Capture that workflow/agent context before opening long-lived helper/setup
+  spans such as memory store, checkpointer, database session, stream-writer,
+  resource setup, or lifecycle wrappers. These helper spans must not become the
+  parent for model/tool lifecycle spans. Event-derived `chat` and `execute_tool`
+  spans must use the captured workflow/agent context, not whichever helper span
+  happens to be current when a callback is translated. Store the workflow/agent
+  span object or context explicitly so stream cleanup writes aggregates to that
+  owner even if the current span has changed.
+  Use this rule for memory store, checkpointer, database session, stream-writer,
+  or resource setup paths: helper spans must not become the parent; capture the
+  workflow/agent context before opening helper spans, start event-derived `chat`
+  and `execute_tool` spans with that captured context, and write aggregate
+  counters to the workflow span, not to whichever current span is active.
+- In async generator, SSE, WebSocket, ping-loop, timeout-wrapper, or task handoff
+  paths that advance a stream with `create_task`, `wait`, `anext`, or equivalent
+  scheduling, do not keep an OpenTelemetry current-span context manager open
+  across yield/task boundaries. Start the workflow/agent span with an explicit
+  parent context, store a workflow span/context handle, pass that handle into the
+  callback/event translator, and end the workflow span manually after stream
+  cleanup.
+- When the captured workflow/agent context must travel through a request, turn
+  input, event payload, callback state, or config object that may be
+  immutable/frozen or owned by a framework, do not mutate that carrier in place.
+  Treat a carrier as immutable/frozen when source evidence shows frozen or
+  readonly declarations, record/value types, no mutation API, framework request
+  immutability patterns, or existing code constructs new copies instead of
+  mutating.
+  Use the app's idiomatic copy/replacement API: Python `dataclasses.replace`,
+  `attrs.evolve`, pydantic `model_copy(update=...)` or v1 `copy(update=...)`;
+  Java records, builders, or copy constructors; TypeScript object spread,
+  explicit `Readonly<T>` replacements, or `structuredClone` only for plain-data
+  carriers and never for live OTel `Context` or `Span` handles; Go value copies
+  with explicit field replacement; or the framework's request clone/with-context
+  API. If no safe copy path exists, use a separate invocation-scoped sidecar
+  context: a local object, context variable, request-scoped map, or callback
+  state keyed to the invocation lifecycle and cleared after cleanup. Do not key
+  sidecar context by raw user, tenant, session, request, or trace IDs. Add a
+  focused test, or explicit static proof when the repo has no test harness, that
+  proves the parent context is passed downstream and the original immutable
+  input remains unchanged; for Python, guard against `FrozenInstanceError`
+  regressions when a frozen dataclass or model is present.
+- Put aggregate selected-trace GenAI attributes on the workflow span or
+  most specific owning GenAI span, not on a generic HTTP root span or generic server span.
+  This includes `gen_ai.usage.input_tokens`,
+  `gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens`,
+  `assistant.llm.calls`, and `assistant.tool.calls`. The HTTP root can remain
+  the server entrypoint, but it should not become the evidence for a GenAI flow
+  card unless it is explicitly instrumented as the workflow span.
+- If runtime telemetry verification is unavailable, perform a static
+  instrumentation proof before claiming GenAI trace coverage: identify the
+  model-call source file, the lifecycle hook or client wrapper, the created
+  inference span name, required `gen_ai.*` attributes, parent-context handoff,
+  aggregate-attribute placement, end/error path, and a focused test or compile
+  check. If the proof shows only workflow-level usage attributes and no
+  inference span, or chat/tool spans that are siblings of the workflow under a
+  generic HTTP root span, keep the surface partial in `remaining_signals`.
+- For local span-first trace explorers such as Obstudio, metrics alone are not enough
+  for a selected-trace summary. When provider usage, model, tool,
+  memory, evaluation, or fanout data is available, also set safe span attributes
+  on the most specific GenAI span and aggregate to the workflow span when
+  useful: `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`,
+  `gen_ai.usage.total_tokens`, `gen_ai.request.model`,
+  `gen_ai.response.model`, service-owned LLM/tool call counts, stable
+  `gen_ai.tool.name`, memory operation names, evaluation names/labels, and
+  low-cardinality `error.type`.
+- For assistant, agent, or streaming workflows, instrument first non-ping event
+  or first chunk latency, timeout, cancellation, disconnect, close reason
+  family, and send/write failure. Normalize timeout classes such as
+  `first_event_timeout` instead of relying only on framework exception class
+  names, while still recording the exception on the span.
 - For custom attribute names use `{domain}.{noun}.{adjective}` format.
 - Span names must be low-cardinality (no IDs, no variable path segments).
 - Metric attributes must avoid high cardinality.
@@ -151,6 +505,12 @@ After auto-instrumentation is wired up, prompt the user:
 
 Then wait for the user's answer.
 
+Skip this prompt when the user already asked for GenAI/LLM workflow
+instrumentation, a specific GenAI custom signal, or when the Audit-Driven GenAI
+Readiness path applies. In those cases, the user's request and audit gaps are
+the approval context; implement the safe scoped signals and clearly list any
+unpatched prerequisites.
+
 - **If no**: proceed to the build check (Step 5).
 - **If yes**: analyze the codebase for high-value custom instrumentation points:
   - Error handling paths that catch and handle exceptions
@@ -158,6 +518,11 @@ Then wait for the user's answer.
   - External calls not covered by auto-instrumentation libraries
   - Background workers and scheduled jobs
   - Cache interactions without auto-instrumentation support
+  - GenAI/LLM workflow boundaries: workflow span, agent/workflow invocation,
+    LLM inference, tool/function execution, MCP method dispatch when present,
+    retrieval, fallback, token usage, model/config readiness, prompt/response
+    parse outcome, safety/policy outcome, AI-derived data freshness, and
+    AI-owned session/stream lifecycle when code evidence exists
   - Suggest specific spans and metrics with names, attributes, and rationale
   - Apply after user approval
 
@@ -179,6 +544,13 @@ the user asks for verification or approves it after being asked.
 7. If verification fails, fix issues caused by the instrumentation and report
    anything outside scope.
 
+When the user or eval task asks to add tests, checks, or verification evidence
+for GenAI instrumentation, add or update the lightest practical test or check
+that exercises the new telemetry paths. For small Python demo apps, prefer a
+focused pytest file when feasible; otherwise extend the existing Makefile check
+and run it. Do not rely on unrun compile targets as evidence when the task asks
+for tests.
+
 ### 6. Enable Debugging in VS Code
 
 This step is REQUIRED whenever `.vscode/launch.json` exists.
@@ -195,8 +567,22 @@ This step is REQUIRED whenever `.vscode/launch.json` exists.
 ### 7. Finalize
 
 - In the final response, separate file changes from verified outcomes
+- Include an instrumentation delta summary with added, modified, and deleted
+  traces/spans, metrics, logs/events, runtime/config, and dependencies. If no
+  prior report existed, state that the run established the baseline.
 - If verification is partial, say exactly what is working and what is still missing instead of reporting full success
 - Always include the service-name configuration, OTLP endpoint configuration, and which automatic spans/metrics are expected from the instrumentation.
+- For GenAI work, state which OTel GenAI operations were instrumented, which
+  GenAI metrics are expected, whether trace continuity should produce a nested
+  workflow/agent/tool/chat/retrieval shape, and which privacy/cardinality limits
+  were enforced.
+- For GenAI incident-evidence work, include a concise coverage summary by
+  incident class or repo surface: MTTD-improving, localization-only, or
+  uncovered. Name any remaining provider/model, workflow, tool/function
+  execution or AI-owned session/stream including MCP when present, retrieval,
+  streaming, token/context, prompt/response, safety/policy, AI-derived data,
+  model/config rollout, or AI-owned cache/session owner that still blocks
+  detector-ready coverage.
 
 ## Credential Safety
 

--- a/skills/otel-instrument/references/signal-mapping-guide.md
+++ b/skills/otel-instrument/references/signal-mapping-guide.md
@@ -57,3 +57,21 @@ When adding log events that should correlate with traces:
 - `{component}.{entity}.{action}` for state changes: `opamp.agent.registered`
 - `{component}.{operation}.{outcome}` for results: `broker.publish.failed`
 - `{component}.{resource}.{condition}` for alerts: `health.agent.status_changed`
+
+---
+
+## GenAI Signal Mapping
+
+For GenAI/LLM code, use the shared `../../references/genai-readiness.md` as the source of
+truth. The most important local trace-view rule is: metrics are not enough for
+single-trace demos. Emit the OTel metric when available, and also add safe
+summary attributes to the relevant span.
+
+| Need | Signal |
+|---|---|
+| Show agent flow | spans with `gen_ai.operation.name` and nested parent/child context |
+| Show model call | `chat {model}` span with provider and request/response model attributes |
+| Show token pressure | `gen_ai.client.token.usage` metric plus `gen_ai.usage.*_tokens` span attributes |
+| Show tool work | `execute_tool {tool}` span with stable `gen_ai.tool.name` |
+| Explain streaming timeout | workflow span status ERROR, `error.type`, first-event/chunk latency, stream close reason |
+| Build detectors | low-cardinality workflow/provider/model/tool outcome, latency, error, timeout, token, fanout, and stream lifecycle metrics |

--- a/skills/references/genai-readiness.md
+++ b/skills/references/genai-readiness.md
@@ -1,0 +1,619 @@
+# GenAI Readiness Reference
+
+Load this reference when a repo contains LLM, agent, workflow, tool/function
+calling, retrieval/RAG, model gateway, or model-provider code, or when the user
+asks about GenAI/LLM incident detection, debugging, or alerting.
+
+## Goal
+
+Create traces and metrics that can explain GenAI incidents quickly:
+workflow latency, provider failure, model/config mismatch, excessive LLM/tool
+fanout, token/context pressure, broken tools, retrieval degradation, fallback
+behavior, prompt/response parsing failures, AI-derived data freshness,
+model/prompt/tool-schema compatibility, evaluation quality regressions, unsafe
+content capture, memory/context degradation, cost spikes, and AI-path capacity
+or state pressure.
+
+Use OpenTelemetry GenAI semantic conventions first. Add custom attributes only
+for service-owned workflow context when no OTel convention exists. Keep this
+reference scoped to AI pathways. Generic app surfaces such as streams, jobs,
+synthetic/canary checks, startup/deployment compatibility, input complexity,
+capacity, and release context belong here only when source evidence shows they
+exercise, carry, or block an AI workflow.
+
+## Obstudio GenAI Trace UI Contract
+
+Obstudio's GenAI trace view is span-first. If a value exists only in a metric
+stream, the trace view may not be able to summarize it for one selected trace.
+For a demoable selected-trace summary, emit both the detector metric and safe
+span-level attributes when the service can observe the value.
+
+| UI evidence | Required telemetry |
+|---|---|
+| GenAI trace detection | At least one span with `gen_ai.operation.name` |
+| Workflow card | Span `invoke_workflow {workflow}` with `gen_ai.operation.name=invoke_workflow` and `gen_ai.workflow.name` |
+| Agent card | Span `invoke_agent {agent}` with `gen_ai.operation.name=invoke_agent` and `gen_ai.agent.name` |
+| LLM/chat card | Span `chat {model}` or another GenAI inference operation with `gen_ai.operation.name=chat`, `gen_ai.provider.name`, `gen_ai.request.model`, and `gen_ai.response.model` when known |
+| Tool card | Span `execute_tool {tool}` with `gen_ai.operation.name=execute_tool` and stable `gen_ai.tool.name` |
+| Retrieval card | Span `retrieval {source}` with `gen_ai.operation.name=retrieval` and a low-cardinality data source attribute |
+| Tokens summary | `gen_ai.client.token.usage` metric with `gen_ai.token.type`; also set `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, and `gen_ai.usage.total_tokens` on the chat span or workflow span when available |
+| LLM/tool call counts | Service-owned per-workflow attributes or metrics such as `assistant.llm.calls` and `assistant.tool.calls`, plus child spans when possible |
+| Error badges | Span status ERROR plus low-cardinality `error.type` |
+| Streaming timeout explanation | First event/chunk latency, stream close reason family, timeout/cancel/disconnect events, and workflow ERROR with `error.type=first_event_timeout` or another stable class |
+
+If an audit gap mentions a local trace summary, Obstudio view, selected trace,
+or demo trace, treat span-level selected-trace summary attributes as required
+acceptance criteria in addition to detector metrics.
+
+Do not put selected-trace aggregate GenAI usage on a generic HTTP root span or
+generic server span. Attributes such as `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens`,
+`assistant.llm.calls`, and `assistant.tool.calls` belong on the workflow span or
+the most specific owning GenAI span. A root HTTP span may wrap the whole request,
+but it should not become a GenAI flow card unless it is explicitly the workflow
+span with `gen_ai.operation.name=invoke_workflow`.
+
+Workflow names must preserve the application's stable business workflow
+identity. Prefer existing constants, handler names, telemetry event names,
+workflow registrations, docs, or prior trace names over route-derived or
+session-derived labels. Do not invent names from HTTP routes, transport
+resources, or storage/session concepts. For example, an assistant turn workflow
+that is already named `assistant_v3_turn` must stay `assistant_v3_turn`; do not
+rename it to `assistant_v3_session_turn`, `POST /v2/assistant/sessions`, or
+another request/route-derived value. If no stable workflow identity exists,
+name the route as the HTTP span only and keep GenAI workflow coverage partial
+until the app owner supplies or accepts a stable low-cardinality workflow name.
+
+Agent names must preserve the application's stable agent identity with the same
+discipline. Prefer framework agent names, agent factory names, class names,
+registration names, callback owner names, docs, or prior trace names over
+generic service-derived labels. For example, a DeepAgents-backed agent should be
+named `deepagents` when that is the discovered agent identity; do not rename it
+to `assistant_v3_agent`, `assistant`, `agent`, or another generic wrapper name.
+If no stable agent identity exists, keep the agent row partial instead of
+inventing a generic GenAI agent name.
+
+## Single-Source GenAI Span Contract
+
+Use one canonical GenAI span source per logical operation. Before adding manual
+workflow, agent, chat, tool, retrieval, memory, or evaluation spans, inventory
+existing framework/vendor bridges, provider SDK hooks, callbacks, middleware,
+and auto-instrumentors that can already emit OTel GenAI spans for the same
+operation. A representative trace should have one GenAI node per logical
+operation: workflow, model call, tool call, retrieval, memory operation, or
+evaluation result, not both a framework wrapper span and an app-owned duplicate
+for the same work.
+
+If the framework/vendor bridge is the canonical source, keep it and add only
+missing app-owned workflow/agent context, safe aggregate attributes, metrics,
+or owner mappings. Do not add duplicate app-owned `chat` or `execute_tool`
+spans for operations that the bridge already emits with correct semconv,
+privacy, model/tool attributes, lifecycle, and parent context.
+
+If app-owned spans are the canonical source, add the complete app-owned
+workflow/agent/chat/tool/retrieval/memory/evaluation spans and disable, opt out
+of, or suppress overlapping framework/vendor GenAI instrumentation in that
+process. The exact mechanism is runtime-specific: use discovered instrumentor
+names, bridge settings, callback configuration, or provider-hook opt-out flags
+instead of hard-coding one framework. Keep baseline HTTP/database/runtime
+instrumentation when it does not create duplicate GenAI nodes.
+For preload, javaagent, `opentelemetry-instrument`, `NODE_OPTIONS --require`,
+or similar auto-instrumentation bootstraps, suppression must be configured in
+the launch environment or startup wrapper before the bootstrap runs; otherwise
+framework hooks may already be registered. App module code that mutates
+environment variables after bootstrap is only defense in depth and is not
+sufficient proof. Update the real startup surfaces that operators use, such as
+Makefile targets, service runner scripts, Docker or Helm env, VS Code launch
+configs, procfiles, systemd units, shell env generators, or generated env
+scripts.
+
+Mark trace/semconv coverage `partial` when a selected trace shows duplicate
+GenAI nodes for the same logical operation, middleware or step-wrapper spans
+counted as tools, framework and app spans racing for parentage, or divergent
+aggregate counts. Closure proof requires one canonical GenAI span source per
+logical operation. The selected trace must show one GenAI node per logical
+operation, correct parent shape, expected LLM and tool counts, stable model/tool
+names, and no wrapper-only spans counted as GenAI work. Required proof should
+name stable model/tool names explicitly.
+
+## LLM Inference Lifecycle Contract
+
+Do not treat workflow-level token accounting as proof of LLM inference
+instrumentation. A repo that owns a model call needs a model-call lifecycle span
+at the code path that starts and finishes the provider call.
+
+Required proof for each app-owned model-call surface:
+
+- A low-cardinality inference span such as `chat {model}`,
+  `generate_content {model}`, or `text_completion {model}` starts before the
+  provider/model gateway request and ends after the response, stream terminal
+  event, or error.
+- The span has `gen_ai.operation.name` set to the actual inference operation,
+  plus `gen_ai.provider.name`, `gen_ai.request.model` when the requested model
+  is known, and `gen_ai.response.model` when the response model is known.
+- Provider usage is recorded on the inference span when available:
+  `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, and
+  `gen_ai.usage.total_tokens`; aggregate to the workflow span only as a
+  summary, not as a replacement for the inference span.
+- Errors, cancellations, provider timeouts, rate limits, and stream-close
+  failures set span error status, record the exception when available, and set
+  low-cardinality `error.type`.
+- Parent context links the inference span under the owning agent, workflow,
+  model gateway, or tool span so selected-trace UIs can render the call path.
+
+For event-derived instrumentation, preserve the owning workflow/agent context.
+Capture or re-enter that context when handling callback events so model and tool
+spans do not attach to the HTTP root span as siblings of the workflow. A
+representative trace must show the intended trace shape, for example
+`workflow -> chat`, `workflow -> execute_tool`, and any follow-up
+`workflow -> chat` or `agent -> chat` edges. If chat/tool spans exist but are
+siblings of the workflow under a generic server span, mark the surface
+`partial` and keep parent-context propagation in `remaining_signals`.
+
+Be explicit about long-lived helper/setup spans. Memory-store setup, checkpointer
+setup, database session spans, stream-writer spans, and other helper/setup spans
+may be active while callback events are translated. They must not become the
+parent for model/tool lifecycle spans, and they must not receive selected-trace
+aggregate attributes. Capture the workflow/agent context before opening those
+helpers, start event-derived `chat` and `execute_tool` spans with that captured
+context, and write aggregate counters/tokens to the captured workflow/agent span
+object rather than using whatever current span is active during stream cleanup.
+Use this rule for memory store, checkpointer, database session, stream-writer,
+or resource setup paths: helper spans must not become the parent; capture the
+workflow/agent context before opening helper spans, start event-derived `chat`
+and `execute_tool` spans with that captured context, and write aggregate
+counters to the workflow span, not to whichever current span is active.
+For async generator, SSE, WebSocket, ping-loop, timeout-wrapper, or task handoff
+paths that advance a stream with `create_task`, `wait`, `anext`, or equivalent
+scheduling, do not keep an OpenTelemetry current-span context manager open across
+yield/task boundaries. Start the workflow span with an explicit parent context,
+store a workflow span/context handle, pass that handle into the callback/event
+translator, and end the span manually after the stream closes.
+When that workflow/agent context has to cross a request, turn input, event
+payload, callback state, or config object that may be immutable/frozen, do not
+mutate the carrier in place. Treat a carrier as immutable/frozen when source
+evidence shows frozen or readonly declarations, record/value types, no mutation
+API, framework request immutability patterns, or existing code constructs new
+copies instead of mutating. Use an idiomatic copy/replacement API such as Python
+`dataclasses.replace`, `attrs.evolve`, pydantic `model_copy(update=...)` or v1
+`copy(update=...)`; Java records, builders, or copy constructors; TypeScript
+object spread, explicit `Readonly<T>` replacements, or `structuredClone` only
+for plain-data carriers and never for live OTel `Context` or `Span` handles; Go
+value copies with explicit field replacement; or the framework's request
+clone/with-context API. If no safe copy path exists, store the span/context
+handle in a separate invocation-scoped sidecar context: a local object, context
+variable, request-scoped map, or callback state keyed to the invocation
+lifecycle and cleared after cleanup. Do not key sidecar context by raw user,
+tenant, session, request, or trace IDs. Tests or explicit static proof must show
+the parent context is passed downstream and the original immutable input remains
+unchanged; in Python, cover `FrozenInstanceError` risk when a
+frozen dataclass or model is present.
+
+Framework bridges must be checked at the real lifecycle hook:
+
+- LangChain, LangGraph, DeepAgents, and callback/event-stream based systems:
+  instrument `on_chat_model_start`, `on_chat_model_end`, and
+  `on_chat_model_error` or the equivalent callback lifecycle. Do not rely on
+  final usage events such as `usage.total`, response aggregation, or
+  turn-finalization events by themselves.
+- Direct provider SDKs and model gateways: wrap the client call or streaming
+  generator that sends the model request, not only the outer HTTP route or
+  workflow function.
+- Streaming responses: keep the inference span open until the model stream
+  completes or fails, and record first chunk latency, finish reason, and
+  stream close reason when observable.
+
+Acceptance gate: for a representative prompt that reaches a model, the trace
+must contain at least one inference span with `gen_ai.operation.name` equal to
+`chat`, `generate_content`, `text_completion`, or another valid GenAI
+inference operation. If token/model attributes exist only on a workflow span
+and no inference span exists, mark the surface `partial` and keep the missing
+model-call lifecycle span in `remaining_signals`. If inference spans exist but
+are parented to a generic HTTP root span instead of the owning workflow/agent
+span, mark the surface `partial` until the trace shape proves the correct
+parent context.
+
+## GenAI Semconv Source Contract
+
+Before auditing or instrumenting GenAI code, reconcile detected AI surfaces
+against the current official OpenTelemetry GenAI semantic conventions.
+
+Source order:
+
+1. `live official docs` from `open-telemetry/semantic-conventions-genai` when
+   network access is available.
+2. The bundled semconv snapshot in this reference when live docs cannot be
+   fetched.
+
+Check only relevant docs:
+
+- Always check the GenAI README, model spans, agent spans, and metrics docs.
+- Check GenAI events when content/event capture, evaluation, or logs are in
+  scope.
+- Check MCP docs when MCP client or server code is present.
+- Check provider-specific docs only when that provider is detected in code or
+  config.
+
+Record provenance in audit and instrument output:
+`GenAI semconv source -> repo/branch-or-commit/docs/date/live-or-snapshot`.
+
+Build a semconv closure matrix before declaring coverage:
+`surface -> official operation -> required attrs -> recommended attrs ->
+metrics/events -> implemented -> proven existing -> remaining`.
+
+Do not claim current semconv coverage unless every detected GenAI surface is
+implemented, proven existing, or explicitly marked unavailable with owner and
+source. Local operation and metric lists are examples only. If live official
+docs disagree with bundled guidance, official docs win, while this skill's
+privacy/cardinality rules remain enforced.
+
+## Audit Checklist
+
+- LLM/provider clients: hosted model APIs, OpenAI-compatible APIs, cloud model
+  services, local or self-hosted model servers, model gateways, SDK wrappers.
+- GenAI workflow code: assistant/chat endpoints, agent orchestration, workflow
+  engines, tool/function dispatch, MCP servers/clients, RAG/retrieval paths.
+- Framework bridges: LangChain, LangGraph, CrewAI, Strands, LlamaIndex,
+  OpenInference, TraceLoop/OpenLLMetry, ADOT, and provider/framework OTel hooks.
+- Model/config code: requested model, resolved response model, deployment name,
+  provider/region selection, fallback policy, config version, readiness checks.
+- Token/context pressure: input/output token counts, cache read/create tokens,
+  prompt/context byte size, tool-call count, LLM-call count per workflow.
+- Memory/context paths: memory store create/search/read/write/upsert/delete,
+  context assembly, conversation/session state, AI cache state, and
+  stale/missing context handling.
+- Evaluation quality: LLM-as-judge, offline eval, online eval, human feedback,
+  scoring, labels, explanations, sample rate, evaluator failures, and freshness.
+- Cost accounting: provider usage-to-cost mapping, per-request/model/provider
+  cost, billing export, quota/budget guardrails, or owner-mapped billing source.
+- Prompt and response assembly: prompt/template version, response schema version,
+  prompt build errors, response parse errors, payload size bucket, and workflow
+  source without recording content.
+- AI-derived data jobs: embedding/index refresh, evaluation, feedback, export,
+  dataset refresh, prompt/cache population, and other AI-owned derived data
+  paths.
+- Model/config paths: requested model, response model, deployment readiness,
+  prompt/tool schema version, feature flag, rollout/canary batch, and
+  expected-vs-running model or config state.
+- Error and timeout classes: timeout, rate limit, throttle, provider 5xx,
+  content/filter rejection, model unavailable, model not found, tool failure.
+- Privacy: raw prompts, completions, retrieved documents, tool arguments, user
+  identifiers, tenant identifiers, secrets, and evaluation explanations must not
+  be recorded by default.
+
+## Incident-Evidence Mode
+
+Use this mode when incidents, postmortems, alerts, tickets, or user-provided
+failure examples involve GenAI, LLM, assistant/chat workflows, agent, MCP, RAG,
+model gateway, tool/function, or streaming response behavior.
+
+Build a coverage matrix before editing:
+
+```text
+incident class -> failure mechanism -> repo/service owner -> code surface -> signal -> MTTD impact -> remaining owner
+```
+
+- Classify the failure mechanism, not only the symptom. For example, separate
+  provider timeout, model/config rollout mismatch, tool serialization failure,
+  retrieval freshness, stream lifecycle leak, token/context limit, safety
+  refusal spike, prompt/response parse failure, stale AI-derived data,
+  missing synthetic/canary coverage of an AI path, and queue/capacity pressure
+  in an AI gateway or tool runtime.
+  Treat detector reliability evidence as relevant when alert behavior is part
+  of the incident evidence.
+- Mark a signal **MTTD-improving** only when it can drive a detector before or
+  at first customer impact. Mark it **localization-only** when it mainly helps
+  root-cause after another alert fires.
+- Add or prove low-cardinality spans and metrics in the owning surface:
+  provider/model gateway, agent orchestrator, workflow engine, tool/function or
+  session/stream dispatcher, MCP dispatcher when present, retriever/vector
+  store, streaming adapter, queue/worker, cache/session store,
+  safety/content filter, prompt/response parser, AI-derived data job, or
+  model/config resolver. Include lifecycle, job, synthetic/canary,
+  startup/deployment, input-complexity, capacity, and release/config signals
+  here only when the evidence shows they exercise or block an AI pathway.
+- Do not call GenAI instrumentation complete while any app-owned GenAI provider,
+  model/config, tool/session/stream lifecycle including MCP when present,
+  retrieval, streaming, token/context, safety/policy, prompt/response parser,
+  AI-derived data job, model rollout, or AI-owned state surface remains only
+  listed as a follow-up, unless the user explicitly narrows scope. Non-AI
+  generic readiness surfaces should be called out as out of scope rather than
+  treated as GenAI completion criteria.
+
+## Token/Context Pressure Contract
+
+When audit identifies token/context pressure, context-window exhaustion, prompt
+growth, tool-schema bloat, or per-turn fanout as a gap, treat the audit ledger
+as the required signal contract. Do not close the gap just because one token
+metric or context-window gauge was added.
+
+Required signals should be listed separately when the repo can observe them:
+
+- context budget percent.
+- truncation rate.
+- token-limit errors.
+- prompt/tool schema size.
+- LLM call count per turn.
+- tool call count per turn.
+- input and output token usage through `gen_ai.client.token.usage` when
+  provider usage data is available.
+
+If only token usage and context-window usage are implemented, mark the ledger
+row as partial instead of filled. Use explicit wording such as: `Partial: token usage and context window added; truncation, token-limit error, prompt/tool schema size, and LLM-call fanout remain missing.`
+
+Prompt/tool schema pressure is detector-ready only when it is implemented or
+proven as a metric or equivalent detector source, for example schema JSON length bucket,
+schema field count, prompt template length bucket, or tool count. Span attributes such as prompt template version,
+schema version, or isolated schema metadata are trace context; they do not close prompt/tool schema size pressure unless a detector can consume them as a stable signal. If the code cannot safely
+emit such a signal, keep prompt/tool schema size in `remaining_signals` and name
+the owner or missing source.
+
+Every GenAI instrumentation result should include a closure summary in the final
+response. `Remaining signals: none` is allowed only when each required GenAI
+signal is implemented, proven existing, or owner-mapped. Otherwise list the
+partial GenAI signals explicitly.
+
+## Required GenAI Surface Patterns
+
+When code evidence exists, audit and instrument these surfaces before declaring
+GenAI readiness complete:
+
+- **Provider/model gateway:** request/response model, deployment, provider,
+  region, endpoint health, latency, timeout, retry, rate-limit/throttle,
+  provider 5xx, circuit-breaker state, fallback/failover outcome,
+  streaming first chunk latency, chunk cadence, partial completion, finish reason,
+  failover readiness, fallback target readiness, content-filter or refusal
+  outcome.
+- **Agent/workflow orchestration:** workflow outcome and duration, step count,
+  LLM-call count, tool-call count, retry/fallback branch, cancellation, timeout,
+  recursion/depth guard, fanout, workflow name, workflow mode, feature flag,
+  synthetic transaction outcome, and model/config version.
+- **Tool/function execution and AI-owned sessions/streams:** stable tool or
+  function name, MCP method name when present, authentication/authorization
+  result, invalid-token or permission failure outcome, validation and
+  serialization errors, tool start/success/error/timeout, output count or size,
+  downstream dependency outcome, active sessions/streams, close reason family,
+  stream duration/outcome, send/write failure, and session/stream lifecycle
+  signals when the AI path owns a long-lived tool/session/stream.
+  Tool execution spans alone are not detector-ready tool coverage. Prefer a
+  tool-specific duration histogram and tool error/timeout counter by stable
+  tool name and low-cardinality failure class when the app owns execution.
+  MCP/JSON-RPC request IDs, raw request IDs, session IDs, trace IDs, raw
+  payloads, prompts, completions, retrieved content, tool arguments, users,
+  accounts, and tenants are not safe metric dimensions. Use stable tool or method names from known registration only; otherwise bucket method values into
+  low-cardinality families such as `known_tool`, `unknown_method`,
+  `invalid_request`, or `unsupported_method`.
+- **RAG/retrieval:** embedding call outcome, vector/search dependency outcome,
+  retrieval count, empty or low-confidence result, top-k, index/corpus/config
+  version, freshness or last-ingest age, and cache hit/miss.
+- **Token/context/cost pressure:** input, output, and cached tokens; context
+  length or bytes; budget percent; truncation; token-limit errors; and
+  per-workflow aggregated tokens and LLM calls. Use `gen_ai.client.token.usage`
+  and provider/model attributes as the semconv source of usage. If the
+  application owns an accurate pricing map, add a low-cardinality custom cost
+  metric by workflow/provider/model and currency. If cost is computed by billing
+  exports, provider dashboards, or finance systems, owner-map the exact source
+  instead of inventing approximate in-process cost. Include payload size, input
+  complexity, item count, or metadata-count signals only when they describe the
+  AI prompt/context/tool path.
+- **Prompt/response assembly:** prompt/template version, response schema or tool
+  schema version, prompt build outcome, input validation failure, response parse
+  failure, malformed or partial response outcome, payload size bucket, and
+  workflow name/source included in low-cardinality payload metadata.
+- **Safety/policy:** content-filter, refusal, moderation, guardrail, and policy
+  outcome by stable policy class. Do not capture raw prompt, completion, or
+  retrieved content.
+- **AI-derived data freshness:** embedding/index refresh, evaluation, feedback,
+  export, dataset refresh, prompt/cache population, record count,
+  empty/partial result, destination outcome, drop reason, and schedule lag.
+  Include job duration, last-success age, retry, backlog, and delivery/publish
+  outcome when the job produces or refreshes AI-owned data.
+- **Memory/context and AI runtime state overlay:** model warmup, model cache
+  health, memory store create/search/read/write/upsert/delete, context assembly,
+  conversation/session state, stale or missing context, per-session AI resource
+  pressure, queue/capacity pressure in an AI gateway or tool runtime, and
+  cache/session state that affects AI workflow correctness. Prefer GenAI memory
+  operation names such as `create_memory_store`, `search_memory`,
+  `create_memory`, `update_memory`, `upsert_memory`, `delete_memory`, and
+  `delete_memory_store` when applicable. Include CPU, memory, disk, thread pool,
+  restart/crashloop, and runtime health signals only when they are emitted by or
+  scoped to the AI gateway/tool runtime.
+- **Model/config compatibility:** requested model, response model, model or
+  deployment readiness, prompt/template version, tool schema version,
+  index/corpus version, workflow mode, feature flag, config version,
+  rollout/canary batch, and expected-vs-running model or AI config state.
+- **AI-path readiness overlays:** synthetic/canary, stream, offline/derived
+  job, input-complexity, capacity, release, and deployment signals are GenAI
+  readiness signals only when repo evidence shows they exercise, carry, or
+  block an AI pathway. Treat missing AI-path coverage as synthetic/canary workflow-check blind spots.
+  When incidents mention missed, flapping, auto-resolved, or no-data alerts,
+  capture detector reliability evidence for `$splunk-configure`.
+
+## Evaluation Quality Contract
+
+When evaluator, scoring, feedback, or LLM-as-judge code exists, treat quality as
+a GenAI surface. Prefer the OTel event `gen_ai.evaluation.result` with:
+
+- `gen_ai.evaluation.name`.
+- `gen_ai.evaluation.score.value` when the evaluator returns a numeric score.
+- `gen_ai.evaluation.score.label` when the evaluator returns a label, verdict,
+  pass/fail state, or bucket.
+- `gen_ai.evaluation.explanation` only when content governance allows it.
+- `gen_ai.response.id` or parent span linkage when available.
+
+Add detector-ready app metrics when events are not detector-ready: score
+distribution, pass/fail or violation count, sample count/rate, evaluator
+duration/error/no-data, and evaluation freshness by low-cardinality
+workflow/model/evaluation name. Do not mark evaluation quality complete when the
+repo only emits job freshness, counters/histograms without
+`gen_ai.evaluation.result`, or free-form evaluation text in logs or reports.
+Metrics-only coverage does not satisfy selected-trace eval visibility.
+
+## Content Capture Governance Contract
+
+Semconv supports prompt, response, system instruction, retrieval document, and
+tool definition/argument content through opt-in attributes such as
+`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`,
+`gen_ai.retrieval.documents`, `gen_ai.retrieval.query.text`,
+`gen_ai.tool.definitions`, and `gen_ai.tool.call.arguments`. These fields are
+sensitive.
+
+Audit content capture as `disabled`, `metadata-only`, `redacted`, or
+`full-content`. Instrumentation must default to no raw content. If content is
+explicitly required, require an opt-in config, redaction/truncation hook, storage
+destination, retention/access owner, and trace/log correlation evidence. Never
+put raw content, identifiers, retrieved documents, URLs, tool arguments, memory
+records, or evaluation explanations in metric names, metric dimensions, detector
+group-bys, or span names.
+
+## Framework Bridge Contract
+
+Before adding custom GenAI wrappers, detect framework or provider bridges such
+as LangChain, LangGraph, CrewAI, Strands, LlamaIndex, OpenInference,
+TraceLoop/OpenLLMetry, ADOT, provider SDK hooks, or MCP instrumentation. Treat a
+bridge as covered only when it is configured to emit OTel-compatible GenAI
+semconv spans/events/metrics, the emitted signal names are proven, and the
+privacy/content settings are understood. Otherwise add missing app-owned signals
+around the owned workflow boundaries and owner-map the bridge/platform gaps.
+
+## Trace Shape
+
+A mature GenAI trace should show the app workflow as the parent and GenAI work
+as children:
+
+```text
+service workflow span
+  agent/workflow span
+    tool execution span
+      nested service workflow span
+        LLM inference span
+        retrieval span
+        nested agent/workflow span
+          LLM inference span
+```
+
+This requires baseline distributed tracing in addition to GenAI semconv:
+`service.name`, environment/version resource attributes, HTTP/job spans, W3C
+context propagation across services/workers/tools, error status, and OTLP export.
+
+For compact local demos, preserve this minimum shape:
+
+```text
+HTTP or job span
+  invoke_workflow assistant_turn
+    invoke_agent planner
+      chat gpt-5.5
+      execute_tool search
+      retrieval vector_store
+      chat gpt-5.5
+```
+
+## Span Conventions
+
+Use stable, low-cardinality span names:
+
+| Operation | Span name | Required/safe attributes |
+|---|---|---|
+| LLM inference | `{gen_ai.operation.name} {gen_ai.request.model}` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` if available, `gen_ai.response.model` if available |
+| Agent invocation | `invoke_agent {gen_ai.agent.name}` | `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name`; provider fields for remote agents when available |
+| Workflow invocation | `invoke_workflow {gen_ai.workflow.name}` | `gen_ai.operation.name=invoke_workflow`, `gen_ai.workflow.name` when the framework has a real workflow concept |
+| Planning | `plan {gen_ai.agent.name}` or `plan` | `gen_ai.operation.name=plan`, stable agent/workflow name when available; never raw chain-of-thought |
+| Tool execution | `execute_tool {gen_ai.tool.name}` | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name` |
+| Retrieval | `retrieval {gen_ai.data_source.id}` | `gen_ai.operation.name=retrieval`, data source id/name only when low-cardinality |
+| Memory/context | `{gen_ai.operation.name}` | `gen_ai.operation.name` set to `create_memory_store`, `search_memory`, `create_memory`, `update_memory`, `upsert_memory`, `delete_memory`, or `delete_memory_store` when applicable |
+
+Use predefined `gen_ai.operation.name` values when they apply: `chat`,
+`generate_content`, `text_completion`, `embeddings`, `invoke_agent`,
+`invoke_workflow`, `plan`, `execute_tool`, `retrieval`, `create_memory_store`,
+`search_memory`, `create_memory`, `update_memory`, `upsert_memory`,
+`delete_memory`, and `delete_memory_store`.
+
+For failed GenAI spans, set span status to error and record `error.type` with a
+low-cardinality class such as `timeout`, `rate_limit`, `provider_5xx`,
+`model_not_found`, `model_unavailable`, `tool_error`, or `content_filter`.
+
+## Metrics
+
+Prefer OTel GenAI metrics where data is available:
+
+- `gen_ai.client.operation.duration` for latency by operation/provider/model.
+- `gen_ai.client.token.usage` for input/output token histograms with
+  `gen_ai.token.type`.
+- `gen_ai.client.operation.time_to_first_chunk` and
+  `gen_ai.client.operation.time_per_output_chunk` for streaming workflows.
+
+Do not report token metrics when token counts cannot be obtained efficiently or
+accurately. When providers distinguish billable tokens from raw used tokens,
+report billable tokens.
+
+Add service-owned metrics only when OTel has no convention:
+
+- workflow duration and outcome by workflow/surface/environment.
+- LLM-call count and tool-call count per workflow request.
+- model/config readiness failures by failure class.
+- fallback selected, fallback failed, and region/provider failover outcomes.
+- evaluation score distributions, pass/fail counts, sample counts, evaluator
+  error/no-data, and evaluation freshness when evaluation events are not directly
+  detector-ready.
+- memory/context operation duration, outcome, hit/miss, stale/missing context,
+  record count bucket, source/version, and permission/auth failure when
+  app-owned.
+- queue depth, memory, restart, and worker saturation for GenAI gateways/tools.
+
+Do not use conversation, user, account, tenant, request, session, task, trace, or
+raw tool argument values as metric dimensions.
+
+## Detector and Dashboard Intents
+
+Map incident patterns to concrete signals:
+
+| Incident pattern | Detection/localization signal |
+|---|---|
+| Slow or timing-out assistant/workflow | workflow p90/p99, `gen_ai.client.operation.duration`, timeout rate by workflow/provider/model/environment |
+| Extra LLM/tool fanout | LLM-call count, tool-call count, input/output tokens, context bytes per workflow request |
+| Provider outage/latency | provider latency/error/timeout/rate-limit by provider/model/region/deployment |
+| Model/config mismatch | model readiness check, failed model resolution, request vs response model, config version |
+| Tool broken | tool success/error/latency by stable `gen_ai.tool.name` and failure class |
+| Missing or stale memory/context | memory/context duration, outcome, hit/miss, stale/missing context, source/version, permission failure |
+| Quality regression | `gen_ai.evaluation.result`, evaluation score distribution, pass/fail or violation count, evaluator no-data/freshness |
+| Unsafe content telemetry | content capture mode, redaction/truncation status, retention/access owner, raw-content dimension absence |
+| Cost spike | token usage by provider/model/workflow and app-owned cost metric or owner-mapped billing source |
+| Model/config incompatibility | failed model resolution, model/deployment readiness, request vs response model, config version, prompt/tool schema version |
+| Synthetic/canary coverage of an AI path | synthetic/canary workflow-check outcome for the AI path, including model/provider/workflow mode when available |
+| Prompt build or response parse failure | prompt/template version, response schema/tool schema version, prompt build outcome, response parse failure, payload size bucket |
+| AI tool/session/stream leak, including MCP when present | lifecycle signals, auth result, send/write failure, close reason family, active stream/session count, stream duration/outcome, plus stable tool/MCP method and AI workflow mode |
+| AI tool/session/stream memory growth, including MCP when present | AI-scoped capacity/state signals, plus stable tool/session/workflow dimensions |
+| Streaming partials or slow first token | time to first chunk, chunk cadence, partial-completion outcome, finish reason |
+| Retrieval stale, empty, or low quality | retrieval empty rate, low-confidence rate, index/corpus version, last-ingest age, vector/search dependency outcome |
+| Token/context pressure | input/output/cache tokens, context budget percent, truncation rate, token-limit error rate, and AI prompt/context input complexity |
+| AI-derived data stale or failed | embedding/index freshness, evaluation/feedback/export/dataset refresh result, empty/partial result, destination outcome, and AI-owned job health |
+| Safety/refusal spike | content-filter/refusal/guardrail outcome by stable policy class |
+| Model rollout or prompt/schema mismatch | expected-vs-running model/config/prompt/tool schema version and rollout/canary batch |
+| Detector reliability concern in AI incident evidence | missed/flapping/auto-resolved/no-data alert evidence to hand off to `$splunk-configure` |
+| Queue, worker, or state pressure in an AI gateway/tool runtime | AI-scoped capacity/backpressure signals plus stable AI workflow/provider/tool dimensions |
+| Crash loop or memory growth affecting AI workflows | AI-scoped capacity/startup signals plus model/provider/workflow dimensions when available |
+| Blast radius unclear | rollups by environment/region/workflow/model/provider/deployment/config version |
+
+Dashboards should show the parent workflow, GenAI child operations, provider
+health, token pressure, memory/context reliability, tool reliability,
+evaluation quality, fallback behavior, cost, AI model/config context, and
+AI-runtime pressure together so operators can separate workflow-degraded,
+provider-degraded, tool-degraded, retrieval-degraded, quality-degraded,
+cost-degraded, and token-pressure impact.
+
+## Privacy and Cardinality
+
+- Do not capture raw prompts, completions, tool arguments, retrieved documents,
+  raw URLs, headers, tokens, secrets, user identifiers, or tenant identifiers by
+  default.
+- If content capture is explicitly required, make it opt-in, redact it, and keep
+  it out of metric dimensions. Treat `gen_ai.input.messages`,
+  `gen_ai.output.messages`, `gen_ai.system_instructions`,
+  `gen_ai.retrieval.documents`, `gen_ai.retrieval.query.text`,
+  `gen_ai.tool.definitions`, `gen_ai.tool.call.arguments`, and
+  `gen_ai.evaluation.explanation` as sensitive.
+- Span names and metric attributes must be stable. Replace IDs and path
+  variables with templates such as `{id}` or `{resource}`.
+- Conversation/session/task IDs may be useful as trace attributes for drilldown
+  only when policy allows; never use them for metrics, detectors, or dashboard
+  group-by dimensions.

--- a/skills/splunk-configure/SKILL.md
+++ b/skills/splunk-configure/SKILL.md
@@ -264,6 +264,10 @@ Use the following structure:
 | GenAI Model Config | N | Critical | Readiness/mismatch failure |
 | GenAI Workflow Fanout | N | Major | LLM/tool call fanout |
 | GenAI Retrieval | N | Major | Retrieval error/latency/staleness |
+| GenAI Memory Context | N | Major | Memory/context latency, error, freshness, or permission failure |
+| GenAI Evaluation Quality | N | Major | Evaluation score, violation, error, no-data, or freshness |
+| GenAI Content Governance | N | Critical | Unsafe capture, redaction, truncation, or policy failure |
+| GenAI Cost | N | Major | Cost spike, budget/quota pressure, or billing freshness |
 | **Total**  | **N** | | |
 
 ## Latency Detectors
@@ -358,6 +362,10 @@ After generating all files (Terraform + report), present a summary:
 | GenAI Model Config | N |
 | GenAI Workflow Fanout | N |
 | GenAI Retrieval | N |
+| GenAI Memory Context | N |
+| GenAI Evaluation Quality | N |
+| GenAI Content Governance | N |
+| GenAI Cost | N |
 
 **Output:** `.observe/terraform/`
 

--- a/skills/splunk-configure/SKILL.md
+++ b/skills/splunk-configure/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   detector categories, and outputs ready-to-apply HCL with SignalFlow
   program_text. Use when the user types $splunk-configure, asks to "generate
   detectors", "create alerts from audit", "build Terraform for monitors",
-  or "set up Splunk detectors".
+  "set up Splunk detectors", or asks for GenAI/LLM detector coverage from an
+  otel-audit report.
 metadata:
   author: otel-studio
   version: 0.1.0
@@ -22,11 +23,19 @@ into detector categories (latency, error, saturation, throughput), and generate
 Terraform configuration for Splunk Observability Cloud `signalfx_detector`
 resources with inline SignalFlow programs.
 
+When the audit report contains `## GenAI Readiness`, classify available GenAI
+metrics first and report missing GenAI signals as instrumentation prerequisites
+instead of inventing detectors from absent data.
+
 ## When to Use
 
 - After running `$otel-audit` to generate `.observe/otel.md`
 - When the user wants alerting/detection Terraform for their service
 - When creating monitors for RED signals or saturation metrics
+- When creating GenAI/LLM detectors from audit output containing `gen_ai.*`
+  metrics, provider/model/tool/retrieval spans, memory/context, evaluation
+  quality, token pressure, content governance, cost, fallback, model/config
+  readiness, or workflow fanout gaps
 
 **When NOT to use:** If no audit report exists yet, instruct the user to run
 `$otel-audit` first.
@@ -43,7 +52,7 @@ Look for `.observe/otel.md` in the repository root.
 > No audit report found at `.observe/otel.md`. Please run `$otel-audit` first
 > to generate the observability coverage report.
 
-### Step 2 -- Parse Service Metadata and Metrics
+### Step 2 -- Parse Service Metadata, Metrics, and GenAI Coverage
 
 Extract from `.observe/otel.md`:
 
@@ -56,17 +65,84 @@ Extract from `.observe/otel.md`:
    - Each row provides: metric name, source, and type (auto/custom)
    - Record all metrics for classification in Step 3
 
-If the Metrics section says "No metrics detected.", stop and respond:
+3. **GenAI Readiness** from the `## GenAI Readiness` section when present:
+   - workflow trace shape
+   - semantic-convention completeness
+   - metrics and detectors
+   - AI pathway surfaces
+   - memory/context
+   - evaluation quality
+   - content governance and privacy/cardinality
+   - cost source or owner mapping
+   Missing or partial GenAI areas become instrumentation prerequisites unless
+   matching metrics already exist in the Metrics table.
+
+4. **Legacy GenAI gap-contract input** when present:
+   - Treat older machine-oriented GenAI gap contracts as legacy audit input.
+     Normalize each row into the human-readable `## GenAI Readiness` surface
+     model before producing detector prerequisites.
+   - Parse surface/status, `required_signals`, owner/source files, and
+     `acceptance_criteria`; do not require or display opaque row IDs.
+   - Treat any GenAI surface with status `missing` or `partial` as an
+     instrumentation prerequisite unless matching metrics already exist in the
+     Metrics table.
+   - Generate detectors only for implemented or proven GenAI signals. Do not
+     imply complete token/context, provider/model, tool, stream, retrieval, or
+     model/config coverage while required signals remain missing.
+
+If the Metrics section says "No metrics detected." and there are no GenAI
+readiness sections or legacy GenAI gap-contract inputs, stop and respond:
 
 > The audit report contains no metrics. Detectors require metric data.
 > Run `$otel-instrument` to add instrumentation, then re-run `$otel-audit`.
+
+If the Metrics section says "No metrics detected." but GenAI readiness sections
+or legacy GenAI gap-contract inputs exist, do not generate detector Terraform. Create
+`.observe/detectors.md` with GenAI instrumentation prerequisites and recommend
+`$otel-instrument` for the specific missing signals.
 
 ### Step 3 -- Classify Metrics into Detector Categories
 
 Load `references/detector-classification.md` and apply the classification rules
 to each metric from Step 2.
 
-Assign each metric to exactly one category:
+Assign each metric to exactly one category. Apply GenAI-specific rules first
+when the audit has a `## GenAI Readiness` section or when metric names or
+dimensions explicitly indicate LLM/GenAI ownership: `gen_ai.*`, LLM, inference,
+embedding, model provider/deployment, agent, tool/function calling, retrieval,
+prompt/completion/context token usage, fallback, or model/config readiness. Do
+not classify generic `model`, `workflow`, `tool`, `config`, `canary`, `token`,
+`session`, `chat`, `memory`, `context`, `evaluation`, `evaluator`, `quality`,
+`cost`, or `billing` metrics as GenAI unless the audit evidence shows they
+belong to a GenAI/LLM path. Use generic latency, error, throughput, or
+saturation categories when no GenAI-specific category matches.
+
+- **genai-latency** -- `gen_ai.client.operation.duration`, model/provider
+  request duration, workflow duration, streaming first-chunk/time-per-chunk
+- **genai-token-pressure** -- `gen_ai.client.token.usage`, prompt/context/token
+  size, cache read/create tokens, input/output token histograms
+- **genai-provider** -- provider/model timeout, rate-limit, throttle, 5xx,
+  unavailable, fallback selected/failed, region/deployment errors
+- **genai-tool** -- `execute_tool` success/error/latency, stable tool name,
+  tool failure class, tool-call count per workflow
+- **genai-model-config** -- requested vs response model, model/deployment
+  readiness, failed model resolution, config version/canary/feature flag
+- **genai-workflow-fanout** -- LLM-call count, tool-call count, nested
+  agent/workflow count, workflow outcome and timeout by surface/environment
+- **genai-retrieval** -- retrieval duration/error/no-result/stale-result
+  signals when retrieval/RAG code exists
+- **genai-memory-context** -- memory/context duration/outcome/error,
+  hit/miss, stale/missing context, source/version, and permission/auth failure
+- **genai-evaluation-quality** -- `gen_ai.evaluation.result` derived or
+  app-owned score distribution, pass/fail or violation count, evaluator
+  error/timeout/no-data, sample rate/count, and freshness
+- **genai-content-governance** -- content capture mode, redaction/truncation
+  outcome, unsafe capture/policy rejection, and access/retention owner evidence;
+  use mostly as a prerequisite/dashboard category, never raw content
+- **genai-cost** -- app-computed request/model/provider cost, budget/quota
+  consumption, billing export freshness, or cost calculation failure. If the app
+  does not own an accurate pricing map, owner-map the billing/provider source
+  instead of generating an approximate cost detector
 - **latency** -- duration histograms
 - **error** -- counters with failure/error/invalid keywords
 - **throughput** -- counters without error keywords
@@ -74,6 +150,13 @@ Assign each metric to exactly one category:
 
 Skip metrics that match the exclusion rules (auto-instrumented library metrics
 that duplicate custom signals).
+
+For every `## GenAI Readiness` row or GenAI `## Gaps` entry that is still
+missing a metric, trace attribute, span event, or owner-mapped external signal,
+add an entry to the generated report's "GenAI Instrumentation Prerequisites"
+section. Do not generate a detector for a missing signal. Recommend
+`$otel-instrument` with the specific human-readable GenAI surface and coverage
+area that must be added first.
 
 ### Step 4 -- Generate Terraform
 
@@ -174,6 +257,13 @@ Use the following structure:
 | Error      | N     | Critical | Sudden change (mean + stddev) |
 | Saturation | N     | Warning  | Static threshold |
 | Throughput | N     | Major    | Sudden change (mean + stddev) |
+| GenAI Latency | N | Major | P99 or sudden change |
+| GenAI Token Pressure | N | Major | Token/context threshold or baseline |
+| GenAI Provider | N | Critical | Error/timeout/rate-limit/fallback |
+| GenAI Tool | N | Major | Tool error/latency/fanout |
+| GenAI Model Config | N | Critical | Readiness/mismatch failure |
+| GenAI Workflow Fanout | N | Major | LLM/tool call fanout |
+| GenAI Retrieval | N | Major | Retrieval error/latency/staleness |
 | **Total**  | **N** | | |
 
 ## Latency Detectors
@@ -216,6 +306,15 @@ Default: **3.0 stddev**, 5m current window vs 1h history.
 |--------|--------|
 | `<metric>` | <why it was not classified> |
 
+## GenAI Instrumentation Prerequisites
+
+Include this section when `## GenAI Readiness` or a legacy GenAI gap-contract input exists
+and any required GenAI signal is missing or partial.
+
+| Surface | Audit Status | Missing Signal | Why No Detector Was Generated | Next Step |
+|---------|--------------|----------------|-------------------------------|-----------|
+| Token/context pressure | partial | truncation rate, token-limit errors, prompt/tool schema size, LLM-call fanout | Matching metrics are absent or only token usage exists | Run `$otel-instrument` to close the named GenAI signals or owner-map them |
+
 ## Classification Rules Applied
 
 <include the decision flowchart from references/detector-classification.md>
@@ -252,6 +351,13 @@ After generating all files (Terraform + report), present a summary:
 | Error       | N     |
 | Saturation  | N     |
 | Throughput  | N     |
+| GenAI Latency | N |
+| GenAI Token Pressure | N |
+| GenAI Provider | N |
+| GenAI Tool | N |
+| GenAI Model Config | N |
+| GenAI Workflow Fanout | N |
+| GenAI Retrieval | N |
 
 **Output:** `.observe/terraform/`
 

--- a/skills/splunk-configure/references/detector-classification.md
+++ b/skills/splunk-configure/references/detector-classification.md
@@ -5,6 +5,119 @@ Apply these rules in order; the first match wins.
 
 ## Classification Rules
 
+### GenAI
+
+Classify GenAI metrics before generic latency, error, throughput, or
+saturation categories, but require explicit GenAI context. A metric has GenAI
+context when the audit contains a `## GenAI Readiness` section for the owning
+workflow, or when the metric/dimensions contain explicit terms such as
+`gen_ai`, `llm`, `inference`, `embedding`, `model_provider`,
+`model.deployment`, `agent`, `function_call`, `execute_tool`, `retrieval`,
+`rag`, `hallucination`, `toxicity`, `factuality`, or provider names. Do not classify generic `model`, `workflow`, `tool`, `config`, `canary`, `token`,
+`session`, `chat`, `memory`, `context`, `evaluation`, `evaluator`, `quality`,
+`cost`, or `billing` metrics as GenAI by name alone; many non-GenAI services
+use those words. Those generic words require audit evidence that the owning
+workflow is a GenAI/LLM path.
+
+A metric is a **genai-latency** detector candidate when:
+
+- The metric name is `gen_ai.client.operation.duration`
+- OR the metric has GenAI context and the metric name contains one of:
+  `gen_ai`, `llm`, `inference`, `completion`, `chat`, `embedding`, `agent`,
+  `workflow`, `model_provider`, `model.deployment`
+- AND it measures operation duration, workflow duration, first-token latency,
+  first-chunk latency, stream chunk latency, or end-to-end response time
+
+A metric is a **genai-token-pressure** detector candidate when:
+
+- The metric name is `gen_ai.client.token.usage`
+- OR the metric has GenAI context and the metric name contains one of: `token`,
+  `prompt`, `completion`, `context`, `cache_read`, `cache_create`
+- AND it measures input, output, total, cached, prompt, completion, context,
+  request, or response token volume
+
+A metric is a **genai-provider** detector candidate when:
+
+- The metric has GenAI context and the metric name contains one of: `gen_ai`,
+  `llm`, `provider`, `model_provider`, `model.deployment`, `inference`,
+  `completion`, `embedding`
+- AND it measures provider/model timeout, rate limit, throttle, 5xx,
+  unavailable, retry, fallback selected, fallback failed, region, or deployment
+  error signals
+
+A metric is a **genai-tool** detector candidate when:
+
+- The metric has GenAI context and the metric name contains one of: `tool`,
+  `function_call`, `execute_tool`
+- AND it measures tool duration, success, error, timeout, failure class, or
+  tool-call count per workflow
+
+A metric is a **genai-model-config** detector candidate when:
+
+- The metric has GenAI context and the metric name contains one of:
+  `request.model`, `response.model`, `model.config`, `model_config`,
+  `model.deployment`, `deployment.readiness`, `model.readiness`,
+  `model_resolution`, `config.version`, `feature_flag`, `canary`
+- AND it measures model/deployment readiness, failed model resolution,
+  requested-vs-response model mismatch, rollout, canary, config, or feature
+  flag state
+
+A metric is a **genai-workflow-fanout** detector candidate when:
+
+- The metric has GenAI context and the metric name contains one of:
+  `llm_call_count`, `model_call_count`, `tool_call_count`, `agent_call_count`,
+  `workflow_fanout`, `nested_agent`, `workflow.timeout`, `workflow.outcome`
+- AND it measures per-request LLM calls, tool calls, nested agent calls,
+  workflow fanout, workflow outcome, or workflow timeout
+
+A metric is a **genai-retrieval** detector candidate when:
+
+- The metric has GenAI context and the metric name contains one of:
+  `retrieval`, `rag`, `vector`, `embedding`, `rerank`
+- AND it measures retrieval duration, errors, no-result rate, stale-result
+  rate, vector search dependency health, or retrieval freshness
+
+A metric is a **genai-memory-context** detector candidate when:
+
+- The metric has GenAI context and the metric name contains one of:
+  `memory`, `context`, `session_state`, `chat_history`, `conversation_state`,
+  `search_memory`, `create_memory`, `update_memory`, `upsert_memory`,
+  `delete_memory`
+- AND it measures memory/context duration, outcome, error, timeout, hit/miss,
+  stale result, missing context, record count, source/version, or
+  permission/auth failure
+
+A metric is a **genai-evaluation-quality** detector candidate when:
+
+- The metric name starts with `gen_ai.evaluation.` or the metric has GenAI
+  context and the metric name contains one of: `evaluation`, `evaluator`,
+  `eval_score`, `quality`, `faithfulness`, `factuality`, `hallucination`,
+  `toxicity`, `harmfulness`, `stereotyping`, `instruction_following`,
+  `helpfulness`
+- AND it measures evaluation score, score label/pass/fail, violation count,
+  evaluator error/timeout, sample count/rate, no-data, freshness, or duration
+
+A metric is a **genai-content-governance** detector or prerequisite candidate
+when:
+
+- The metric or audit evidence has GenAI context and contains one of:
+  `content_capture`, `redaction`, `masking`, `pii`, `privacy`,
+  `prompt_capture`, `response_capture`, `retrieval_capture`,
+  `tool_argument_capture`
+- AND it measures capture mode, redaction/truncation outcome, unsafe capture,
+  policy rejection, audit/report outcome, or access/retention owner evidence.
+  Do not alert on raw content; use this category mostly as an instrumentation or
+  dashboard prerequisite.
+
+A metric is a **genai-cost** detector candidate when:
+
+- The metric has GenAI context and the metric name contains one of: `cost`,
+  `spend`, `billing`, `price`, `charge`
+- AND it measures app-computed request/model/provider cost, budget/quota
+  consumption, billing export freshness, or cost calculation failure. If cost
+  is not computed by the app from an accurate pricing map, owner-map the
+  billing/provider source instead of generating an approximate detector.
+
 ### Latency
 
 A metric is a **latency** detector candidate when:
@@ -80,6 +193,10 @@ Skip a metric (do not generate a detector) when:
 ## Decision Flowchart
 
 ```
+metric name starts with "gen_ai." or audit has GenAI Readiness plus explicit genai/llm/inference/embedding/model-provider/agent/tool-call/retrieval/memory/evaluation keyword?
+  -> YES -> genai-* detector using GenAI rules above
+  -> NO
+
 metric name contains ".duration"?
   → YES → latency detector
   → NO ↓
@@ -99,7 +216,8 @@ metric type is gauge AND name matches saturation keywords?
 
 When a metric could match multiple categories (rare), use this priority:
 
-1. Latency (duration histograms are unambiguous)
-2. Error (error counters are high-value signals)
-3. Throughput (general counters)
-4. Saturation (gauges)
+1. GenAI categories (provider/model/tool/retrieval/memory/evaluation/token/fanout/cost signals before generic RED)
+2. Latency (duration histograms are unambiguous)
+3. Error (error counters are high-value signals)
+4. Throughput (general counters)
+5. Saturation (gauges)

--- a/skills/splunk-configure/references/terraform-templates.md
+++ b/skills/splunk-configure/references/terraform-templates.md
@@ -153,6 +153,30 @@ variable "throughput_<metric_id>_stddev" {
 }
 ```
 
+## GenAI Detector Defaults
+
+Use these defaults for GenAI categories from
+`detector-classification.md`. Generate concrete HCL with the same
+`signalfx_detector` resource shape used above.
+
+| Category | SignalFlow Method | Default | Severity | Detect Label |
+|---|---|---|---|---|
+| genai-latency | P99 model/provider/workflow duration and streaming first-chunk or chunk latency | 5.0s workflow, 2.0s first chunk, or 3 stddev | Major | GenAI Latency Degraded |
+| genai-token-pressure | P95/P99 input, output, total, cached, prompt, completion, and context token volume | 3 stddev above baseline or service-specific token limit | Major | GenAI Token Pressure High |
+| genai-provider | Provider/model timeout, throttle, rate-limit, unavailable, retry, fallback, or deployment error rate | 1 timeout/unavailable event or 3 stddev error increase | Critical | GenAI Provider Degraded |
+| genai-tool | Tool execution error/timeout rate, p99 tool latency, and tool-call count per workflow | 1.0s, 1 timeout/error, or 3 stddev fanout increase | Major | GenAI Tool Degraded |
+| genai-model-config | Model/deployment readiness failure, model resolution failure, requested-vs-response mismatch, config/canary failure | 1 readiness or mismatch failure | Critical | GenAI Model Config Degraded |
+| genai-workflow-fanout | LLM-call count, tool-call count, nested-agent count, workflow timeout, and workflow outcome rate | 3 stddev fanout increase or 1 timeout/unavailable event | Major | GenAI Workflow Fanout High |
+| genai-retrieval | Retrieval/RAG latency, error/no-result/stale-result rate, vector search dependency health | 1.0s, 3 stddev error/no-result increase, or freshness threshold | Major | GenAI Retrieval Degraded |
+| genai-memory-context | Memory/context latency, error, hit/miss, stale/missing context, source/version, or permission failure | 1.0s, 1 permission failure, or freshness threshold | Major | GenAI Memory Context Degraded |
+| genai-evaluation-quality | Evaluation score distribution, pass/fail or violation count, evaluator error/no-data, sample rate/count, freshness | 3 stddev score drop, 1 critical violation, or no-data threshold | Major | GenAI Evaluation Quality Degraded |
+| genai-content-governance | Content capture mode, redaction/truncation outcome, unsafe capture, policy rejection, access/retention owner evidence | 1 unsafe capture or policy failure | Critical | GenAI Content Governance Risk |
+| genai-cost | App-computed cost, budget/quota consumption, billing export freshness, or cost calculation failure | 3 stddev cost spike or budget threshold | Major | GenAI Cost Spike |
+
+When a GenAI readiness area is missing in `.observe/otel.md`, do not generate a
+detector placeholder. Add it to `.observe/detectors.md` as a GenAI
+instrumentation prerequisite and recommend `$otel-instrument`.
+
 ## terraform.tfvars.example
 
 Generated alongside the `.tf` files so users know exactly which values to provide.


### PR DESCRIPTION
## Summary

This PR narrows PR #115 to GenAI-only observability skill work.

- Adds a shared `genai-readiness` reference for OpenTelemetry GenAI semantic-convention sourcing, AI pathway incident evidence, token/context pressure closure, MCP/tool/session/stream lifecycle, AI-derived data jobs, model/config compatibility, privacy/cardinality constraints, and the local span-first Obstudio trace UI contract.
- Updates `$otel-audit` and `$otel-instrument` so GenAI audit output is a required gap contract, not background context. Instrumentation must close each required signal, prove it existing, or keep it explicitly owner-mapped/partial.
- Tightens the GenAI token/context contract so token usage and context-window metrics cannot silently close broader gaps like truncation, token-limit errors, prompt/tool schema size, and LLM/tool fanout.
- Updates `$splunk-configure` with GenAI-specific detector classification only, avoiding generic/non-GenAI readiness changes in this PR.
- Adds AI assistant and MCP-style AI tool demo apps plus matching audit/instrument eval fixtures.

## Verification

- `uv run pytest test_genai_skill_guidance.py` in `evals` (34 passed)
- `git diff --check`
- Combined review: Claude diff review plus independent baseline review; the only verified issue was a test-diagnostic gap and it was fixed.

Additional validation from the earlier PR split:

- Installed the PR skills locally before eval/rubric runs.
- `uv run pytest -s python/ai-assistant-demo/eval/qual/audit.json python/mcp-ai-tool-demo/eval/qual/audit.json --skill ../skills/otel-audit --codex-eval-config codex-evals.validation.toml --codex-eval-progress` - 4 passed.
- `uv run pytest -s python/ai-assistant-demo/eval/qual/instrument.json python/mcp-ai-tool-demo/eval/qual/instrument.json --skill ../skills/otel-instrument --codex-eval-config codex-evals.validation.toml --codex-eval-progress` - 4 passed.
- `uv run pytest -s -n 4 python/ai-assistant-demo/eval/qual/audit.json python/mcp-ai-tool-demo/eval/qual/audit.json --skill ../skills/otel-audit --codex-eval-config codex-evals.toml --codex-eval-kind rubric --codex-eval-progress` - 4 passed.
- `uv run pytest -s -n 4 python/ai-assistant-demo/eval/qual/instrument.json python/mcp-ai-tool-demo/eval/qual/instrument.json --skill ../skills/otel-instrument --codex-eval-config codex-evals.toml --codex-eval-kind rubric --codex-eval-progress` - 4 passed.
