### PR TITLE
Add GenAI trace DAG view

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -386,27 +386,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(observerStatusBarItem);
 	context.subscriptions.push({
 		dispose: () => {
-			logObserverLifecycle('Extension disposed; terminating observer process.');
-			stopObserverRun(observerLifecycleState);
-			observerStartupPromise = undefined;
-			observerStopPromise = undefined;
-			observerBaseUrl = undefined;
-			observerUsesSharedServer = false;
-			terminateObserverProcess(observerProcess, 'SIGTERM');
-			observerProcess = undefined;
+			disposeObserverForExtensionUnload('Extension disposed');
 		},
 	});
 }
 
-export function deactivate() {
-	logObserverLifecycle('Extension deactivated; terminating observer process.');
-	stopObserverRun(observerLifecycleState);
-	observerStartupPromise = undefined;
-	observerStopPromise = undefined;
-	observerBaseUrl = undefined;
-	observerUsesSharedServer = false;
-	terminateObserverProcess(observerProcess, 'SIGTERM');
-	observerProcess = undefined;
+export async function deactivate(): Promise<void> {
+	await shutdownObserverForExtensionUnload('Extension deactivated');
 }
 
 // ---------------------------------------------------------------------------
@@ -708,6 +694,28 @@ async function stopObserver(): Promise<void> {
 
 	observerStopPromise = stopPromise;
 	return observerStopPromise;
+}
+
+async function shutdownObserverForExtensionUnload(reason: string): Promise<void> {
+	logObserverLifecycle(`${reason}; stopping observer process.`);
+	try {
+		await stopObserver();
+	} catch (error) {
+		logObserverLifecycle(`${reason}; observer shutdown failed: ${getErrorMessage(error)}`);
+	}
+}
+
+function disposeObserverForExtensionUnload(reason: string): void {
+	logObserverLifecycle(`${reason}; synchronously terminating observer process.`);
+	const proc = observerProcess;
+	stopObserverRun(observerLifecycleState);
+	observerProcess = undefined;
+	observerStartupPromise = undefined;
+	observerStopPromise = undefined;
+	observerBaseUrl = undefined;
+	observerUsesSharedServer = false;
+	syncObserverUi();
+	terminateObserverProcess(proc, 'SIGTERM');
 }
 
 function syncObserverUi(): void {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -386,7 +386,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(observerStatusBarItem);
 	context.subscriptions.push({
 		dispose: () => {
-			void shutdownObserverForExtensionUnload('Extension disposed');
+			disposeObserverForExtensionUnload('Extension disposed');
 		},
 	});
 }
@@ -703,6 +703,19 @@ async function shutdownObserverForExtensionUnload(reason: string): Promise<void>
 	} catch (error) {
 		logObserverLifecycle(`${reason}; observer shutdown failed: ${getErrorMessage(error)}`);
 	}
+}
+
+function disposeObserverForExtensionUnload(reason: string): void {
+	logObserverLifecycle(`${reason}; terminating observer process.`);
+	const proc = observerProcess;
+	stopObserverRun(observerLifecycleState);
+	observerProcess = undefined;
+	observerStartupPromise = undefined;
+	observerStopPromise = undefined;
+	observerBaseUrl = undefined;
+	observerUsesSharedServer = false;
+	syncObserverUi();
+	terminateObserverProcess(proc, 'SIGTERM');
 }
 
 function syncObserverUi(): void {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -386,7 +386,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(observerStatusBarItem);
 	context.subscriptions.push({
 		dispose: () => {
-			disposeObserverForExtensionUnload('Extension disposed');
+			void shutdownObserverForExtensionUnload('Extension disposed');
 		},
 	});
 }
@@ -703,19 +703,6 @@ async function shutdownObserverForExtensionUnload(reason: string): Promise<void>
 	} catch (error) {
 		logObserverLifecycle(`${reason}; observer shutdown failed: ${getErrorMessage(error)}`);
 	}
-}
-
-function disposeObserverForExtensionUnload(reason: string): void {
-	logObserverLifecycle(`${reason}; synchronously terminating observer process.`);
-	const proc = observerProcess;
-	stopObserverRun(observerLifecycleState);
-	observerProcess = undefined;
-	observerStartupPromise = undefined;
-	observerStopPromise = undefined;
-	observerBaseUrl = undefined;
-	observerUsesSharedServer = false;
-	syncObserverUi();
-	terminateObserverProcess(proc, 'SIGTERM');
 }
 
 function syncObserverUi(): void {

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -168,8 +168,9 @@ test('extension unload paths clean up observer state', () => {
 	assert.match(source, /await\s+shutdownObserverForExtensionUnload\('Extension deactivated'\)/);
 	assert.match(source, /async\s+function\s+shutdownObserverForExtensionUnload\(reason:\s*string\):\s*Promise<void>/);
 	assert.match(source, /await\s+stopObserver\(\)/);
-	assert.match(source, /void\s+shutdownObserverForExtensionUnload\('Extension disposed'\)/);
-	assert.doesNotMatch(source, /function\s+disposeObserverForExtensionUnload\(reason:\s*string\):\s*void/);
+	assert.match(source, /dispose:\s*\(\)\s*=>\s*\{[\s\S]*?disposeObserverForExtensionUnload\('Extension disposed'\)/);
+	assert.match(source, /function\s+disposeObserverForExtensionUnload\(reason:\s*string\):\s*void/);
+	assert.match(source, /stopObserverRun\(observerLifecycleState\)/);
 	assert.match(source, /terminateObserverProcess\(proc,\s*'SIGTERM'\)/);
 	assert.doesNotMatch(source, /export\s+function\s+deactivate\(\)\s*\{[\s\S]*?terminateObserverProcess\(observerProcess,\s*'SIGTERM'\)/);
 });

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -168,8 +168,8 @@ test('extension unload paths clean up observer state', () => {
 	assert.match(source, /await\s+shutdownObserverForExtensionUnload\('Extension deactivated'\)/);
 	assert.match(source, /async\s+function\s+shutdownObserverForExtensionUnload\(reason:\s*string\):\s*Promise<void>/);
 	assert.match(source, /await\s+stopObserver\(\)/);
-	assert.match(source, /disposeObserverForExtensionUnload\('Extension disposed'\)/);
-	assert.match(source, /function\s+disposeObserverForExtensionUnload\(reason:\s*string\):\s*void/);
+	assert.match(source, /void\s+shutdownObserverForExtensionUnload\('Extension disposed'\)/);
+	assert.doesNotMatch(source, /function\s+disposeObserverForExtensionUnload\(reason:\s*string\):\s*void/);
 	assert.match(source, /terminateObserverProcess\(proc,\s*'SIGTERM'\)/);
 	assert.doesNotMatch(source, /export\s+function\s+deactivate\(\)\s*\{[\s\S]*?terminateObserverProcess\(observerProcess,\s*'SIGTERM'\)/);
 });

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -160,6 +160,20 @@ test('observer webview panel uses the bundled observer icon', () => {
 	assert.match(source, /observer-icon\.png/);
 });
 
+test('extension unload paths clean up observer state', () => {
+	const extensionSourcePath = path.join(extensionRoot, 'src', 'extension.ts');
+	const source = fs.readFileSync(extensionSourcePath, 'utf-8');
+
+	assert.match(source, /export\s+async\s+function\s+deactivate\(\):\s*Promise<void>\s*\{/);
+	assert.match(source, /await\s+shutdownObserverForExtensionUnload\('Extension deactivated'\)/);
+	assert.match(source, /async\s+function\s+shutdownObserverForExtensionUnload\(reason:\s*string\):\s*Promise<void>/);
+	assert.match(source, /await\s+stopObserver\(\)/);
+	assert.match(source, /disposeObserverForExtensionUnload\('Extension disposed'\)/);
+	assert.match(source, /function\s+disposeObserverForExtensionUnload\(reason:\s*string\):\s*void/);
+	assert.match(source, /terminateObserverProcess\(proc,\s*'SIGTERM'\)/);
+	assert.doesNotMatch(source, /export\s+function\s+deactivate\(\)\s*\{[\s\S]*?terminateObserverProcess\(observerProcess,\s*'SIGTERM'\)/);
+});
+
 test('resolveBackend throws when the observer binary is missing', () => {
 	withTempExtensionRoot((extensionRoot) => {
 		assert.throws(() => resolveBackend(extensionRoot), /observer binary not found/);

--- a/observer/client/src/api/types.ts
+++ b/observer/client/src/api/types.ts
@@ -117,6 +117,60 @@ export interface TraceSummary {
   spans?: SpanPreview[];
 }
 
+export type GenAISpanKind = "workflow" | "agent" | "tool" | "llm" | "retrieval" | "loop" | "genai";
+
+export interface GenAITokenUsage {
+  input: number;
+  output: number;
+  total: number;
+}
+
+export interface GenAIFlowNode {
+  nodeId: string;
+  traceId: string;
+  spanId: string;
+  name: string;
+  kind: GenAISpanKind;
+  operation?: string;
+  modelNames: string[];
+  tokenUsage: GenAITokenUsage;
+  depth: number;
+  durationMs: number;
+  avgDurationMs?: number;
+  maxDurationMs?: number;
+  statusCode: string;
+  grouped: boolean;
+  callCount?: number;
+  groupedSpanIds: string[];
+  parentFlowSpanId?: string;
+  descendantSpanIds: string[];
+  descendantTokenUsage: GenAITokenUsage;
+  descendantLlmCalls: number;
+  descendantLlmSpanIds: string[];
+  descendantToolCalls: number;
+  descendantToolSpanIds: string[];
+  descendantSecurityRiskCount: number;
+  descendantSecurityRiskSpanIds: string[];
+  descendantPrivacyRiskCount: number;
+  descendantPrivacyRiskSpanIds: string[];
+  descendantRiskCount: number;
+}
+
+export interface GenAIFlowEdge {
+  source: string;
+  target: string;
+}
+
+export interface GenAITraceSummary {
+  isGenAI: boolean;
+  tokens: GenAITokenUsage;
+  toolCalls: number;
+  llmCalls: number;
+  modelNames: string[];
+  flowNodes: GenAIFlowNode[];
+  flowEdges: GenAIFlowEdge[];
+}
+
 /** Full trace detail including all spans. */
 export interface TraceDetail {
   traceId: string;
@@ -126,6 +180,7 @@ export interface TraceDetail {
   durationMs?: number;
   status: string;
   spans: Span[];
+  genAI?: GenAITraceSummary;
 }
 
 /** A metric grouped by name, service, and scope with bounded data points. */

--- a/observer/client/src/api/types.ts
+++ b/observer/client/src/api/types.ts
@@ -114,6 +114,7 @@ export interface TraceSummary {
   spanCount: number;
   durationMs?: number;
   status: string;
+  isGenAI?: boolean;
   spans?: SpanPreview[];
 }
 

--- a/observer/client/src/api/types.ts
+++ b/observer/client/src/api/types.ts
@@ -154,6 +154,9 @@ export interface GenAIFlowNode {
   descendantPrivacyRiskCount: number;
   descendantPrivacyRiskSpanIds: string[];
   descendantRiskCount: number;
+  descendantEvaluationCount: number;
+  descendantEvaluationFailedCount: number;
+  descendantEvaluationFailedSpanIds: string[];
 }
 
 export interface GenAIFlowEdge {

--- a/observer/client/src/layout/DetailPanel.test.tsx
+++ b/observer/client/src/layout/DetailPanel.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment happy-dom
 
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DetailPanel } from "./DetailPanel";
+import { DetailPanel, ResizablePanel } from "./DetailPanel";
 
 afterEach(() => cleanup());
 
@@ -54,5 +54,37 @@ describe("DetailPanel", () => {
     );
 
     expect(scrollTo).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("ResizablePanel", () => {
+  it("preserves user width when the default width prop changes after a resize", () => {
+    const view = render(
+      <ResizablePanel defaultWidth={500} minWidth={300} maxWidth={900}>
+        <div>panel body</div>
+      </ResizablePanel>,
+    );
+    const panel = view.container.querySelector<HTMLElement>(".resizable-panel");
+    const handle = view.container.querySelector<HTMLElement>(".resizable-panel__handle");
+    expect(panel?.style.getPropertyValue("--panel-width")).toBe("500px");
+
+    view.rerender(
+      <ResizablePanel defaultWidth={600} minWidth={300} maxWidth={900}>
+        <div>panel body</div>
+      </ResizablePanel>,
+    );
+    expect(panel?.style.getPropertyValue("--panel-width")).toBe("600px");
+
+    fireEvent.mouseDown(handle as HTMLElement, { clientX: 0 });
+    fireEvent.mouseMove(window, { clientX: -120 });
+    fireEvent.mouseUp(window);
+    expect(panel?.style.getPropertyValue("--panel-width")).toBe("720px");
+
+    view.rerender(
+      <ResizablePanel defaultWidth={650} minWidth={300} maxWidth={900}>
+        <div>panel body</div>
+      </ResizablePanel>,
+    );
+    expect(panel?.style.getPropertyValue("--panel-width")).toBe("720px");
   });
 });

--- a/observer/client/src/layout/DetailPanel.tsx
+++ b/observer/client/src/layout/DetailPanel.tsx
@@ -95,7 +95,7 @@ export function ResizablePanel({
     const observer = new ResizeObserver(updateMeasuredWidth);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [panelWidth]);
+  }, []);
 
   useEffect(() => {
     if (!isResizing) {

--- a/observer/client/src/layout/DetailPanel.tsx
+++ b/observer/client/src/layout/DetailPanel.tsx
@@ -49,7 +49,7 @@ export function DetailPanel({
 interface ResizablePanelProps {
   children: ReactNode;
   className?: string;
-  defaultWidth?: number;
+  defaultWidth?: number | string;
   minWidth?: number;
   maxWidth?: number;
   resizeLabel?: string;
@@ -65,9 +65,37 @@ export function ResizablePanel({
   resizeLabel = "Resize panel",
   widthVarName = "--panel-width",
 }: ResizablePanelProps): React.ReactElement {
-  const [panelWidth, setPanelWidth] = useState(defaultWidth);
+  const [panelWidth, setPanelWidth] = useState<number | string>(defaultWidth);
   const [isResizing, setIsResizing] = useState(false);
   const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const lastMeasuredWidthRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    setPanelWidth(defaultWidth);
+  }, [defaultWidth]);
+
+  useEffect(() => {
+    const element = panelRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    const updateMeasuredWidth = () => {
+      const width = element.getBoundingClientRect().width;
+      if (width > 0) {
+        lastMeasuredWidthRef.current = width;
+      }
+    };
+
+    updateMeasuredWidth();
+    if (typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+    const observer = new ResizeObserver(updateMeasuredWidth);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [panelWidth]);
 
   useEffect(() => {
     if (!isResizing) {
@@ -106,15 +134,21 @@ export function ResizablePanel({
 
   return (
     <div
+      ref={panelRef}
       className={`resizable-panel ${isResizing ? "is-resizing" : ""} ${className}`.trim()}
-      style={{ [widthVarName]: `${panelWidth}px` } as React.CSSProperties}
+      style={{ [widthVarName]: typeof panelWidth === "number" ? `${panelWidth}px` : panelWidth } as React.CSSProperties}
     >
       <button
         type="button"
         className="resizable-panel__handle"
         aria-label={resizeLabel}
         onMouseDown={(event) => {
-          dragStateRef.current = { startX: event.clientX, startWidth: panelWidth };
+          const measuredWidth = panelRef.current?.getBoundingClientRect().width;
+          const fallbackWidth = typeof panelWidth === "number" ? panelWidth : lastMeasuredWidthRef.current ?? maxWidth;
+          dragStateRef.current = {
+            startX: event.clientX,
+            startWidth: measuredWidth && measuredWidth > 0 ? measuredWidth : fallbackWidth,
+          };
           setIsResizing(true);
           event.preventDefault();
         }}

--- a/observer/client/src/layout/DetailPanel.tsx
+++ b/observer/client/src/layout/DetailPanel.tsx
@@ -70,9 +70,17 @@ export function ResizablePanel({
   const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const lastMeasuredWidthRef = useRef<number | null>(null);
+  const hasUserResizedRef = useRef(false);
+  const previousDefaultWidthRef = useRef(defaultWidth);
 
   useEffect(() => {
-    setPanelWidth(defaultWidth);
+    if (Object.is(previousDefaultWidthRef.current, defaultWidth)) {
+      return;
+    }
+    previousDefaultWidthRef.current = defaultWidth;
+    if (!hasUserResizedRef.current) {
+      setPanelWidth(defaultWidth);
+    }
   }, [defaultWidth]);
 
   useEffect(() => {
@@ -113,6 +121,7 @@ export function ResizablePanel({
       }
       const deltaX = event.clientX - dragStateRef.current.startX;
       const nextWidth = Math.min(maxWidth, Math.max(minWidth, dragStateRef.current.startWidth - deltaX));
+      hasUserResizedRef.current = true;
       setPanelWidth(nextWidth);
     };
 

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -1322,6 +1322,429 @@ code {
 }
 
 /* ======================================
+   GenAI Trace Overview
+   ====================================== */
+
+.genai-trace {
+  border-bottom: 1px solid var(--border);
+  background: rgba(10, 18, 28, 0.72);
+  font-size: var(--font-meta);
+}
+
+.genai-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--chrome-2);
+}
+
+.genai-summary__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex: 0 0 auto;
+  min-width: 0;
+  font-size: var(--font-meta);
+}
+
+.genai-summary__label {
+  color: var(--row-primary-text);
+  font-weight: 600;
+}
+
+.genai-summary__value {
+  color: var(--text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.genai-flow {
+  padding: 6px 10px 8px;
+}
+
+.genai-flow__topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.genai-flow__header {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--row-primary-text);
+  font: inherit;
+  font-size: var(--font-title-sm);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.genai-flow__header:hover .genai-flow__title {
+  color: #fff;
+}
+
+.genai-flow__chevron {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  fill: none;
+  stroke: var(--text-dim);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.genai-flow__status {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 8px;
+  background: rgba(171, 116, 241, 0.18);
+  color: #c9a7ff;
+  font-size: var(--font-xs);
+  font-weight: 600;
+}
+
+.genai-flow__controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.genai-flow__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 0;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.genai-flow__icon-button:hover,
+.genai-flow__icon-button:focus-visible {
+  background: var(--chrome-3);
+  color: var(--row-primary-text);
+}
+
+.genai-flow__icon-button svg {
+  width: 15px;
+  height: 15px;
+  fill: currentColor;
+}
+
+.genai-flow__canvas {
+  position: relative;
+  height: 74px;
+  margin-top: 6px;
+  overflow: auto;
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  background: rgba(10, 18, 28, 0.28);
+}
+
+.genai-flow__canvas-inner {
+  position: relative;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+.genai-flow__canvas-scale {
+  position: relative;
+  transform-origin: 0 0;
+}
+
+.genai-flow__links {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.genai-flow__link {
+  fill: none;
+  stroke: var(--text);
+  stroke-linecap: round;
+  stroke-width: 1.4;
+  opacity: 0.65;
+}
+
+#genai-flow-arrow path {
+  fill: var(--text);
+  opacity: 0.7;
+}
+
+.genai-flow__dag-node {
+  position: absolute;
+  display: block;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.genai-flow__dag-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 7px;
+  background: var(--chrome);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.18);
+  font-size: var(--font-meta);
+  transition: background-color 120ms ease, border-color 120ms ease, outline-color 120ms ease;
+}
+
+.genai-flow__dag-node:hover .genai-flow__dag-card,
+.genai-flow__dag-node:focus-visible .genai-flow__dag-card {
+  border-color: var(--accent);
+  background: var(--chrome-3);
+}
+
+.genai-flow__dag-node--selected .genai-flow__dag-card {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.genai-flow__dag-card .title-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 5px;
+  min-width: 0;
+}
+
+.genai-flow__dag-card .title-container-wrapper {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.genai-flow__node-icon {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 12px;
+  margin-right: 3px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+}
+
+.genai-flow__node-icon--workflow {
+  color: var(--blue);
+}
+
+.genai-flow__node-icon--agent {
+  color: var(--purple);
+}
+
+.genai-flow__node-icon--llm {
+  color: var(--accent);
+}
+
+.genai-flow__node-icon--tool {
+  color: var(--yellow);
+}
+
+.genai-flow__node-icon--retrieval {
+  color: #49d5b4;
+}
+
+.genai-flow__node-icon--loop {
+  color: var(--green);
+}
+
+.genai-flow__node-icon--genai {
+  color: var(--muted);
+}
+
+.genai-flow__name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--row-primary-text);
+  font-size: var(--font-meta);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.genai-flow__duration {
+  color: var(--text);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-xs);
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.genai-flow__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-height: 16px;
+  color: var(--text-dim);
+  font-size: var(--font-meta);
+}
+
+.genai-flow__meta span:not(:last-child)::after {
+  content: "/";
+  margin-left: 6px;
+  color: var(--text-soft);
+}
+
+.genai-flow__signals {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 3px;
+  height: 14px;
+  margin-top: 2px;
+  min-height: 14px;
+}
+
+.genai-flow__badge {
+  display: inline-flex;
+  align-items: center;
+  height: 14px;
+  padding: 0 5px;
+  border-radius: 5px;
+  font-size: var(--font-xs);
+  font-weight: 600;
+}
+
+.genai-flow__badge--error {
+  background: rgba(255, 82, 82, 0.16);
+  color: #ffb4a8;
+}
+
+.genai-flow__badge--risk {
+  background: rgba(244, 145, 6, 0.18);
+  color: #ffc06b;
+}
+
+.genai-flow__signal {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  font-family: inherit;
+  line-height: 1;
+  padding: 0;
+}
+
+.genai-flow__signal[data-tooltip]::before,
+.genai-flow__signal[data-tooltip]::after {
+  position: absolute;
+  left: 50%;
+  z-index: 40;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 4px);
+  transition: none;
+}
+
+.genai-flow__signal[data-tooltip]::before {
+  bottom: calc(100% + 5px);
+  border: 5px solid transparent;
+  border-top-color: #202a38;
+  content: "";
+}
+
+.genai-flow__signal[data-tooltip]::after {
+  bottom: calc(100% + 14px);
+  max-width: 220px;
+  min-width: max-content;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #202a38;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  color: var(--row-primary-text);
+  content: attr(data-tooltip);
+  font-size: var(--font-meta);
+  font-weight: 500;
+  line-height: 1.25;
+  padding: 6px 8px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.genai-flow__signal[data-tooltip]:hover::before,
+.genai-flow__signal[data-tooltip]:hover::after,
+.genai-flow__signal[data-tooltip]:focus-visible::before,
+.genai-flow__signal[data-tooltip]:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.genai-flow__signal svg {
+  width: 12px;
+  height: 12px;
+  margin-right: 0;
+  fill: currentColor;
+}
+
+.genai-flow__signal-button {
+  cursor: pointer;
+}
+
+.genai-flow__signal-button:hover,
+.genai-flow__signal-button:focus-visible {
+  color: #ffb44f;
+  outline: none;
+}
+
+.genai-flow__signal-button:focus-visible::after {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.genai-flow__signal--ok {
+  color: var(--green);
+}
+
+.genai-flow__signal--issue {
+  color: var(--red);
+}
+
+.genai-flow__signal--call {
+  gap: 2px;
+  color: var(--blue);
+}
+
+.genai-flow__signal--risk {
+  color: var(--yellow);
+}
+
+/* ======================================
    Waterfall
    ====================================== */
 
@@ -1361,6 +1784,29 @@ code {
 .waterfall__span-count {
   font-size: 11px;
   color: var(--text-dim);
+}
+
+.waterfall__filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  border: 1px solid rgba(255, 176, 74, 0.45);
+  border-radius: 6px;
+  background: rgba(255, 176, 74, 0.12);
+  color: var(--yellow);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-xs);
+  font-weight: 600;
+  padding: 0 8px;
+}
+
+.waterfall__filter-chip:hover,
+.waterfall__filter-chip:focus-visible {
+  border-color: rgba(255, 176, 74, 0.72);
+  background: rgba(255, 176, 74, 0.18);
+  outline: none;
 }
 
 .waterfall__duration {
@@ -3503,9 +3949,9 @@ code {
   }
 
   .signal-view--trace-detail .signal-view__panel {
-    width: clamp(300px, 38vw, 360px);
+    width: var(--panel-width, min(560px, calc(100vw - 320px)));
     height: auto;
-    flex: 0 0 clamp(300px, 38vw, 360px);
+    flex: 0 0 var(--panel-width, min(560px, calc(100vw - 320px)));
     border-left: 1px solid var(--border);
     border-top: 0;
   }

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -1375,6 +1375,63 @@ code {
   gap: 12px;
 }
 
+.genai-flow__legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  color: var(--text-dim);
+  font-size: var(--font-xs);
+  white-space: nowrap;
+}
+
+.genai-flow__legend-label {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.genai-flow__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex: 0 0 auto;
+}
+
+.genai-flow__legend-divider {
+  width: 1px;
+  height: 14px;
+  flex: 0 0 auto;
+  background: var(--border);
+}
+
+.genai-flow__legend-signal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.genai-flow__legend-signal svg {
+  width: 12px;
+  height: 12px;
+  fill: currentColor;
+}
+
+.genai-flow__legend-signal--ok {
+  color: var(--green);
+}
+
+.genai-flow__legend-signal--issue {
+  color: var(--red);
+}
+
+.genai-flow__legend-chip {
+  color: var(--blue);
+  font-weight: 600;
+}
+
 .genai-flow__header {
   display: inline-flex;
   align-items: center;
@@ -3792,6 +3849,28 @@ code {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.trace-row__operation-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.trace-row__genai-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 5px;
+  background: rgba(171, 116, 241, 0.18);
+  color: #c9a7ff;
+  font-size: var(--font-xs);
+  font-weight: 700;
+  line-height: 1;
+  flex: 0 0 auto;
 }
 
 .trace-row__service {

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -1388,11 +1388,6 @@ code {
   white-space: nowrap;
 }
 
-.genai-flow__legend-label {
-  color: var(--text);
-  font-weight: 600;
-}
-
 .genai-flow__legend-item {
   display: inline-flex;
   align-items: center;
@@ -1427,9 +1422,15 @@ code {
   color: var(--red);
 }
 
-.genai-flow__legend-chip {
-  color: var(--blue);
+.genai-flow__legend-call {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
   font-weight: 600;
+}
+
+.genai-flow__legend-call .genai-flow__node-icon {
+  margin-right: 0;
 }
 
 .genai-flow__header {
@@ -1775,6 +1776,10 @@ code {
   height: 12px;
   margin-right: 0;
   fill: currentColor;
+}
+
+.genai-flow__signal .genai-flow__node-icon {
+  margin-right: 0;
 }
 
 .genai-flow__signal-button {

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -1661,6 +1661,14 @@ code {
   padding: 0;
 }
 
+.genai-flow__signal[aria-label] {
+  cursor: inherit;
+}
+
+.genai-flow__signal--interactive {
+  cursor: pointer;
+}
+
 .genai-flow__signal[data-tooltip]::before,
 .genai-flow__signal[data-tooltip]::after {
   position: absolute;
@@ -1733,6 +1741,10 @@ code {
 
 .genai-flow__signal--issue {
   color: var(--red);
+}
+
+.genai-flow__signal--unknown {
+  color: var(--text-dim);
 }
 
 .genai-flow__signal--call {
@@ -1866,7 +1878,7 @@ code {
   gap: 4px;
   min-width: 0;
   padding-right: 8px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .waterfall__toggle {
@@ -1905,11 +1917,87 @@ code {
 }
 
 .waterfall__span-name {
+  min-width: 0;
+  flex: 1 1 auto;
   font-size: 12px;
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.waterfall__ai-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: 120px;
+  height: 18px;
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  padding: 0 7px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.waterfall__ai-chip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.waterfall__ai-chip--issue {
+  border-color: rgba(244, 135, 113, 0.45);
+  background: rgba(244, 135, 113, 0.16);
+  color: #ffb4a8;
+}
+
+.waterfall__ai-chip--ok {
+  border-color: rgba(133, 244, 21, 0.36);
+  background: rgba(133, 244, 21, 0.12);
+  color: var(--green);
+}
+
+.waterfall__ai-chip[data-tooltip]::before,
+.waterfall__ai-chip[data-tooltip]::after {
+  position: absolute;
+  left: 50%;
+  z-index: 45;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 4px);
+}
+
+.waterfall__ai-chip[data-tooltip]::before {
+  bottom: calc(100% + 5px);
+  border: 5px solid transparent;
+  border-top-color: #202a38;
+  content: "";
+}
+
+.waterfall__ai-chip[data-tooltip]::after {
+  bottom: calc(100% + 14px);
+  max-width: 280px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #202a38;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  color: var(--row-primary-text);
+  content: attr(data-tooltip);
+  font-size: var(--font-meta);
+  font-weight: 500;
+  line-height: 1.25;
+  padding: 6px 8px;
+  text-align: center;
+  white-space: normal;
+}
+
+.waterfall__ai-chip[data-tooltip]:hover::before,
+.waterfall__ai-chip[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .waterfall__row-timeline {
@@ -2071,6 +2159,114 @@ code {
   margin: 0;
   font-size: 12px;
   color: var(--text-dim);
+}
+
+.span-details__ai-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 10px;
+}
+
+.ai-evaluations__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ai-evaluations__title {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.ai-evaluations__issue-count,
+.ai-evaluations__ok-count {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  border-radius: 9px;
+  padding: 0 7px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.ai-evaluations__issue-count {
+  background: rgba(244, 135, 113, 0.16);
+  color: #ffb4a8;
+}
+
+.ai-evaluations__ok-count {
+  background: rgba(133, 244, 21, 0.12);
+  color: var(--green);
+}
+
+.ai-evaluations__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ai-evaluations__item {
+  display: flex;
+  gap: 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 8px;
+}
+
+.ai-evaluations__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.ai-evaluations__item--ok .ai-evaluations__status {
+  border: 1px solid var(--green);
+  color: var(--green);
+}
+
+.ai-evaluations__item--issue .ai-evaluations__status {
+  border: 1px solid var(--red);
+  color: var(--red);
+}
+
+.ai-evaluations__content {
+  min-width: 0;
+}
+
+.ai-evaluations__line {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.ai-evaluations__label {
+  color: var(--orange);
+  font-family: var(--font-family-mono);
+  font-weight: 700;
+}
+
+.ai-evaluations__score {
+  color: var(--blue);
+  font-family: var(--font-family-mono);
+}
+
+.ai-evaluations__explanation {
+  margin-top: 4px;
+  color: var(--text-dim);
+  font-size: 11px;
+  line-height: 1.35;
 }
 
 .span-details__attrs {

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -1719,16 +1719,16 @@ code {
 .genai-flow__signal[data-tooltip]::before,
 .genai-flow__signal[data-tooltip]::after {
   position: absolute;
-  left: 50%;
   z-index: 40;
   opacity: 0;
   pointer-events: none;
-  transform: translate(-50%, 4px);
+  transform: translateY(4px);
   transition: none;
 }
 
 .genai-flow__signal[data-tooltip]::before {
   bottom: calc(100% + 5px);
+  left: 4px;
   border: 5px solid transparent;
   border-top-color: #202a38;
   content: "";
@@ -1736,6 +1736,7 @@ code {
 
 .genai-flow__signal[data-tooltip]::after {
   bottom: calc(100% + 14px);
+  left: 0;
   max-width: 220px;
   min-width: max-content;
   border: 1px solid var(--border);
@@ -1757,7 +1758,7 @@ code {
 .genai-flow__signal[data-tooltip]:focus-visible::before,
 .genai-flow__signal[data-tooltip]:focus-visible::after {
   opacity: 1;
-  transform: translate(-50%, 0);
+  transform: translateY(0);
 }
 
 .genai-flow__signal svg {

--- a/observer/client/src/styles.css
+++ b/observer/client/src/styles.css
@@ -1422,17 +1422,6 @@ code {
   color: var(--red);
 }
 
-.genai-flow__legend-call {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  font-weight: 600;
-}
-
-.genai-flow__legend-call .genai-flow__node-icon {
-  margin-right: 0;
-}
-
 .genai-flow__header {
   display: inline-flex;
   align-items: center;

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -4,7 +4,7 @@ import { ValidationBadge } from "../components/ValidationBadge";
 import type { ValidationIndex } from "../validation/utils";
 import { lookupSpanValidation } from "../validation/utils";
 
-type GenAISpanFilterType = "security" | "privacy" | "llm" | "tool" | "loop" | "quality";
+export type GenAISpanFilterType = "security" | "privacy" | "llm" | "tool" | "loop" | "quality";
 
 interface GenAITraceOverviewProps {
   summary: GenAITraceSummary | null;

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -132,17 +132,20 @@ export function GenAITraceOverview({
           </button>
 
           {!collapsed ? (
-            <div className="genai-flow__controls" aria-label="Agent flow controls">
-              <IconButton label="Center flow" onClick={resetFlowView}>
-                <CenterIcon />
-              </IconButton>
-              <IconButton label="Zoom out" onClick={() => setZoom((value) => Math.max(0.7, roundZoom(value - 0.1)))}>
-                <ZoomOutIcon />
-              </IconButton>
-              <IconButton label="Zoom in" onClick={() => setZoom((value) => Math.min(1.4, roundZoom(value + 0.1)))}>
-                <ZoomInIcon />
-              </IconButton>
-            </div>
+            <>
+              <GenAIFlowLegend />
+              <div className="genai-flow__controls" aria-label="Agent flow controls">
+                <IconButton label="Center flow" onClick={resetFlowView}>
+                  <CenterIcon />
+                </IconButton>
+                <IconButton label="Zoom out" onClick={() => setZoom((value) => Math.max(0.7, roundZoom(value - 0.1)))}>
+                  <ZoomOutIcon />
+                </IconButton>
+                <IconButton label="Zoom in" onClick={() => setZoom((value) => Math.min(1.4, roundZoom(value + 0.1)))}>
+                  <ZoomInIcon />
+                </IconButton>
+              </div>
+            </>
           ) : null}
         </div>
 
@@ -226,6 +229,46 @@ function SummaryValue({ label, value }: { label: string; value: string }): React
     <div className="genai-summary__item">
       <span className="genai-summary__label">{label}:</span>
       <span className="genai-summary__value">{value}</span>
+    </div>
+  );
+}
+
+function GenAIFlowLegend(): React.ReactElement {
+  const kindItems: Array<{ kind: GenAIFlowNode["kind"]; label: string }> = [
+    { kind: "workflow", label: "Workflow" },
+    { kind: "agent", label: "Agent" },
+    { kind: "llm", label: "LLM" },
+    { kind: "tool", label: "Tool" },
+    { kind: "retrieval", label: "Retrieval" },
+    { kind: "loop", label: "Loop" },
+  ];
+
+  return (
+    <div className="genai-flow__legend" aria-label="GenAI flow legend">
+      <span className="genai-flow__legend-label">Legend</span>
+      {kindItems.map((item) => (
+        <span className="genai-flow__legend-item" key={item.kind}>
+          <NodeKindIcon kind={item.kind} />
+          <span>{item.label}</span>
+        </span>
+      ))}
+      <span className="genai-flow__legend-divider" aria-hidden="true" />
+      <span className="genai-flow__legend-item">
+        <span className="genai-flow__legend-signal genai-flow__legend-signal--ok">
+          <CheckIcon />
+        </span>
+        <span>Evaluated</span>
+      </span>
+      <span className="genai-flow__legend-item">
+        <span className="genai-flow__legend-signal genai-flow__legend-signal--issue">
+          <IssueIcon />
+        </span>
+        <span>Issue</span>
+      </span>
+      <span className="genai-flow__legend-item">
+        <span className="genai-flow__legend-chip">LLM n</span>
+        <span>Nested calls</span>
+      </span>
     </div>
   );
 }

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -1,0 +1,909 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { GenAIFlowEdge, GenAIFlowNode, GenAITraceSummary } from "../api/types";
+import { ValidationBadge } from "../components/ValidationBadge";
+import type { ValidationIndex } from "../validation/utils";
+import { lookupSpanValidation } from "../validation/utils";
+
+interface GenAITraceOverviewProps {
+  summary: GenAITraceSummary | null;
+  selectedSpanId: string | null;
+  onSelectSpan: (spanId: string | null) => void;
+  onApplySpanFilter: (type: "security" | "privacy" | "llm" | "tool" | "loop", spanIds: string[]) => void;
+  validationIndex: ValidationIndex;
+}
+
+interface FlowLayoutNode {
+  node: GenAIFlowNode;
+  x: number;
+  y: number;
+}
+
+interface FlowLayout {
+  nodes: FlowLayoutNode[];
+  links: Array<{
+    source: FlowLayoutNode;
+    target: FlowLayoutNode;
+    path: string;
+  }>;
+  nodeWidth: number;
+  nodeHeight: number;
+  width: number;
+  height: number;
+  orientation: "horizontal" | "vertical";
+}
+
+const NODE_WIDTH = 190;
+const NODE_HEIGHT = 42;
+const LAYER_GAP = 52;
+const BRANCH_COLUMN_GAP = 64;
+const ROW_GAP = 10;
+const HORIZONTAL_FLOW_MIN_WIDTH = 720;
+const FLOW_MARGIN = { top: 8, right: 12, bottom: 10, left: 12 };
+const LINEAR_FLOW_MIN_HEIGHT = 74;
+const VERTICAL_FLOW_MIN_HEIGHT = 92;
+const BRANCH_FLOW_MIN_HEIGHT = 142;
+const FLOW_MAX_HEIGHT = 210;
+
+export function GenAITraceOverview({
+  summary,
+  selectedSpanId,
+  onSelectSpan,
+  onApplySpanFilter,
+  validationIndex,
+}: GenAITraceOverviewProps): React.ReactElement | null {
+  const [collapsed, setCollapsed] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const [canvasWidth, setCanvasWidth] = useState(0);
+  const flowNodes = summary?.flowNodes ?? [];
+  const flowEdges = summary?.flowEdges ?? [];
+  const layout = useMemo(() => buildFlowLayout(flowNodes, flowEdges, canvasWidth), [flowNodes, flowEdges, canvasWidth]);
+  const flowNodeKey = useMemo(() => flowNodes.map((node) => node.spanId).join("|"), [flowNodes]);
+
+  useEffect(() => {
+    const element = canvasRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    const updateWidth = () => {
+      const nextWidth = element.clientWidth;
+      setCanvasWidth((currentWidth) => (currentWidth === nextWidth ? currentWidth : nextWidth));
+    };
+    updateWidth();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateWidth);
+      return () => window.removeEventListener("resize", updateWidth);
+    }
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [collapsed]);
+
+  useEffect(() => {
+    setZoom(1);
+    const element = canvasRef.current;
+    if (element) {
+      element.scrollTop = 0;
+      element.scrollLeft = 0;
+    }
+  }, [flowNodeKey, layout.orientation]);
+
+  if (!summary?.isGenAI) {
+    return null;
+  }
+
+  const resetFlowView = () => {
+    setZoom(1);
+    const element = canvasRef.current;
+    if (element) {
+      element.scrollTop = 0;
+      element.scrollLeft = 0;
+    }
+  };
+
+  return (
+    <section className="genai-trace" aria-label="GenAI trace overview">
+      <div className="genai-summary" aria-label="GenAI trace summary">
+        <SummaryValue
+          label="Tokens"
+          value={`${formatCount(summary.tokens.total)} (In: ${formatCount(summary.tokens.input)} | Out: ${formatCount(summary.tokens.output)})`}
+        />
+        <SummaryValue label="Tool calls" value={formatCount(summary.toolCalls)} />
+        <SummaryValue label="LLM calls" value={formatCount(summary.llmCalls)} />
+        <SummaryValue label="Model names" value={summary.modelNames.length > 0 ? summary.modelNames.join(", ") : "unknown"} />
+      </div>
+
+      <div className="genai-flow">
+        <div className="genai-flow__topbar">
+          <button
+            className="genai-flow__header"
+            type="button"
+            aria-expanded={!collapsed}
+            onClick={() => setCollapsed((value) => !value)}
+          >
+            <ChevronIcon collapsed={collapsed} />
+            <span className="genai-flow__title">Agent flow</span>
+            <span className="genai-flow__status">GenAI</span>
+          </button>
+
+          {!collapsed ? (
+            <div className="genai-flow__controls" aria-label="Agent flow controls">
+              <IconButton label="Center flow" onClick={resetFlowView}>
+                <CenterIcon />
+              </IconButton>
+              <IconButton label="Zoom out" onClick={() => setZoom((value) => Math.max(0.7, roundZoom(value - 0.1)))}>
+                <ZoomOutIcon />
+              </IconButton>
+              <IconButton label="Zoom in" onClick={() => setZoom((value) => Math.min(1.4, roundZoom(value + 0.1)))}>
+                <ZoomInIcon />
+              </IconButton>
+            </div>
+          ) : null}
+        </div>
+
+        {!collapsed ? (
+          <div
+            ref={canvasRef}
+            className={`genai-flow__canvas genai-flow__canvas--${layout.orientation}`}
+            data-testid="genai-agent-flow"
+            style={{ height: `${Math.min(FLOW_MAX_HEIGHT, Math.max(LINEAR_FLOW_MIN_HEIGHT, layout.height))}px` }}
+          >
+            <div
+              className="genai-flow__canvas-inner"
+              style={{
+                width: `${layout.width * zoom}px`,
+                height: `${layout.height * zoom}px`,
+              }}
+            >
+              <div
+                className="genai-flow__canvas-scale"
+                style={{
+                  width: `${layout.width}px`,
+                  height: `${layout.height}px`,
+                  transform: `scale(${zoom})`,
+                }}
+              >
+                <svg
+                  className="genai-flow__links"
+                  width={layout.width}
+                  height={layout.height}
+                  viewBox={`0 0 ${layout.width} ${layout.height}`}
+                  aria-hidden="true"
+                >
+                  <defs>
+                    <marker
+                      id="genai-flow-arrow"
+                      viewBox="0 -5 10 10"
+                      refX="10"
+                      refY="0"
+                      markerWidth="6"
+                      markerHeight="6"
+                      orient="auto"
+                    >
+                      <path d="M0,-5L10,0L0,5" />
+                    </marker>
+                  </defs>
+                  {layout.links.map((link) => (
+                    <path
+                      key={`${link.source.node.spanId}-${link.target.node.spanId}`}
+                      className="genai-flow__link"
+                      d={link.path}
+                      markerEnd="url(#genai-flow-arrow)"
+                    />
+                  ))}
+                </svg>
+
+                {layout.nodes.map((layoutNode) => (
+                  <GenAIFlowCard
+                    key={layoutNode.node.nodeId}
+                    node={layoutNode.node}
+                    selected={isNodeSelected(layoutNode.node, selectedSpanId)}
+                    x={layoutNode.x}
+                    y={layoutNode.y}
+                    width={layout.nodeWidth}
+                    height={layout.nodeHeight}
+                    onSelectSpan={onSelectSpan}
+                    onApplySpanFilter={onApplySpanFilter}
+                    validationIndex={validationIndex}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function SummaryValue({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="genai-summary__item">
+      <span className="genai-summary__label">{label}:</span>
+      <span className="genai-summary__value">{value}</span>
+    </div>
+  );
+}
+
+function GenAIFlowCard({
+  node,
+  selected,
+  x,
+  y,
+  width,
+  height,
+  onSelectSpan,
+  onApplySpanFilter,
+  validationIndex,
+}: {
+  node: GenAIFlowNode;
+  selected: boolean;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  onSelectSpan: (spanId: string | null) => void;
+  onApplySpanFilter: (type: "security" | "privacy" | "llm" | "tool" | "loop", spanIds: string[]) => void;
+  validationIndex: ValidationIndex;
+}): React.ReactElement {
+  const validation = lookupSpanValidation(validationIndex, node.traceId, node.spanId);
+  const title = getNodeTitle(node);
+  const hasQualityIssues = (validation?.count ?? 0) > 0;
+  const hasLLMCalls = (node.kind === "loop" || !node.grouped) && node.descendantLlmCalls > 0;
+  const hasToolCalls = (node.kind === "loop" || !node.grouped) && node.descendantToolCalls > 0;
+  const hasSecurityRisk = node.descendantSecurityRiskCount > 0;
+  const hasPrivacyRisk = node.descendantPrivacyRiskCount > 0;
+  const meta = getNodeMeta(node);
+  const ariaLabel = `${node.kind} ${title}${meta.length > 0 ? `, ${meta.join(", ")}` : ""}`;
+  const groupedFilterType = getGroupedFilterType(node);
+  const selectNode = () => {
+    if (groupedFilterType && node.groupedSpanIds.length > 0) {
+      onApplySpanFilter(groupedFilterType, node.groupedSpanIds);
+      return;
+    }
+    onSelectSpan(node.spanId);
+  };
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      selectNode();
+    }
+  };
+  const stopSignalPropagation = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+  };
+  const applySpanFilter = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    type: "security" | "privacy" | "llm" | "tool" | "loop",
+    spanIds: string[],
+  ) => {
+    event.stopPropagation();
+    onApplySpanFilter(type, spanIds);
+  };
+
+  return (
+    <div
+      className={`genai-flow__dag-node genai-flow__dag-node--${node.kind}${selected ? " genai-flow__dag-node--selected" : ""}`}
+      style={{
+        left: `${x}px`,
+        top: `${y}px`,
+        width: `${width}px`,
+        height: `${height}px`,
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      onClick={selectNode}
+      onKeyDown={handleCardKeyDown}
+    >
+      <span className="genai-flow__dag-card dag-card">
+        <span className="title-container">
+          <span className="title-container-wrapper">
+            <NodeKindIcon kind={node.kind} />
+            <span className="title genai-flow__name" title={title}>
+              {title}
+            </span>
+          </span>
+          <span className="meta genai-flow__duration">{formatDuration(node.durationMs)}</span>
+        </span>
+        <span
+          className="quality-issues-container genai-flow__signals"
+          aria-label="GenAI node signals"
+          onClick={stopSignalPropagation}
+          onKeyDown={stopSignalPropagation}
+        >
+          {node.statusCode === "ERROR" ? <span className="genai-flow__badge genai-flow__badge--error">Error</span> : null}
+          <span
+            className={`genai-flow__signal genai-flow__signal--${hasQualityIssues ? "issue" : "ok"}`}
+            aria-label={hasQualityIssues ? `${validation?.count ?? 0} quality issues` : "No quality issues detected"}
+            data-tooltip={hasQualityIssues ? `${validation?.count ?? 0} quality issues` : "No quality issues detected"}
+          >
+            {hasQualityIssues ? <IssueIcon /> : <CheckIcon />}
+          </span>
+          {hasLLMCalls ? (
+            <button
+              className="genai-flow__signal genai-flow__signal--call genai-flow__signal-button"
+              type="button"
+              aria-label={formatCallFilterLabel(node.descendantLlmCalls, "LLM")}
+              data-tooltip={`${formatCallLabel(node.descendantLlmCalls, "LLM")}. Click to filter waterfall.`}
+              onClick={(event) => applySpanFilter(event, "llm", node.descendantLlmSpanIds)}
+            >
+              <span>LLM</span>
+              <span>{formatCount(node.descendantLlmCalls)}</span>
+            </button>
+          ) : null}
+          {hasToolCalls ? (
+            <button
+              className="genai-flow__signal genai-flow__signal--call genai-flow__signal-button"
+              type="button"
+              aria-label={formatCallFilterLabel(node.descendantToolCalls, "Tool")}
+              data-tooltip={`${formatCallLabel(node.descendantToolCalls, "tool")}. Click to filter waterfall.`}
+              onClick={(event) => applySpanFilter(event, "tool", node.descendantToolSpanIds)}
+            >
+              <span>Tool</span>
+              <span>{formatCount(node.descendantToolCalls)}</span>
+            </button>
+          ) : null}
+          {hasSecurityRisk ? (
+            <button
+              className="genai-flow__signal genai-flow__signal--risk genai-flow__signal-button"
+              type="button"
+              aria-label={formatRiskFilterLabel(node.descendantSecurityRiskCount, "security")}
+              data-tooltip={`${formatRiskLabel(node.descendantSecurityRiskCount, "security")}. Click to filter waterfall.`}
+              onClick={(event) => applySpanFilter(event, "security", node.descendantSecurityRiskSpanIds)}
+            >
+              <ShieldIcon />
+              <span>{formatCount(node.descendantSecurityRiskCount)}</span>
+            </button>
+          ) : null}
+          {hasPrivacyRisk ? (
+            <button
+              className="genai-flow__signal genai-flow__signal--risk genai-flow__signal-button"
+              type="button"
+              aria-label={formatRiskFilterLabel(node.descendantPrivacyRiskCount, "privacy")}
+              data-tooltip={`${formatRiskLabel(node.descendantPrivacyRiskCount, "privacy")}. Click to filter waterfall.`}
+              onClick={(event) => applySpanFilter(event, "privacy", node.descendantPrivacyRiskSpanIds)}
+            >
+              <LockIcon />
+              <span>{formatCount(node.descendantPrivacyRiskCount)}</span>
+            </button>
+          ) : null}
+          <ValidationBadge count={validation?.count ?? 0} severity={validation?.highestSeverity ?? null} />
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function IconButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <button className="genai-flow__icon-button" type="button" aria-label={label} title={label} onClick={onClick}>
+      {children}
+    </button>
+  );
+}
+
+function buildFlowLayout(nodes: GenAIFlowNode[], edges: GenAIFlowEdge[], containerWidth: number): FlowLayout {
+  if (containerWidth === 0 || containerWidth < HORIZONTAL_FLOW_MIN_WIDTH) {
+    return buildVerticalFlowLayout(nodes, edges);
+  }
+  return buildHorizontalFlowLayout(nodes, edges);
+}
+
+function buildVerticalFlowLayout(nodes: GenAIFlowNode[], edges: GenAIFlowEdge[]): FlowLayout {
+  const orderIndex = new Map(nodes.map((node, index) => [node.spanId, index]));
+  const byId = new Map(nodes.map((node) => [node.spanId, node]));
+  const predecessorIdsBySpanId = getPredecessorIdsBySpanId(nodes, edges);
+  const levelCache = new Map<string, number>();
+
+  const getLevel = (node: GenAIFlowNode, visiting = new Set<string>()): number => {
+    const cached = levelCache.get(node.spanId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(node.spanId)) {
+      return 0;
+    }
+    const predecessorIds = predecessorIdsBySpanId.get(node.spanId) ?? [];
+    if (predecessorIds.length === 0) {
+      levelCache.set(node.spanId, 0);
+      return 0;
+    }
+
+    visiting.add(node.spanId);
+    const predecessorLevels = predecessorIds.flatMap((predecessorId) => {
+      const predecessor = byId.get(predecessorId);
+      return predecessor ? [getLevel(predecessor, visiting)] : [];
+    });
+    visiting.delete(node.spanId);
+
+    const level = predecessorLevels.length > 0 ? Math.max(...predecessorLevels) + 1 : 0;
+    levelCache.set(node.spanId, level);
+    return level;
+  };
+
+  const layers = new Map<number, GenAIFlowNode[]>();
+  for (const node of nodes) {
+    const level = getLevel(node);
+    const layer = layers.get(level) ?? [];
+    layer.push(node);
+    layers.set(level, layer);
+  }
+
+  const sortedLevels = Array.from(layers.keys()).sort((a, b) => a - b);
+  for (const level of sortedLevels) {
+    layers.get(level)?.sort((a, b) => (orderIndex.get(a.spanId) ?? 0) - (orderIndex.get(b.spanId) ?? 0));
+  }
+
+  const maxLayerSize = Math.max(1, ...Array.from(layers.values()).map((layer) => layer.length));
+  const contentWidth = maxLayerSize * NODE_WIDTH + Math.max(0, maxLayerSize - 1) * BRANCH_COLUMN_GAP;
+  const width = Math.max(260, FLOW_MARGIN.left + FLOW_MARGIN.right + contentWidth);
+  const height = Math.max(
+    VERTICAL_FLOW_MIN_HEIGHT,
+    FLOW_MARGIN.top + FLOW_MARGIN.bottom + sortedLevels.length * NODE_HEIGHT + Math.max(0, sortedLevels.length - 1) * ROW_GAP,
+  );
+  const positioned = new Map<string, FlowLayoutNode>();
+  const layoutNodes: FlowLayoutNode[] = [];
+
+  for (const level of sortedLevels) {
+    const layer = layers.get(level) ?? [];
+    const layerWidth = layer.length * NODE_WIDTH + Math.max(0, layer.length - 1) * BRANCH_COLUMN_GAP;
+    const left = FLOW_MARGIN.left + Math.max(0, (contentWidth - layerWidth) / 2);
+
+    layer.forEach((node, index) => {
+      const layoutNode = {
+        node,
+        x: left + index * (NODE_WIDTH + BRANCH_COLUMN_GAP),
+        y: FLOW_MARGIN.top + level * (NODE_HEIGHT + ROW_GAP),
+      };
+      layoutNodes.push(layoutNode);
+      positioned.set(node.spanId, layoutNode);
+    });
+  }
+
+  const links = layoutNodes.flatMap((target) => {
+    const predecessorIds = predecessorIdsBySpanId.get(target.node.spanId) ?? [];
+    return predecessorIds.flatMap((predecessorId) => {
+      const source = positioned.get(predecessorId);
+      if (!source) {
+        return [];
+      }
+      return [
+        {
+          source,
+          target,
+          path: buildTopDownLinkPath(source, target, NODE_WIDTH, NODE_HEIGHT),
+        },
+      ];
+    });
+  });
+
+  return {
+    nodes: layoutNodes,
+    links,
+    nodeWidth: NODE_WIDTH,
+    nodeHeight: NODE_HEIGHT,
+    width,
+    height,
+    orientation: "vertical",
+  };
+}
+
+function buildHorizontalFlowLayout(nodes: GenAIFlowNode[], edges: GenAIFlowEdge[]): FlowLayout {
+  const orderIndex = new Map(nodes.map((node, index) => [node.spanId, index]));
+  const byId = new Map(nodes.map((node) => [node.spanId, node]));
+  const predecessorIdsBySpanId = getPredecessorIdsBySpanId(nodes, edges);
+  const successorsBySpanId = new Map(nodes.map((node) => [node.spanId, [] as string[]]));
+  const levelCache = new Map<string, number>();
+
+  const getLevel = (node: GenAIFlowNode, visiting = new Set<string>()): number => {
+    const cached = levelCache.get(node.spanId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(node.spanId)) {
+      return 0;
+    }
+    const predecessorIds = predecessorIdsBySpanId.get(node.spanId) ?? [];
+    if (predecessorIds.length === 0) {
+      levelCache.set(node.spanId, 0);
+      return 0;
+    }
+
+    visiting.add(node.spanId);
+    const predecessorLevels = predecessorIds.flatMap((predecessorId) => {
+      const predecessor = byId.get(predecessorId);
+      return predecessor ? [getLevel(predecessor, visiting)] : [];
+    });
+    visiting.delete(node.spanId);
+
+    const level = predecessorLevels.length > 0 ? Math.max(...predecessorLevels) + 1 : 0;
+    levelCache.set(node.spanId, level);
+    return level;
+  };
+
+  for (const node of nodes) {
+    for (const predecessorId of predecessorIdsBySpanId.get(node.spanId) ?? []) {
+      successorsBySpanId.get(predecessorId)?.push(node.spanId);
+    }
+  }
+
+  const reachCache = new Map<string, number>();
+  const getReach = (spanId: string, visiting = new Set<string>()): number => {
+    const cached = reachCache.get(spanId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(spanId)) {
+      return 0;
+    }
+    visiting.add(spanId);
+    const reach = Math.max(0, ...(successorsBySpanId.get(spanId) ?? []).map((successorId) => getReach(successorId, visiting) + 1));
+    visiting.delete(spanId);
+    reachCache.set(spanId, reach);
+    return reach;
+  };
+
+  const layers = new Map<number, GenAIFlowNode[]>();
+  for (const node of nodes) {
+    const level = getLevel(node);
+    const layer = layers.get(level) ?? [];
+    layer.push(node);
+    layers.set(level, layer);
+  }
+
+  const sortedLevels = Array.from(layers.keys()).sort((a, b) => a - b);
+  for (const level of sortedLevels) {
+    layers.get(level)?.sort((a, b) => (orderIndex.get(a.spanId) ?? 0) - (orderIndex.get(b.spanId) ?? 0));
+  }
+
+  const maxLayerSize = Math.max(1, ...Array.from(layers.values()).map((layer) => layer.length));
+  const maxLevel = Math.max(0, ...sortedLevels);
+  const width = Math.max(560, FLOW_MARGIN.left + FLOW_MARGIN.right + (maxLevel + 1) * NODE_WIDTH + maxLevel * LAYER_GAP);
+  const hasBranchRows = maxLayerSize > 1;
+  const hasSkippedLinks = nodes.some((node) => {
+    const targetLevel = getLevel(node);
+    return (predecessorIdsBySpanId.get(node.spanId) ?? []).some((predecessorId) => {
+      const predecessor = byId.get(predecessorId);
+      return predecessor ? targetLevel - getLevel(predecessor) > 1 : false;
+    });
+  });
+  const rowTop = hasBranchRows ? FLOW_MARGIN.top + 24 : 0;
+  const routedLinkY = rowTop + maxLayerSize * NODE_HEIGHT + Math.max(0, maxLayerSize - 1) * ROW_GAP + 14;
+  const branchHeight = rowTop + maxLayerSize * NODE_HEIGHT + Math.max(0, maxLayerSize - 1) * ROW_GAP + FLOW_MARGIN.bottom + (hasSkippedLinks ? 24 : 0);
+  const height = hasBranchRows
+    ? Math.max(BRANCH_FLOW_MIN_HEIGHT, branchHeight)
+    : Math.max(LINEAR_FLOW_MIN_HEIGHT, FLOW_MARGIN.top + FLOW_MARGIN.bottom + maxLayerSize * NODE_HEIGHT + Math.max(0, maxLayerSize - 1) * ROW_GAP);
+  const positioned = new Map<string, FlowLayoutNode>();
+  const layoutNodes: FlowLayoutNode[] = [];
+
+  for (const level of sortedLevels) {
+    const layer = layers.get(level) ?? [];
+    const primaryNode = hasBranchRows
+      ? [...layer].sort((a, b) => getReach(b.spanId) - getReach(a.spanId) || (orderIndex.get(a.spanId) ?? 0) - (orderIndex.get(b.spanId) ?? 0))[0]
+      : null;
+    const layerRows = primaryNode
+      ? [primaryNode, ...layer.filter((node) => node.spanId !== primaryNode.spanId)]
+      : layer;
+    const layerHeight = layerRows.length * NODE_HEIGHT + Math.max(0, layerRows.length - 1) * ROW_GAP;
+    const top = hasBranchRows ? rowTop : FLOW_MARGIN.top + Math.max(0, (height - FLOW_MARGIN.top - FLOW_MARGIN.bottom - layerHeight) / 2);
+
+    layerRows.forEach((node, row) => {
+      const layoutNode = {
+        node,
+        x: FLOW_MARGIN.left + level * (NODE_WIDTH + LAYER_GAP),
+        y: top + row * (NODE_HEIGHT + ROW_GAP),
+      };
+      layoutNodes.push(layoutNode);
+      positioned.set(node.spanId, layoutNode);
+    });
+  }
+
+  const links = layoutNodes.flatMap((target) => {
+    const predecessorIds = predecessorIdsBySpanId.get(target.node.spanId) ?? [];
+    return predecessorIds.flatMap((predecessorId) => {
+      const source = positioned.get(predecessorId);
+      if (!source) {
+        return [];
+      }
+      const sourceLevel = getLevel(source.node);
+      const targetLevel = getLevel(target.node);
+      const routeY = targetLevel - sourceLevel > 1 ? routedLinkY : null;
+      return [
+        {
+          source,
+          target,
+          path: buildHorizontalLinkPath(source, target, NODE_WIDTH, NODE_HEIGHT, routeY),
+        },
+      ];
+    });
+  });
+
+  return {
+    nodes: layoutNodes,
+    links,
+    nodeWidth: NODE_WIDTH,
+    nodeHeight: NODE_HEIGHT,
+    width,
+    height,
+    orientation: "horizontal",
+  };
+}
+
+function buildHorizontalLinkPath(source: FlowLayoutNode, target: FlowLayoutNode, nodeWidth: number, nodeHeight: number, routeY: number | null = null): string {
+  const startX = source.x + nodeWidth;
+  const startY = source.y + nodeHeight / 2;
+  const endX = target.x;
+  const endY = target.y + nodeHeight / 2;
+  if (routeY !== null) {
+    const elbow = 28;
+    return `M${startX},${startY} C${startX + elbow},${startY} ${startX + elbow},${routeY} ${startX + elbow * 2},${routeY} L${endX - elbow * 2},${routeY} C${endX - elbow},${routeY} ${endX - elbow},${endY} ${endX},${endY}`;
+  }
+  const controlOffset = Math.max(48, Math.min(96, (endX - startX) / 2));
+  return `M${startX},${startY} C${startX + controlOffset},${startY} ${endX - controlOffset},${endY} ${endX},${endY}`;
+}
+
+function buildTopDownLinkPath(source: FlowLayoutNode, target: FlowLayoutNode, nodeWidth: number, nodeHeight: number): string {
+  const startX = source.x + nodeWidth / 2;
+  const startY = source.y + nodeHeight;
+  const endX = target.x + nodeWidth / 2;
+  const endY = target.y;
+  const controlOffset = Math.max(24, Math.min(64, (endY - startY) / 2));
+  return `M${startX},${startY} C${startX},${startY + controlOffset} ${endX},${endY - controlOffset} ${endX},${endY}`;
+}
+
+function getPredecessorIdsBySpanId(nodes: GenAIFlowNode[], edges: GenAIFlowEdge[]): Map<string, string[]> {
+  const selectedIds = new Set(nodes.map((node) => node.spanId));
+  const predecessorIdsBySpanId = new Map(nodes.map((node) => [node.spanId, [] as string[]]));
+  for (const edge of edges) {
+    if (!selectedIds.has(edge.source) || !selectedIds.has(edge.target)) {
+      continue;
+    }
+    predecessorIdsBySpanId.get(edge.target)?.push(edge.source);
+  }
+  for (const [spanId, predecessorIds] of predecessorIdsBySpanId) {
+    predecessorIdsBySpanId.set(spanId, uniqueValues(predecessorIds));
+  }
+  return predecessorIdsBySpanId;
+}
+
+function uniqueValues<T>(items: T[]): T[] {
+  return Array.from(new Set(items));
+}
+
+function isNodeSelected(node: GenAIFlowNode, selectedSpanId: string | null): boolean {
+  if (!selectedSpanId) {
+    return false;
+  }
+  return node.spanId === selectedSpanId || node.descendantSpanIds.includes(selectedSpanId) || node.groupedSpanIds.includes(selectedSpanId);
+}
+
+function getNodeTitle(node: GenAIFlowNode): string {
+  return node.name;
+}
+
+function getNodeMeta(node: GenAIFlowNode): string[] {
+  const tokenUsage = node.descendantTokenUsage.total > 0 ? node.descendantTokenUsage : node.tokenUsage;
+  return [
+    node.operation,
+    node.modelNames.length > 0 ? node.modelNames.join(", ") : null,
+    node.kind === "loop" && node.callCount ? `${formatCount(node.callCount)} iterations` : null,
+    node.grouped && node.kind !== "loop" && node.callCount ? `${formatCount(node.callCount)} calls` : null,
+    node.grouped && node.avgDurationMs ? `avg ${formatDuration(node.avgDurationMs)}` : null,
+    node.grouped && node.maxDurationMs ? `max ${formatDuration(node.maxDurationMs)}` : null,
+    (node.kind === "loop" || !node.grouped) && node.descendantLlmCalls > 0 ? `${formatCount(node.descendantLlmCalls)} LLM` : null,
+    (node.kind === "loop" || !node.grouped) && node.descendantToolCalls > 0 ? `${formatCount(node.descendantToolCalls)} tools` : null,
+    tokenUsage.total > 0 ? `${formatCount(tokenUsage.total)} tokens` : null,
+  ].filter((item): item is string => Boolean(item));
+}
+
+function getGroupedFilterType(node: GenAIFlowNode): "llm" | "tool" | "loop" | null {
+  if (!node.grouped) {
+    return null;
+  }
+  if (node.kind === "llm") {
+    return "llm";
+  }
+  if (node.kind === "tool") {
+    return "tool";
+  }
+  if (node.kind === "loop") {
+    return "loop";
+  }
+  return null;
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatRiskLabel(value: number, type: "security" | "privacy"): string {
+  return `${formatCount(value)} ${type} risk${value === 1 ? "" : "s"}`;
+}
+
+function formatRiskFilterLabel(value: number, type: "security" | "privacy"): string {
+  return `Filter waterfall to ${formatCount(value)} ${type} risk span${value === 1 ? "" : "s"}`;
+}
+
+function formatCallLabel(value: number, label: "LLM" | "tool"): string {
+  const noun = label === "LLM" ? "LLM call" : "tool call";
+  return `${formatCount(value)} ${noun}${value === 1 ? "" : "s"}`;
+}
+
+function formatCallFilterLabel(value: number, label: "LLM" | "Tool"): string {
+  const noun = label === "LLM" ? "LLM call" : "tool call";
+  return `Filter waterfall to ${formatCount(value)} ${noun} span${value === 1 ? "" : "s"}`;
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs >= 1000) {
+    return `${(durationMs / 1000).toFixed(1)}s`;
+  }
+  return `${durationMs.toFixed(1)}ms`;
+}
+
+function roundZoom(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function ChevronIcon({ collapsed }: { collapsed: boolean }): React.ReactElement {
+  return (
+    <svg className="genai-flow__chevron" viewBox="0 0 16 16" aria-hidden="true">
+      <path d={collapsed ? "M6 3.5 10.5 8 6 12.5" : "M3.5 6 8 10.5 12.5 6"} />
+    </svg>
+  );
+}
+
+function NodeKindIcon({ kind }: { kind: GenAIFlowNode["kind"] }): React.ReactElement {
+  switch (kind) {
+    case "workflow":
+      return (
+        <svg className="genai-flow__node-icon genai-flow__node-icon--workflow" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M3 3.5h3.2c1.1 0 2 .9 2 2v5c0 1.1.9 2 2 2H13" />
+          <path d="M3 12.5h2.2c1.1 0 2-.9 2-2v-5c0-1.1.9-2 2-2H13" />
+          <path d="M11 1.5 13 3.5 11 5.5" />
+          <path d="M11 10.5 13 12.5 11 14.5" />
+        </svg>
+      );
+    case "agent":
+      return (
+        <svg className="genai-flow__node-icon genai-flow__node-icon--agent" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M3 8a5 5 0 0 1 10 0v3" />
+          <path d="M3 8h2v4H3V8Zm8 0h2v4h-2V8Z" />
+          <path d="M9.4 13H8" />
+        </svg>
+      );
+    case "llm":
+      return (
+        <svg className="genai-flow__node-icon genai-flow__node-icon--llm" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M5 5h6v6H5V5Z" />
+          <path d="M3 6h2M3 10h2M11 6h2M11 10h2M6 3v2M10 3v2M6 11v2M10 11v2" />
+          <path d="M7 7.4h2M7 9h1.2" />
+        </svg>
+      );
+    case "tool":
+      return (
+        <svg className="genai-flow__node-icon genai-flow__node-icon--tool" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M10.5 2.5a3 3 0 0 0 3 3L6 13a2 2 0 0 1-3-3l7.5-7.5Z" />
+          <path d="M4.2 10.8 5.2 11.8" />
+        </svg>
+      );
+    case "retrieval":
+      return (
+        <svg className="genai-flow__node-icon genai-flow__node-icon--retrieval" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M3 4c0-1.1 2.2-2 5-2s5 .9 5 2-2.2 2-5 2-5-.9-5-2Z" />
+          <path d="M3 4v4c0 1.1 2.2 2 5 2s5-.9 5-2V4" />
+          <path d="M3 8v4c0 1.1 2.2 2 5 2s5-.9 5-2V8" />
+        </svg>
+      );
+    case "loop":
+      return (
+        <svg className="genai-flow__node-icon genai-flow__node-icon--loop" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M4.2 5.2A4.6 4.6 0 0 1 12 4.6L13 6" />
+          <path d="M13.2 10.8A4.6 4.6 0 0 1 5.4 11.4L4 10" />
+          <path d="M13.2 3.2V6H10.4" />
+          <path d="M2.8 12.8V10H5.6" />
+        </svg>
+      );
+    default:
+      return (
+        <svg className="genai-flow__node-icon genai-flow__node-icon--genai" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M8 2.5 9.4 6.6 13.5 8 9.4 9.4 8 13.5 6.6 9.4 2.5 8 6.6 6.6 8 2.5Z" />
+        </svg>
+      );
+  }
+}
+
+function CheckIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M16.8739 10.0405C17.2645 9.64996 17.2645 9.01679 16.8739 8.62627C16.4834 8.23574 15.8502 8.23574 15.4597 8.62627L10.5247 13.5613L8.5405 11.5776C8.14992 11.1872 7.51675 11.1873 7.12629 11.5779C6.73582 11.9684 6.73591 12.6016 7.12649 12.9921L9.46426 15.3291C10.0501 15.9148 10.9997 15.9147 11.5854 15.329L16.8739 10.0405Z" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z"
+      />
+    </svg>
+  );
+}
+
+function IssueIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M13.2003 15.8001C13.2003 16.4628 12.663 17.0001 12.0003 17.0001C11.3376 17.0001 10.8003 16.4628 10.8003 15.8001C10.8003 15.1374 11.3376 14.6001 12.0003 14.6001C12.663 14.6001 13.2003 15.1374 13.2003 15.8001Z" />
+      <path d="M11.0005 7.9906V12.0001C11.0005 12.5524 11.4482 13.0001 12.0005 13.0001C12.5528 13.0001 13.0005 12.5524 13.0005 12.0001V7.9906C13.0005 7.43832 12.5528 6.9906 12.0005 6.9906C11.4482 6.9906 11.0005 7.43832 11.0005 7.9906Z" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4Z"
+      />
+    </svg>
+  );
+}
+
+function ShieldIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M13 12.0161C13.7409 11.6479 14.25 10.8834 14.25 10C14.25 8.75736 13.2426 7.75 12 7.75C10.7574 7.75 9.75 8.75736 9.75 10C9.75 10.8834 10.2591 11.6479 11 12.0161V16H13V12.0161Z" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12.8061 2.32738C12.3127 2.02076 11.6876 2.02076 11.1941 2.32738C10.2532 2.91204 7.16424 4.71652 4.24662 5.25247C3.53752 5.38273 2.99511 6.00641 3.00202 6.75477C3.04969 11.9204 3.92652 15.2072 5.48287 17.4717C7.0462 19.7463 9.20062 20.8421 11.3878 21.8218C11.777 21.9961 12.2233 21.9961 12.6125 21.8218C14.7997 20.8421 16.9541 19.7463 18.5174 17.4717C20.0738 15.2072 20.9506 11.9204 20.9983 6.75477C21.0052 6.00641 20.4628 5.38273 19.7537 5.25247C16.836 4.71652 13.7471 2.91204 12.8061 2.32738ZM12.0001 4.17905C10.8488 4.87511 7.9483 6.50532 5.00749 7.1397C5.09466 11.8756 5.93216 14.5944 7.13112 16.3389C8.3175 18.065 9.9447 18.9732 12.0001 19.9041C14.0556 18.9732 15.6828 18.065 16.8692 16.3389C18.0681 14.5944 18.9056 11.8756 18.9928 7.1397C16.052 6.50532 13.1515 4.87511 12.0001 4.17905Z"
+      />
+    </svg>
+  );
+}
+
+function LockIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M11 17C11 17.5523 11.4477 18 12 18C12.5523 18 13 17.5523 13 17V15C13 14.4477 12.5523 14 12 14C11.4477 14 11 14.4477 11 15V17Z" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M7.05078 7.05836V9.90576H6C4.89543 9.90576 4 10.8012 4 11.9058V19.9058C4 21.0103 4.89543 21.9058 6 21.9058H18C19.1046 21.9058 20 21.0103 20 19.9058V11.9058C20 10.8012 19.1046 9.90576 18 9.90576H16.9766V7.05836C16.9766 4.31743 14.7546 2.09546 12.0137 2.09546C9.27274 2.09546 7.05078 4.31742 7.05078 7.05836ZM12.0137 4.09546C10.3773 4.09546 9.05078 5.42199 9.05078 7.05836V9.90576H14.9766V7.05836C14.9766 5.42199 13.65 4.09546 12.0137 4.09546ZM18 11.9058H6V19.9058H18V11.9058Z"
+      />
+    </svg>
+  );
+}
+
+function CenterIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M7.2 1h1.6v4.2H7.2V1Zm0 9.8h1.6V15H7.2v-4.2ZM1 7.2h4.2v1.6H1V7.2Zm9.8 0H15v1.6h-4.2V7.2Z" />
+      <path d="M6.2 6.2h3.6v3.6H6.2V6.2Z" />
+    </svg>
+  );
+}
+
+function ZoomOutIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M7 2a5 5 0 1 0 3 9l2.5 2.5 1-1L11 10A5 5 0 0 0 7 2Zm0 1.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z" />
+      <path d="M4.8 6.3h4.4v1.4H4.8V6.3Z" />
+    </svg>
+  );
+}
+
+function ZoomInIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M7 2a5 5 0 1 0 3 9l2.5 2.5 1-1L11 10A5 5 0 0 0 7 2Zm0 1.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z" />
+      <path d="M6.3 4.8h1.4v1.5h1.5v1.4H7.7v1.5H6.3V7.7H4.8V6.3h1.5V4.8Z" />
+    </svg>
+  );
+}

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -885,9 +885,11 @@ function NodeKindIcon({ kind }: { kind: GenAIFlowNode["kind"] }): React.ReactEle
     case "retrieval":
       return (
         <svg className="genai-flow__node-icon genai-flow__node-icon--retrieval" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M3 4c0-1.1 2.2-2 5-2s5 .9 5 2-2.2 2-5 2-5-.9-5-2Z" />
-          <path d="M3 4v4c0 1.1 2.2 2 5 2s5-.9 5-2V4" />
-          <path d="M3 8v4c0 1.1 2.2 2 5 2s5-.9 5-2V8" />
+          <path d="M2.8 4c0-1.1 2-2 4.5-2s4.5.9 4.5 2-2 2-4.5 2-4.5-.9-4.5-2Z" />
+          <path d="M2.8 4v4c0 1 1.6 1.8 3.8 2" />
+          <path d="M11.8 4v2.8" />
+          <path d="M9 10.8a2.2 2.2 0 1 0 4.4 0 2.2 2.2 0 0 0-4.4 0Z" />
+          <path d="M12.8 12.4 14.2 13.8" />
         </svg>
       );
     case "loop":

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -264,13 +264,6 @@ function GenAIFlowLegend(): React.ReactElement {
         </span>
         <span>Issue</span>
       </span>
-      <span className="genai-flow__legend-item">
-        <span className="genai-flow__legend-call">
-          <NodeKindIcon kind="llm" />
-          <span>2</span>
-        </span>
-        <span>Nested calls</span>
-      </span>
     </div>
   );
 }

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -244,8 +244,7 @@ function GenAIFlowLegend(): React.ReactElement {
   ];
 
   return (
-    <div className="genai-flow__legend" aria-label="GenAI flow legend">
-      <span className="genai-flow__legend-label">Legend</span>
+    <div className="genai-flow__legend" aria-label="GenAI flow guide">
       {kindItems.map((item) => (
         <span className="genai-flow__legend-item" key={item.kind}>
           <NodeKindIcon kind={item.kind} />
@@ -266,7 +265,10 @@ function GenAIFlowLegend(): React.ReactElement {
         <span>Issue</span>
       </span>
       <span className="genai-flow__legend-item">
-        <span className="genai-flow__legend-chip">LLM n</span>
+        <span className="genai-flow__legend-call">
+          <NodeKindIcon kind="llm" />
+          <span>2</span>
+        </span>
         <span>Nested calls</span>
       </span>
     </div>
@@ -418,7 +420,7 @@ function GenAIFlowCard({
               onClick={(event) => applySpanFilterFromSignal(event, "llm", node.descendantLlmSpanIds)}
               onKeyDown={(event) => handleSpanFilterSignalKeyDown(event, "llm", node.descendantLlmSpanIds)}
             >
-              <span>LLM</span>
+              <NodeKindIcon kind="llm" />
               <span>{formatCount(node.descendantLlmCalls)}</span>
             </span>
           ) : null}
@@ -432,7 +434,7 @@ function GenAIFlowCard({
               onClick={(event) => applySpanFilterFromSignal(event, "tool", node.descendantToolSpanIds)}
               onKeyDown={(event) => handleSpanFilterSignalKeyDown(event, "tool", node.descendantToolSpanIds)}
             >
-              <span>Tool</span>
+              <NodeKindIcon kind="tool" />
               <span>{formatCount(node.descendantToolCalls)}</span>
             </span>
           ) : null}

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -82,7 +82,7 @@ export function GenAITraceOverview({
     const observer = new ResizeObserver(updateWidth);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [collapsed]);
+  }, []);
 
   useEffect(() => {
     setZoom(1);

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -4,11 +4,13 @@ import { ValidationBadge } from "../components/ValidationBadge";
 import type { ValidationIndex } from "../validation/utils";
 import { lookupSpanValidation } from "../validation/utils";
 
+type GenAISpanFilterType = "security" | "privacy" | "llm" | "tool" | "loop" | "quality";
+
 interface GenAITraceOverviewProps {
   summary: GenAITraceSummary | null;
   selectedSpanId: string | null;
   onSelectSpan: (spanId: string | null) => void;
-  onApplySpanFilter: (type: "security" | "privacy" | "llm" | "tool" | "loop", spanIds: string[]) => void;
+  onApplySpanFilter: (type: GenAISpanFilterType, spanIds: string[]) => void;
   validationIndex: ValidationIndex;
 }
 
@@ -246,16 +248,21 @@ function GenAIFlowCard({
   width: number;
   height: number;
   onSelectSpan: (spanId: string | null) => void;
-  onApplySpanFilter: (type: "security" | "privacy" | "llm" | "tool" | "loop", spanIds: string[]) => void;
+  onApplySpanFilter: (type: GenAISpanFilterType, spanIds: string[]) => void;
   validationIndex: ValidationIndex;
 }): React.ReactElement {
   const validation = lookupSpanValidation(validationIndex, node.traceId, node.spanId);
   const title = getNodeTitle(node);
-  const hasQualityIssues = (validation?.count ?? 0) > 0;
+  const evaluationCount = node.descendantEvaluationCount ?? 0;
+  const failedEvaluationCount = node.descendantEvaluationFailedCount ?? 0;
+  const hasEvaluations = evaluationCount > 0;
+  const hasQualityIssues = failedEvaluationCount > 0;
   const hasLLMCalls = (node.kind === "loop" || !node.grouped) && node.descendantLlmCalls > 0;
   const hasToolCalls = (node.kind === "loop" || !node.grouped) && node.descendantToolCalls > 0;
   const hasSecurityRisk = node.descendantSecurityRiskCount > 0;
   const hasPrivacyRisk = node.descendantPrivacyRiskCount > 0;
+  const firstFailedEvaluationSpanId = node.descendantEvaluationFailedSpanIds?.[0] ?? "";
+  const canSelectFailedEvaluationSpan = firstFailedEvaluationSpanId !== "";
   const meta = getNodeMeta(node);
   const ariaLabel = `${node.kind} ${title}${meta.length > 0 ? `, ${meta.join(", ")}` : ""}`;
   const groupedFilterType = getGroupedFilterType(node);
@@ -275,16 +282,16 @@ function GenAIFlowCard({
       selectNode();
     }
   };
-  const stopSignalPropagation = (event: React.SyntheticEvent) => {
+  const selectFirstFailedEvaluationSpan = (event: React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>) => {
     event.stopPropagation();
+    if (!firstFailedEvaluationSpanId) return;
+    onSelectSpan(firstFailedEvaluationSpanId);
   };
-  const applySpanFilter = (
-    event: React.MouseEvent<HTMLButtonElement>,
-    type: "security" | "privacy" | "llm" | "tool" | "loop",
-    spanIds: string[],
-  ) => {
-    event.stopPropagation();
-    onApplySpanFilter(type, spanIds);
+  const handleFailedEvaluationSignalKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      selectFirstFailedEvaluationSpan(event);
+    }
   };
 
   return (
@@ -315,64 +322,69 @@ function GenAIFlowCard({
         <span
           className="quality-issues-container genai-flow__signals"
           aria-label="GenAI node signals"
-          onClick={stopSignalPropagation}
-          onKeyDown={stopSignalPropagation}
         >
           {node.statusCode === "ERROR" ? <span className="genai-flow__badge genai-flow__badge--error">Error</span> : null}
-          <span
-            className={`genai-flow__signal genai-flow__signal--${hasQualityIssues ? "issue" : "ok"}`}
-            aria-label={hasQualityIssues ? `${validation?.count ?? 0} quality issues` : "No quality issues detected"}
-            data-tooltip={hasQualityIssues ? `${validation?.count ?? 0} quality issues` : "No quality issues detected"}
-          >
-            {hasQualityIssues ? <IssueIcon /> : <CheckIcon />}
-          </span>
+          {hasQualityIssues ? (
+            <span
+              className={`genai-flow__signal genai-flow__signal--issue${canSelectFailedEvaluationSpan ? " genai-flow__signal--interactive" : ""}`}
+              aria-label={formatQualityIssueLabel(failedEvaluationCount)}
+              data-tooltip={`${formatQualityIssueLabel(failedEvaluationCount)} on nested spans`}
+              role={canSelectFailedEvaluationSpan ? "button" : undefined}
+              tabIndex={canSelectFailedEvaluationSpan ? 0 : undefined}
+              onClick={canSelectFailedEvaluationSpan ? selectFirstFailedEvaluationSpan : undefined}
+              onKeyDown={canSelectFailedEvaluationSpan ? handleFailedEvaluationSignalKeyDown : undefined}
+            >
+              <IssueIcon />
+              {failedEvaluationCount > 1 ? <span>{formatCount(failedEvaluationCount)}</span> : null}
+            </span>
+          ) : (
+            <span
+              className={`genai-flow__signal genai-flow__signal--${hasEvaluations ? "ok" : "unknown"}`}
+              aria-label={hasEvaluations ? "Evaluated with no quality issues" : "Not evaluated for quality issues"}
+              data-tooltip={hasEvaluations ? "Evaluated with no quality issues" : "Not evaluated for quality issues"}
+            >
+              {hasEvaluations ? <CheckIcon /> : <NotEvaluatedIcon />}
+            </span>
+          )}
           {hasLLMCalls ? (
-            <button
-              className="genai-flow__signal genai-flow__signal--call genai-flow__signal-button"
-              type="button"
-              aria-label={formatCallFilterLabel(node.descendantLlmCalls, "LLM")}
-              data-tooltip={`${formatCallLabel(node.descendantLlmCalls, "LLM")}. Click to filter waterfall.`}
-              onClick={(event) => applySpanFilter(event, "llm", node.descendantLlmSpanIds)}
+            <span
+              className="genai-flow__signal genai-flow__signal--call"
+              aria-label={formatCallLabel(node.descendantLlmCalls, "LLM")}
+              data-tooltip={`${formatCallLabel(node.descendantLlmCalls, "LLM")} on nested spans`}
             >
               <span>LLM</span>
               <span>{formatCount(node.descendantLlmCalls)}</span>
-            </button>
+            </span>
           ) : null}
           {hasToolCalls ? (
-            <button
-              className="genai-flow__signal genai-flow__signal--call genai-flow__signal-button"
-              type="button"
-              aria-label={formatCallFilterLabel(node.descendantToolCalls, "Tool")}
-              data-tooltip={`${formatCallLabel(node.descendantToolCalls, "tool")}. Click to filter waterfall.`}
-              onClick={(event) => applySpanFilter(event, "tool", node.descendantToolSpanIds)}
+            <span
+              className="genai-flow__signal genai-flow__signal--call"
+              aria-label={formatCallLabel(node.descendantToolCalls, "tool")}
+              data-tooltip={`${formatCallLabel(node.descendantToolCalls, "tool")} on nested spans`}
             >
               <span>Tool</span>
               <span>{formatCount(node.descendantToolCalls)}</span>
-            </button>
+            </span>
           ) : null}
           {hasSecurityRisk ? (
-            <button
-              className="genai-flow__signal genai-flow__signal--risk genai-flow__signal-button"
-              type="button"
-              aria-label={formatRiskFilterLabel(node.descendantSecurityRiskCount, "security")}
-              data-tooltip={`${formatRiskLabel(node.descendantSecurityRiskCount, "security")}. Click to filter waterfall.`}
-              onClick={(event) => applySpanFilter(event, "security", node.descendantSecurityRiskSpanIds)}
+            <span
+              className="genai-flow__signal genai-flow__signal--risk"
+              aria-label={formatRiskLabel(node.descendantSecurityRiskCount, "security")}
+              data-tooltip={`${formatRiskLabel(node.descendantSecurityRiskCount, "security")} on nested spans`}
             >
               <ShieldIcon />
               <span>{formatCount(node.descendantSecurityRiskCount)}</span>
-            </button>
+            </span>
           ) : null}
           {hasPrivacyRisk ? (
-            <button
-              className="genai-flow__signal genai-flow__signal--risk genai-flow__signal-button"
-              type="button"
-              aria-label={formatRiskFilterLabel(node.descendantPrivacyRiskCount, "privacy")}
-              data-tooltip={`${formatRiskLabel(node.descendantPrivacyRiskCount, "privacy")}. Click to filter waterfall.`}
-              onClick={(event) => applySpanFilter(event, "privacy", node.descendantPrivacyRiskSpanIds)}
+            <span
+              className="genai-flow__signal genai-flow__signal--risk"
+              aria-label={formatRiskLabel(node.descendantPrivacyRiskCount, "privacy")}
+              data-tooltip={`${formatRiskLabel(node.descendantPrivacyRiskCount, "privacy")} on nested spans`}
             >
               <LockIcon />
               <span>{formatCount(node.descendantPrivacyRiskCount)}</span>
-            </button>
+            </span>
           ) : null}
           <ValidationBadge count={validation?.count ?? 0} severity={validation?.highestSeverity ?? null} />
         </span>
@@ -735,18 +747,13 @@ function formatRiskLabel(value: number, type: "security" | "privacy"): string {
   return `${formatCount(value)} ${type} risk${value === 1 ? "" : "s"}`;
 }
 
-function formatRiskFilterLabel(value: number, type: "security" | "privacy"): string {
-  return `Filter waterfall to ${formatCount(value)} ${type} risk span${value === 1 ? "" : "s"}`;
-}
-
 function formatCallLabel(value: number, label: "LLM" | "tool"): string {
   const noun = label === "LLM" ? "LLM call" : "tool call";
   return `${formatCount(value)} ${noun}${value === 1 ? "" : "s"}`;
 }
 
-function formatCallFilterLabel(value: number, label: "LLM" | "Tool"): string {
-  const noun = label === "LLM" ? "LLM call" : "tool call";
-  return `Filter waterfall to ${formatCount(value)} ${noun} span${value === 1 ? "" : "s"}`;
+function formatQualityIssueLabel(value: number): string {
+  return `${formatCount(value)} quality issue${value === 1 ? "" : "s"}`;
 }
 
 function formatDuration(durationMs: number): string {
@@ -851,6 +858,19 @@ function IssueIcon(): React.ReactElement {
         clipRule="evenodd"
         d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4Z"
       />
+    </svg>
+  );
+}
+
+function NotEvaluatedIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12Z"
+      />
+      <path d="M8 11H16V13H8V11Z" />
     </svg>
   );
 }

--- a/observer/client/src/traces/GenAITraceOverview.tsx
+++ b/observer/client/src/traces/GenAITraceOverview.tsx
@@ -287,10 +287,29 @@ function GenAIFlowCard({
     if (!firstFailedEvaluationSpanId) return;
     onSelectSpan(firstFailedEvaluationSpanId);
   };
+  const applySpanFilterFromSignal = (
+    event: React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>,
+    type: GenAISpanFilterType,
+    spanIds: string[],
+  ) => {
+    event.stopPropagation();
+    if (spanIds.length === 0) return;
+    onApplySpanFilter(type, spanIds);
+  };
   const handleFailedEvaluationSignalKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       selectFirstFailedEvaluationSpan(event);
+    }
+  };
+  const handleSpanFilterSignalKeyDown = (
+    event: React.KeyboardEvent<HTMLSpanElement>,
+    type: GenAISpanFilterType,
+    spanIds: string[],
+  ) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      applySpanFilterFromSignal(event, type, spanIds);
     }
   };
 
@@ -348,9 +367,13 @@ function GenAIFlowCard({
           )}
           {hasLLMCalls ? (
             <span
-              className="genai-flow__signal genai-flow__signal--call"
+              className="genai-flow__signal genai-flow__signal--call genai-flow__signal--interactive"
               aria-label={formatCallLabel(node.descendantLlmCalls, "LLM")}
               data-tooltip={`${formatCallLabel(node.descendantLlmCalls, "LLM")} on nested spans`}
+              role="button"
+              tabIndex={0}
+              onClick={(event) => applySpanFilterFromSignal(event, "llm", node.descendantLlmSpanIds)}
+              onKeyDown={(event) => handleSpanFilterSignalKeyDown(event, "llm", node.descendantLlmSpanIds)}
             >
               <span>LLM</span>
               <span>{formatCount(node.descendantLlmCalls)}</span>
@@ -358,9 +381,13 @@ function GenAIFlowCard({
           ) : null}
           {hasToolCalls ? (
             <span
-              className="genai-flow__signal genai-flow__signal--call"
+              className="genai-flow__signal genai-flow__signal--call genai-flow__signal--interactive"
               aria-label={formatCallLabel(node.descendantToolCalls, "tool")}
               data-tooltip={`${formatCallLabel(node.descendantToolCalls, "tool")} on nested spans`}
+              role="button"
+              tabIndex={0}
+              onClick={(event) => applySpanFilterFromSignal(event, "tool", node.descendantToolSpanIds)}
+              onKeyDown={(event) => handleSpanFilterSignalKeyDown(event, "tool", node.descendantToolSpanIds)}
             >
               <span>Tool</span>
               <span>{formatCount(node.descendantToolCalls)}</span>
@@ -368,9 +395,13 @@ function GenAIFlowCard({
           ) : null}
           {hasSecurityRisk ? (
             <span
-              className="genai-flow__signal genai-flow__signal--risk"
+              className="genai-flow__signal genai-flow__signal--risk genai-flow__signal--interactive"
               aria-label={formatRiskLabel(node.descendantSecurityRiskCount, "security")}
               data-tooltip={`${formatRiskLabel(node.descendantSecurityRiskCount, "security")} on nested spans`}
+              role="button"
+              tabIndex={0}
+              onClick={(event) => applySpanFilterFromSignal(event, "security", node.descendantSecurityRiskSpanIds)}
+              onKeyDown={(event) => handleSpanFilterSignalKeyDown(event, "security", node.descendantSecurityRiskSpanIds)}
             >
               <ShieldIcon />
               <span>{formatCount(node.descendantSecurityRiskCount)}</span>
@@ -378,9 +409,13 @@ function GenAIFlowCard({
           ) : null}
           {hasPrivacyRisk ? (
             <span
-              className="genai-flow__signal genai-flow__signal--risk"
+              className="genai-flow__signal genai-flow__signal--risk genai-flow__signal--interactive"
               aria-label={formatRiskLabel(node.descendantPrivacyRiskCount, "privacy")}
               data-tooltip={`${formatRiskLabel(node.descendantPrivacyRiskCount, "privacy")} on nested spans`}
+              role="button"
+              tabIndex={0}
+              onClick={(event) => applySpanFilterFromSignal(event, "privacy", node.descendantPrivacyRiskSpanIds)}
+              onKeyDown={(event) => handleSpanFilterSignalKeyDown(event, "privacy", node.descendantPrivacyRiskSpanIds)}
             >
               <LockIcon />
               <span>{formatCount(node.descendantPrivacyRiskCount)}</span>

--- a/observer/client/src/traces/SpanDetailsPanel.tsx
+++ b/observer/client/src/traces/SpanDetailsPanel.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { Span, ValidationFinding } from "../api/types";
 import { CopyTextButton } from "../layout";
 import { KVTable } from "../components/KVTable";
+import { formatEvaluationName, getSpanEvaluations, type GenAIEvaluation } from "./genai-evaluations";
 
 interface SpanDetailsPanelProps {
   span: Span;
@@ -9,7 +10,7 @@ interface SpanDetailsPanelProps {
   onClose?: () => void;
 }
 
-type TabId = "info" | "attributes" | "events" | "links";
+type TabId = "info" | "ai-details" | "attributes" | "events" | "links";
 
 function nanoToMs(ts: string): number {
   if (/^\d+$/.test(ts)) {
@@ -31,17 +32,28 @@ function relativeTime(eventNano: string, spanStartNano: string): string {
 export function SpanDetailsPanel({ span, validationFindings, onClose }: SpanDetailsPanelProps): React.ReactElement {
   const [activeTab, setActiveTab] = useState<TabId>("info");
   const [attributeFilter, setAttributeFilter] = useState("");
+  const lastSpanIdRef = useRef<string | null>(null);
 
   const attrCount = Object.keys(span.attributes ?? {}).length;
   const eventCount = (span.events ?? []).length;
   const linkCount = (span.links ?? []).length;
+  const evaluations = useMemo(() => getSpanEvaluations(span), [span]);
+  const failedEvaluationCount = evaluations.filter((evaluation) => !evaluation.passed).length;
   const filteredAttributes = useMemo(
     () => Object.entries(span.attributes ?? {}).filter(([key, value]) => attributeMatchesFilter(key, value, attributeFilter)),
     [attributeFilter, span.attributes],
   );
 
+  useEffect(() => {
+    if (lastSpanIdRef.current === span.spanId) return;
+    lastSpanIdRef.current = span.spanId;
+    setActiveTab(evaluations.length > 0 ? "ai-details" : "info");
+    setAttributeFilter("");
+  }, [span.spanId, evaluations.length]);
+
   const tabs: { id: TabId; label: string; count?: number }[] = [
     { id: "info", label: "Info" },
+    ...(evaluations.length > 0 ? [{ id: "ai-details" as const, label: "AI details", count: evaluations.length }] : []),
     { id: "attributes", label: "Attributes", count: attrCount },
     { id: "events", label: "Events", count: eventCount },
     { id: "links", label: "Links", count: linkCount },
@@ -110,6 +122,28 @@ export function SpanDetailsPanel({ span, validationFindings, onClose }: SpanDeta
                 ...(span.resource?.serviceName ? [{ key: "Service", value: span.resource.serviceName }] : []),
                 ...(span.scope?.name ? [{ key: "Scope", value: `${span.scope.name}${span.scope.version ? ` v${span.scope.version}` : ""}` }] : []),
               ]} />
+            </div>
+          </div>
+        ) : null}
+
+        {activeTab === "ai-details" ? (
+          <div className="span-details__section">
+            <div className="span-details__section-body span-details__ai-details">
+              <div className="ai-evaluations__header">
+                <span className="ai-evaluations__title">Evaluations</span>
+                {failedEvaluationCount > 0 ? (
+                  <span className="ai-evaluations__issue-count">
+                    {failedEvaluationCount} issue{failedEvaluationCount === 1 ? "" : "s"}
+                  </span>
+                ) : (
+                  <span className="ai-evaluations__ok-count">No quality issues</span>
+                )}
+              </div>
+              <div className="ai-evaluations__list">
+                {evaluations.map((evaluation, index) => (
+                  <EvaluationItem evaluation={evaluation} key={`${evaluation.name}:${index}`} />
+                ))}
+              </div>
             </div>
           </div>
         ) : null}
@@ -184,6 +218,33 @@ export function SpanDetailsPanel({ span, validationFindings, onClose }: SpanDeta
       </div>
     </div>
   );
+}
+
+function EvaluationItem({ evaluation }: { evaluation: GenAIEvaluation }): React.ReactElement {
+  const scoreText = formatEvaluationScore(evaluation);
+  return (
+    <div className={`ai-evaluations__item ${evaluation.passed ? "ai-evaluations__item--ok" : "ai-evaluations__item--issue"}`}>
+      <span className="ai-evaluations__status" aria-hidden="true">
+        {evaluation.passed ? "✓" : "!"}
+      </span>
+      <div className="ai-evaluations__content">
+        <div className="ai-evaluations__line">
+          <strong>{formatEvaluationName(evaluation.name)}</strong>
+          {evaluation.scoreLabel ? <span className="ai-evaluations__label">{evaluation.scoreLabel}</span> : null}
+          {scoreText ? <span className="ai-evaluations__score">{scoreText}</span> : null}
+        </div>
+        {evaluation.explanation ? <div className="ai-evaluations__explanation">{evaluation.explanation}</div> : null}
+        {evaluation.errorType ? <div className="ai-evaluations__explanation">Error: {evaluation.errorType}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+function formatEvaluationScore(evaluation: GenAIEvaluation): string | null {
+  if (evaluation.scoreValue == null) {
+    return null;
+  }
+  return Number.isInteger(evaluation.scoreValue) ? String(evaluation.scoreValue) : evaluation.scoreValue.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
 }
 
 function formatNanoTimestamp(ts: string): string {

--- a/observer/client/src/traces/TraceWaterfall.test.tsx
+++ b/observer/client/src/traces/TraceWaterfall.test.tsx
@@ -454,6 +454,13 @@ describe("TraceWaterfall GenAI overview", () => {
     const riskSignal = container.querySelector(".genai-flow__signal--risk");
     expect(riskSignal?.getAttribute("title")).toBeNull();
     expect(riskSignal?.getAttribute("data-tooltip")).toBe("1 security risk on nested spans");
+    fireEvent.click(riskSignal as Element);
+    expect(onSelectSpan).toHaveBeenCalledWith(null);
+    expect(screen.getByRole("button", { name: /Security risk spans/ })).toBeTruthy();
+    expect(screen.getByText("1 / 4 spans")).toBeTruthy();
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: /Security risk spans/ }));
+    onSelectSpan.mockClear();
     expect(screen.getByRole("button", { name: /llm chat gpt-4o/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /tool fetch_logs/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /retrieval retrieval vector_store/i })).toBeTruthy();

--- a/observer/client/src/traces/TraceWaterfall.test.tsx
+++ b/observer/client/src/traces/TraceWaterfall.test.tsx
@@ -705,6 +705,83 @@ describe("TraceWaterfall GenAI overview", () => {
     expect(container.querySelectorAll(".waterfall__row")).toHaveLength(4);
   });
 
+  it("keeps GenAI-filtered waterfall rows aligned with collapsed parents", () => {
+    setObservedCanvasWidth(900);
+    const spans = [
+      makeSpan({
+        spanId: "workflow",
+        name: "Budget Guru",
+        attributes: {
+          "gen_ai.operation.name": "invoke_workflow",
+          "gen_ai.workflow.name": "Budget Guru",
+        },
+      }),
+      makeSpan({
+        spanId: "agent",
+        parentSpanId: "workflow",
+        name: "LangGraph",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "LangGraph",
+        },
+      }),
+      makeSpan({
+        spanId: "llm",
+        parentSpanId: "agent",
+        name: "chat gpt-5.5",
+        attributes: {
+          "gen_ai.operation.name": "chat",
+          "gen_ai.request.model": "gpt-5.5",
+        },
+      }),
+    ];
+    const baseSummary = makeGenAISummary(spans);
+    const workflowNode = baseSummary.flowNodes.find((node) => node.spanId === "workflow");
+    const agentNode = baseSummary.flowNodes.find((node) => node.spanId === "agent");
+    const llmTemplate = baseSummary.flowNodes.find((node) => node.spanId === "llm");
+    if (!workflowNode || !agentNode || !llmTemplate) {
+      throw new Error("missing fixture flow nodes");
+    }
+    const loopNode: GenAIFlowNode = {
+      ...llmTemplate,
+      nodeId: "group:agent:loop:agent_llm",
+      spanId: "group:agent:loop:agent_llm",
+      name: "agent + chat loop x1",
+      kind: "loop",
+      operation: "loop",
+      grouped: true,
+      callCount: 1,
+      groupedSpanIds: ["agent", "llm"],
+      descendantSpanIds: ["agent", "llm"],
+      descendantLlmCalls: 1,
+      descendantLlmSpanIds: ["llm"],
+    };
+
+    const { container } = render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={{
+          ...baseSummary,
+          flowNodes: [workflowNode, loopNode],
+          flowEdges: [{ source: "workflow", target: loopNode.spanId }],
+        }}
+        selectedSpanId={null}
+        onSelectSpan={vi.fn()}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /loop agent \+ chat loop x1/i }));
+    expect(screen.getByText("2 / 3 spans")).toBeTruthy();
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(2);
+
+    const collapseButton = container.querySelector<HTMLElement>(".waterfall__toggle");
+    fireEvent.click(collapseButton as HTMLElement);
+
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(1);
+  });
+
   it("renders branching GenAI agent flows vertically on narrow panels", () => {
     setObservedCanvasWidth(480);
     const spans = makeBranchingFixtureSpans();

--- a/observer/client/src/traces/TraceWaterfall.test.tsx
+++ b/observer/client/src/traces/TraceWaterfall.test.tsx
@@ -449,7 +449,7 @@ describe("TraceWaterfall GenAI overview", () => {
     expect(screen.getByLabelText("Center flow")).toBeTruthy();
     expect(screen.getByLabelText("Zoom out")).toBeTruthy();
     expect(screen.getByLabelText("Zoom in")).toBeTruthy();
-    expect(screen.getByLabelText("GenAI flow legend")).toBeTruthy();
+    expect(screen.getByLabelText("GenAI flow guide")).toBeTruthy();
     expect(screen.getByText("Workflow")).toBeTruthy();
     expect(screen.getByText("Agent")).toBeTruthy();
     expect(screen.getByText("LLM")).toBeTruthy();

--- a/observer/client/src/traces/TraceWaterfall.test.tsx
+++ b/observer/client/src/traces/TraceWaterfall.test.tsx
@@ -455,7 +455,6 @@ describe("TraceWaterfall GenAI overview", () => {
     expect(screen.getByText("LLM")).toBeTruthy();
     expect(screen.getByText("Tool")).toBeTruthy();
     expect(screen.getByText("Evaluated")).toBeTruthy();
-    expect(screen.getByText("Nested calls")).toBeTruthy();
     expect(screen.getByTestId("genai-agent-flow")).toBeTruthy();
     expect(screen.getByRole("button", { name: /triage-agent/i })).toBeTruthy();
     const riskSignal = container.querySelector(".genai-flow__signal--risk");

--- a/observer/client/src/traces/TraceWaterfall.test.tsx
+++ b/observer/client/src/traces/TraceWaterfall.test.tsx
@@ -449,6 +449,13 @@ describe("TraceWaterfall GenAI overview", () => {
     expect(screen.getByLabelText("Center flow")).toBeTruthy();
     expect(screen.getByLabelText("Zoom out")).toBeTruthy();
     expect(screen.getByLabelText("Zoom in")).toBeTruthy();
+    expect(screen.getByLabelText("GenAI flow legend")).toBeTruthy();
+    expect(screen.getByText("Workflow")).toBeTruthy();
+    expect(screen.getByText("Agent")).toBeTruthy();
+    expect(screen.getByText("LLM")).toBeTruthy();
+    expect(screen.getByText("Tool")).toBeTruthy();
+    expect(screen.getByText("Evaluated")).toBeTruthy();
+    expect(screen.getByText("Nested calls")).toBeTruthy();
     expect(screen.getByTestId("genai-agent-flow")).toBeTruthy();
     expect(screen.getByRole("button", { name: /triage-agent/i })).toBeTruthy();
     const riskSignal = container.querySelector(".genai-flow__signal--risk");

--- a/observer/client/src/traces/TraceWaterfall.test.tsx
+++ b/observer/client/src/traces/TraceWaterfall.test.tsx
@@ -75,11 +75,11 @@ function makeBranchingFixtureSpans(): Span[] {
 }
 
 function makeGenAISummary(spans: Span[]): GenAITraceSummary {
-  const flowSpans = spans.filter((span) => Object.keys(span.attributes).some((key) => key.startsWith("gen_ai.")));
+  const flowSpans = spans.filter(hasFixtureGenAISignal);
   const nodeSpans = flowSpans.filter((span) => {
     const operation = String(span.attributes["gen_ai.operation.name"] ?? "");
     const kind = getFixtureKind(span, operation);
-    return kind === "workflow" || kind === "agent" || kind === "tool" || kind === "llm" || kind === "retrieval";
+    return !isFixtureEvaluationOnlySpan(span) && (kind === "workflow" || kind === "agent" || kind === "tool" || kind === "llm" || kind === "retrieval");
   });
   const selectedIds = new Set(nodeSpans.map((span) => span.spanId));
   const nodeBySpanId = new Map<string, GenAIFlowNode>();
@@ -115,6 +115,9 @@ function makeGenAISummary(spans: Span[]): GenAITraceSummary {
       descendantPrivacyRiskCount: 0,
       descendantPrivacyRiskSpanIds: [],
       descendantRiskCount: 0,
+      descendantEvaluationCount: 0,
+      descendantEvaluationFailedCount: 0,
+      descendantEvaluationFailedSpanIds: [],
     };
     nodeBySpanId.set(span.spanId, node);
     return node;
@@ -149,6 +152,7 @@ function makeGenAISummary(spans: Span[]): GenAITraceSummary {
       node.descendantPrivacyRiskCount += 1;
     }
     node.descendantRiskCount = new Set([...node.descendantSecurityRiskSpanIds, ...node.descendantPrivacyRiskSpanIds]).size;
+    addFixtureEvaluationSignals(node, span);
   };
 
   const visit = (span: Span, currentNode: GenAIFlowNode | null) => {
@@ -164,6 +168,7 @@ function makeGenAISummary(spans: Span[]): GenAITraceSummary {
         node.descendantPrivacyRiskCount += 1;
       }
       node.descendantRiskCount = new Set([...node.descendantSecurityRiskSpanIds, ...node.descendantPrivacyRiskSpanIds]).size;
+      addFixtureEvaluationSignals(node, span);
     } else if (currentNode) {
       addOwnedSpan(currentNode, span);
     }
@@ -186,7 +191,7 @@ function makeGenAISummary(spans: Span[]): GenAITraceSummary {
   });
 
   const tokens = flowSpans.map(makeTokenUsage).reduce(addTokenUsage, { input: 0, output: 0, total: 0 });
-  const kinds = flowSpans.map((span) => getFixtureKind(span, String(span.attributes["gen_ai.operation.name"] ?? "")));
+  const kinds = flowSpans.filter((span) => !isFixtureEvaluationOnlySpan(span)).map((span) => getFixtureKind(span, String(span.attributes["gen_ai.operation.name"] ?? "")));
   return {
     isGenAI: flowSpans.length > 0,
     tokens,
@@ -246,6 +251,69 @@ function findFixtureParentFlowSpanId(span: Span, parentBySpanId: Map<string, str
 function hasFixtureRisk(spanId: string, spans: Span[], type: "security" | "privacy"): boolean {
   const span = spans.find((candidate) => candidate.spanId === spanId);
   return Object.keys(span?.attributes ?? {}).some((key) => key.startsWith(`gen_ai.${type}.`));
+}
+
+function hasFixtureGenAISignal(span: Span): boolean {
+  return Object.keys(span.attributes).some((key) => key.startsWith("gen_ai.")) || hasFixtureEvaluationSignal(span);
+}
+
+function isFixtureEvaluationOnlySpan(span: Span): boolean {
+  return hasFixtureEvaluationSignal(span) && !span.attributes["gen_ai.operation.name"] && !span.attributes["gen_ai.agent.name"] && !span.attributes["gen_ai.tool.name"] && !span.attributes["gen_ai.retrieval.source"];
+}
+
+function hasFixtureEvaluationSignal(span: Span): boolean {
+  return hasFixtureEvaluationAttributes(span.attributes) || span.events.some((event) => event.name === "gen_ai.evaluation.result" || hasFixtureEvaluationAttributes(event.attributes));
+}
+
+function hasFixtureEvaluationAttributes(attributes: Record<string, unknown>): boolean {
+  return Object.keys(attributes).some((key) => key.startsWith("gen_ai.evaluation.")) || "gen_ai.evaluations" in attributes || "assistant.evaluation.outcome" in attributes;
+}
+
+function addFixtureEvaluationSignals(node: GenAIFlowNode, span: Span): void {
+  const { count, failed } = getFixtureEvaluationCounts(span);
+  if (count === 0) return;
+  node.descendantEvaluationCount += count;
+  node.descendantEvaluationFailedCount += failed;
+  if (failed > 0 && !node.descendantEvaluationFailedSpanIds.includes(span.spanId)) {
+    node.descendantEvaluationFailedSpanIds.push(span.spanId);
+  }
+}
+
+function getFixtureEvaluationCounts(span: Span): { count: number; failed: number } {
+  const evaluationEvents = span.events.filter((event) => event.name === "gen_ai.evaluation.result" || hasFixtureEvaluationAttributes(event.attributes));
+  if (evaluationEvents.length > 0) {
+    return {
+      count: evaluationEvents.length,
+      failed: evaluationEvents.filter((event) => fixtureEvaluationAttributesFailed(event.attributes)).length,
+    };
+  }
+  if (!hasFixtureEvaluationAttributes(span.attributes)) {
+    return { count: 0, failed: 0 };
+  }
+  return { count: 1, failed: fixtureEvaluationAttributesFailed(span.attributes) ? 1 : 0 };
+}
+
+function fixtureEvaluationAttributesFailed(attributes: Record<string, unknown>): boolean {
+  const passed = attributes["gen_ai.evaluation.passed"];
+  if (typeof passed === "boolean") {
+    return !passed;
+  }
+  if (typeof passed === "string" && ["true", "false"].includes(passed.trim().toLowerCase())) {
+    return passed.trim().toLowerCase() === "false";
+  }
+
+  const outcome = String(attributes["assistant.evaluation.outcome"] ?? "").toLowerCase();
+  if (["failed", "fail", "error", "no_data"].includes(outcome)) {
+    return true;
+  }
+
+  const scoreLabel = String(attributes["gen_ai.evaluation.score.label"] ?? "").toLowerCase();
+  if (["failed", "fail", "error"].includes(scoreLabel)) {
+    return true;
+  }
+
+  const errorType = String(attributes["error.type"] ?? "").toLowerCase();
+  return errorType !== "" && errorType !== "unknown" && errorType !== "none";
 }
 
 let restoreClientWidth = () => undefined;
@@ -327,6 +395,17 @@ describe("TraceWaterfall GenAI overview", () => {
           "gen_ai.usage.output_tokens": 20,
           "gen_ai.security.prompt_injection.detected": true,
         },
+        events: [
+          {
+            name: "gen_ai.evaluation.result",
+            timeUnixNano: "2026-06-12T18:00:02.500Z",
+            attributes: {
+              "gen_ai.evaluation.name": "faithfulness",
+              "gen_ai.evaluation.score.label": "fail",
+              "assistant.evaluation.outcome": "failed",
+            },
+          },
+        ],
       }),
       makeSpan({
         spanId: "tool",
@@ -374,23 +453,18 @@ describe("TraceWaterfall GenAI overview", () => {
     expect(screen.getByRole("button", { name: /triage-agent/i })).toBeTruthy();
     const riskSignal = container.querySelector(".genai-flow__signal--risk");
     expect(riskSignal?.getAttribute("title")).toBeNull();
-    expect(riskSignal?.getAttribute("data-tooltip")).toBe("1 security risk. Click to filter waterfall.");
+    expect(riskSignal?.getAttribute("data-tooltip")).toBe("1 security risk on nested spans");
     expect(screen.getByRole("button", { name: /llm chat gpt-4o/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /tool fetch_logs/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /retrieval retrieval vector_store/i })).toBeTruthy();
     expect(container.querySelectorAll(".waterfall__row")).toHaveLength(4);
-    fireEvent.click(screen.getAllByLabelText("No quality issues detected")[0]);
-    expect(onSelectSpan).not.toHaveBeenCalled();
-    fireEvent.click(screen.getAllByRole("button", { name: "Filter waterfall to 1 security risk span" })[0]);
-    expect(onSelectSpan).toHaveBeenCalledWith(null);
-    expect(screen.getByRole("button", { name: /Security risk spans/ })).toBeTruthy();
-    expect(screen.getByText("1 / 4 spans")).toBeTruthy();
-    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(1);
-    expect(Array.from(container.querySelectorAll(".waterfall__span-name")).map((element) => element.textContent)).toEqual([
-      "assistant: chat",
-    ]);
-    fireEvent.click(screen.getByRole("button", { name: /Security risk spans/ }));
-    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(4);
+    const qualitySignal = container.querySelector(".genai-flow__signal--issue");
+    expect(qualitySignal?.getAttribute("data-tooltip")).toBe("1 quality issue on nested spans");
+    const qualityChip = container.querySelector(".waterfall__ai-chip--issue");
+    expect(qualityChip?.textContent).toBe("Faithfulness");
+    expect(qualityChip?.getAttribute("data-tooltip")).toBe("Faithfulness quality issue");
+    fireEvent.click(qualitySignal as Element);
+    expect(onSelectSpan).toHaveBeenCalledWith("llm");
     onSelectSpan.mockClear();
     expect(screen.getByText("4 spans")).toBeTruthy();
 

--- a/observer/client/src/traces/TraceWaterfall.test.tsx
+++ b/observer/client/src/traces/TraceWaterfall.test.tsx
@@ -1,0 +1,822 @@
+// @vitest-environment happy-dom
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GenAIFlowEdge, GenAIFlowNode, GenAITraceSummary, GenAITokenUsage, Span } from "../api/types";
+import type { ValidationIndex } from "../validation/utils";
+import { TraceWaterfall } from "./TraceWaterfall";
+
+const emptyValidationIndex: ValidationIndex = {
+  trace: new Map(),
+  span: new Map(),
+  metric: new Map(),
+  log: new Map(),
+};
+
+function makeSpan(overrides: Partial<Span> & { spanId: string }): Span {
+  const { spanId, ...rest } = overrides;
+  return {
+    traceId: "trace-genai",
+    spanId,
+    parentSpanId: "",
+    name: `span-${spanId}`,
+    kind: "INTERNAL",
+    startTimeUnixNano: "2026-06-12T18:00:00.000Z",
+    endTimeUnixNano: "2026-06-12T18:00:01.000Z",
+    durationMs: 1000,
+    status: { code: "UNSET" },
+    attributes: {},
+    events: [],
+    links: [],
+    resource: { attributes: {}, serviceName: "assistant" },
+    scope: { name: "test" },
+    ...rest,
+  };
+}
+
+function makeBranchingFixtureSpans(): Span[] {
+  return [
+    makeSpan({
+      spanId: "workflow",
+      name: "Budget Guru",
+      attributes: {
+        "gen_ai.operation.name": "invoke_workflow",
+        "gen_ai.workflow.name": "Budget Guru",
+      },
+    }),
+    makeSpan({
+      spanId: "triage",
+      parentSpanId: "workflow",
+      name: "Triage Agent",
+      attributes: {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "Triage Agent",
+      },
+    }),
+    makeSpan({
+      spanId: "education",
+      parentSpanId: "triage",
+      name: "Education Agent",
+      attributes: {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "Education Agent",
+      },
+    }),
+    makeSpan({
+      spanId: "investment",
+      parentSpanId: "triage",
+      name: "Investment Agent",
+      attributes: {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "Investment Agent",
+      },
+    }),
+  ];
+}
+
+function makeGenAISummary(spans: Span[]): GenAITraceSummary {
+  const flowSpans = spans.filter((span) => Object.keys(span.attributes).some((key) => key.startsWith("gen_ai.")));
+  const nodeSpans = flowSpans.filter((span) => {
+    const operation = String(span.attributes["gen_ai.operation.name"] ?? "");
+    const kind = getFixtureKind(span, operation);
+    return kind === "workflow" || kind === "agent" || kind === "tool" || kind === "llm" || kind === "retrieval";
+  });
+  const selectedIds = new Set(nodeSpans.map((span) => span.spanId));
+  const nodeBySpanId = new Map<string, GenAIFlowNode>();
+  const parentBySpanId = new Map(spans.map((span) => [span.spanId, span.parentSpanId ?? ""]));
+
+  const nodes = nodeSpans.map((span) => {
+    const operation = String(span.attributes["gen_ai.operation.name"] ?? "");
+    const modelName = String(span.attributes["gen_ai.request.model"] ?? "");
+    const tokenUsage = makeTokenUsage(span);
+    const node: GenAIFlowNode = {
+      nodeId: span.spanId,
+      traceId: span.traceId,
+      spanId: span.spanId,
+      name: getFixtureNodeName(span, operation),
+      kind: getFixtureKind(span, operation),
+      operation,
+      modelNames: modelName ? [modelName] : [],
+      tokenUsage,
+      depth: 0,
+      durationMs: span.durationMs,
+      statusCode: span.status.code,
+      grouped: false,
+      groupedSpanIds: [],
+      parentFlowSpanId: findFixtureParentFlowSpanId(span, parentBySpanId, selectedIds),
+      descendantSpanIds: [],
+      descendantTokenUsage: { input: 0, output: 0, total: 0 },
+      descendantLlmCalls: 0,
+      descendantLlmSpanIds: [],
+      descendantToolCalls: 0,
+      descendantToolSpanIds: [],
+      descendantSecurityRiskCount: 0,
+      descendantSecurityRiskSpanIds: [],
+      descendantPrivacyRiskCount: 0,
+      descendantPrivacyRiskSpanIds: [],
+      descendantRiskCount: 0,
+    };
+    nodeBySpanId.set(span.spanId, node);
+    return node;
+  });
+
+  const childrenByParent = new Map<string, Span[]>();
+  for (const span of spans) {
+    if (!span.parentSpanId) continue;
+    childrenByParent.set(span.parentSpanId, [...(childrenByParent.get(span.parentSpanId) ?? []), span]);
+  }
+
+  const addOwnedSpan = (node: GenAIFlowNode, span: Span) => {
+    node.descendantSpanIds.push(span.spanId);
+    if (Object.keys(span.attributes).some((key) => key.startsWith("gen_ai."))) {
+      const kind = getFixtureKind(span, String(span.attributes["gen_ai.operation.name"] ?? ""));
+      node.descendantTokenUsage = addTokenUsage(node.descendantTokenUsage, makeTokenUsage(span));
+      if (kind === "llm") {
+        node.descendantLlmCalls += 1;
+        node.descendantLlmSpanIds.push(span.spanId);
+      }
+      if (kind === "tool") {
+        node.descendantToolCalls += 1;
+        node.descendantToolSpanIds.push(span.spanId);
+      }
+    }
+    if (hasFixtureRisk(span.spanId, spans, "security")) {
+      node.descendantSecurityRiskSpanIds.push(span.spanId);
+      node.descendantSecurityRiskCount += 1;
+    }
+    if (hasFixtureRisk(span.spanId, spans, "privacy")) {
+      node.descendantPrivacyRiskSpanIds.push(span.spanId);
+      node.descendantPrivacyRiskCount += 1;
+    }
+    node.descendantRiskCount = new Set([...node.descendantSecurityRiskSpanIds, ...node.descendantPrivacyRiskSpanIds]).size;
+  };
+
+  const visit = (span: Span, currentNode: GenAIFlowNode | null) => {
+    const node = nodeBySpanId.get(span.spanId);
+    const nextNode = node ?? currentNode;
+    if (node) {
+      if (hasFixtureRisk(span.spanId, spans, "security")) {
+        node.descendantSecurityRiskSpanIds.push(span.spanId);
+        node.descendantSecurityRiskCount += 1;
+      }
+      if (hasFixtureRisk(span.spanId, spans, "privacy")) {
+        node.descendantPrivacyRiskSpanIds.push(span.spanId);
+        node.descendantPrivacyRiskCount += 1;
+      }
+      node.descendantRiskCount = new Set([...node.descendantSecurityRiskSpanIds, ...node.descendantPrivacyRiskSpanIds]).size;
+    } else if (currentNode) {
+      addOwnedSpan(currentNode, span);
+    }
+    for (const child of childrenByParent.get(span.spanId) ?? []) {
+      visit(child, nextNode);
+    }
+  };
+
+  for (const root of spans.filter((span) => !span.parentSpanId || !spans.some((candidate) => candidate.spanId === span.parentSpanId))) {
+    visit(root, null);
+  }
+
+  const edges: GenAIFlowEdge[] = nodes.flatMap((node) => {
+    const span = spans.find((candidate) => candidate.spanId === node.spanId);
+    const linkedPredecessors = (span?.links ?? []).map((link) => link.spanId).filter((spanId) => selectedIds.has(spanId));
+    if (linkedPredecessors.length > 0) {
+      return linkedPredecessors.map((source) => ({ source, target: node.spanId }));
+    }
+    return node.parentFlowSpanId ? [{ source: node.parentFlowSpanId, target: node.spanId }] : [];
+  });
+
+  const tokens = flowSpans.map(makeTokenUsage).reduce(addTokenUsage, { input: 0, output: 0, total: 0 });
+  const kinds = flowSpans.map((span) => getFixtureKind(span, String(span.attributes["gen_ai.operation.name"] ?? "")));
+  return {
+    isGenAI: flowSpans.length > 0,
+    tokens,
+    toolCalls: kinds.filter((kind) => kind === "tool").length,
+    llmCalls: kinds.filter((kind) => kind === "llm").length,
+    modelNames: Array.from(new Set(flowSpans.flatMap((span) => {
+      const model = span.attributes["gen_ai.request.model"];
+      return model ? [String(model)] : [];
+    }))),
+    flowNodes: nodes,
+    flowEdges: edges,
+  };
+}
+
+function makeTokenUsage(span: Span): GenAITokenUsage {
+  const input = Number(span.attributes["gen_ai.usage.input_tokens"] ?? 0);
+  const output = Number(span.attributes["gen_ai.usage.output_tokens"] ?? 0);
+  const total = Number(span.attributes["gen_ai.usage.total_tokens"] ?? input + output);
+  return { input, output, total };
+}
+
+function addTokenUsage(acc: GenAITokenUsage, usage: GenAITokenUsage): GenAITokenUsage {
+  return { input: acc.input + usage.input, output: acc.output + usage.output, total: acc.total + usage.total };
+}
+
+function getFixtureKind(span: Span, operation: string): GenAIFlowNode["kind"] {
+  if (operation.includes("tool") || span.attributes["gen_ai.tool.name"]) return "tool";
+  if (operation.includes("workflow")) return "workflow";
+  if (operation.includes("agent") || span.attributes["gen_ai.agent.name"]) return "agent";
+  if (operation.includes("retrieval") || operation.includes("retriever")) return "retrieval";
+  if (operation.includes("chat") || span.attributes["gen_ai.request.model"]) return "llm";
+  return "genai";
+}
+
+function getFixtureNodeName(span: Span, operation: string): string {
+  if ((operation.includes("retrieval") || operation.includes("retriever")) && span.attributes["gen_ai.retrieval.source"]) {
+    return `${operation} ${span.attributes["gen_ai.retrieval.source"]}`;
+  }
+  return String(
+    span.attributes["gen_ai.workflow.name"] ??
+      span.attributes["gen_ai.agent.name"] ??
+      span.attributes["gen_ai.tool.name"] ??
+      (operation === "chat" && span.attributes["gen_ai.request.model"] ? `chat ${span.attributes["gen_ai.request.model"]}` : operation) ??
+      span.name,
+  );
+}
+
+function findFixtureParentFlowSpanId(span: Span, parentBySpanId: Map<string, string>, selectedIds: Set<string>): string | undefined {
+  let parentSpanId = span.parentSpanId ?? "";
+  while (parentSpanId) {
+    if (selectedIds.has(parentSpanId)) return parentSpanId;
+    parentSpanId = parentBySpanId.get(parentSpanId) ?? "";
+  }
+  return undefined;
+}
+
+function hasFixtureRisk(spanId: string, spans: Span[], type: "security" | "privacy"): boolean {
+  const span = spans.find((candidate) => candidate.spanId === spanId);
+  return Object.keys(span?.attributes ?? {}).some((key) => key.startsWith(`gen_ai.${type}.`));
+}
+
+let restoreClientWidth = () => undefined;
+
+function setObservedCanvasWidth(width: number): void {
+  restoreClientWidth();
+  const descriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return width;
+    },
+  });
+  restoreClientWidth = () => {
+    if (descriptor) {
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", descriptor);
+    } else {
+      delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth;
+    }
+  };
+
+  vi.stubGlobal(
+    "ResizeObserver",
+    class TestResizeObserver {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+      observe(): void {
+        this.callback([], this as unknown as ResizeObserver);
+      }
+      unobserve(): void {}
+      disconnect(): void {}
+    },
+  );
+}
+
+describe("TraceWaterfall GenAI overview", () => {
+  afterEach(() => {
+    cleanup();
+    restoreClientWidth();
+    restoreClientWidth = () => undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps non-GenAI traces on the traditional waterfall only", () => {
+    render(
+      <TraceWaterfall
+        spans={[makeSpan({ spanId: "plain", name: "GET /health" })]}
+        selectedSpanId={null}
+        onSelectSpan={vi.fn()}
+        traceDurationMs={1000}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    expect(screen.queryByText("Agent flow")).toBeNull();
+    expect(screen.getByText("1 spans")).toBeTruthy();
+  });
+
+  it("renders GenAI summary and selectable agent-flow canvas", () => {
+    const onSelectSpan = vi.fn();
+    const spans = [
+      makeSpan({
+        spanId: "agent",
+        name: "runtime: invoke_agent",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "triage-agent",
+        },
+      }),
+      makeSpan({
+        spanId: "llm",
+        parentSpanId: "agent",
+        name: "assistant: chat",
+        durationMs: 2400,
+        startTimeUnixNano: "2026-06-12T18:00:00.100Z",
+        attributes: {
+          "gen_ai.operation.name": "chat",
+          "gen_ai.request.model": "gpt-4o",
+          "gen_ai.usage.input_tokens": 120,
+          "gen_ai.usage.output_tokens": 20,
+          "gen_ai.security.prompt_injection.detected": true,
+        },
+      }),
+      makeSpan({
+        spanId: "tool",
+        parentSpanId: "agent",
+        name: "tool: fetch_logs",
+        startTimeUnixNano: "2026-06-12T18:00:00.200Z",
+        attributes: {
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": "fetch_logs",
+        },
+      }),
+      makeSpan({
+        spanId: "retrieval",
+        parentSpanId: "agent",
+        name: "retrieval vector_store",
+        startTimeUnixNano: "2026-06-12T18:00:00.300Z",
+        attributes: {
+          "gen_ai.operation.name": "retrieval",
+          "gen_ai.retrieval.source": "vector_store",
+        },
+      }),
+    ];
+    const { container } = render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={makeGenAISummary(spans)}
+        selectedSpanId="llm"
+        onSelectSpan={onSelectSpan}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    expect(screen.getByText("Agent flow")).toBeTruthy();
+    expect(screen.getByText("Tokens:")).toBeTruthy();
+    expect(screen.getByText("140 (In: 120 | Out: 20)")).toBeTruthy();
+    expect(screen.getByText("Tool calls:")).toBeTruthy();
+    expect(screen.getByText("LLM calls:")).toBeTruthy();
+    expect(screen.getAllByText("1", { selector: ".genai-summary__value" })).toHaveLength(2);
+    expect(screen.getByText("gpt-4o", { selector: ".genai-summary__value" })).toBeTruthy();
+    expect(screen.getByLabelText("Center flow")).toBeTruthy();
+    expect(screen.getByLabelText("Zoom out")).toBeTruthy();
+    expect(screen.getByLabelText("Zoom in")).toBeTruthy();
+    expect(screen.getByTestId("genai-agent-flow")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /triage-agent/i })).toBeTruthy();
+    const riskSignal = container.querySelector(".genai-flow__signal--risk");
+    expect(riskSignal?.getAttribute("title")).toBeNull();
+    expect(riskSignal?.getAttribute("data-tooltip")).toBe("1 security risk. Click to filter waterfall.");
+    expect(screen.getByRole("button", { name: /llm chat gpt-4o/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /tool fetch_logs/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /retrieval retrieval vector_store/i })).toBeTruthy();
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(4);
+    fireEvent.click(screen.getAllByLabelText("No quality issues detected")[0]);
+    expect(onSelectSpan).not.toHaveBeenCalled();
+    fireEvent.click(screen.getAllByRole("button", { name: "Filter waterfall to 1 security risk span" })[0]);
+    expect(onSelectSpan).toHaveBeenCalledWith(null);
+    expect(screen.getByRole("button", { name: /Security risk spans/ })).toBeTruthy();
+    expect(screen.getByText("1 / 4 spans")).toBeTruthy();
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(1);
+    expect(Array.from(container.querySelectorAll(".waterfall__span-name")).map((element) => element.textContent)).toEqual([
+      "assistant: chat",
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: /Security risk spans/ }));
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(4);
+    onSelectSpan.mockClear();
+    expect(screen.getByText("4 spans")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /llm chat gpt-4o/i }));
+    expect(onSelectSpan).toHaveBeenCalledWith("llm");
+    onSelectSpan.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /tool fetch_logs/i }));
+    expect(onSelectSpan).toHaveBeenCalledWith("tool");
+    onSelectSpan.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /retrieval retrieval vector_store/i }));
+    expect(onSelectSpan).toHaveBeenCalledWith("retrieval");
+    onSelectSpan.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /triage-agent/i }));
+
+    expect(onSelectSpan).toHaveBeenCalledWith("agent");
+  });
+
+  it("filters waterfall spans when a grouped LLM flow node is selected", () => {
+    setObservedCanvasWidth(900);
+    const llmSpans = Array.from({ length: 9 }, (_, index) =>
+      makeSpan({
+        spanId: `llm-${index}`,
+        parentSpanId: "agent",
+        name: "chat gpt-5.5",
+        durationMs: 1000,
+        attributes: {
+          "gen_ai.operation.name": "chat",
+          "gen_ai.request.model": "gpt-5.5",
+          "gen_ai.usage.input_tokens": 100,
+          "gen_ai.usage.output_tokens": 10,
+        },
+      }),
+    );
+    const spans = [
+      makeSpan({
+        spanId: "workflow",
+        name: "Budget Guru",
+        attributes: {
+          "gen_ai.operation.name": "invoke_workflow",
+          "gen_ai.workflow.name": "Budget Guru",
+        },
+      }),
+      makeSpan({
+        spanId: "agent",
+        parentSpanId: "workflow",
+        name: "LangGraph",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "LangGraph",
+        },
+      }),
+      ...llmSpans,
+    ];
+    const baseSummary = makeGenAISummary(spans);
+    const workflowNode = baseSummary.flowNodes.find((node) => node.spanId === "workflow");
+    const agentNode = baseSummary.flowNodes.find((node) => node.spanId === "agent");
+    const llmTemplate = baseSummary.flowNodes.find((node) => node.spanId === "llm-0");
+    if (!workflowNode || !agentNode || !llmTemplate) {
+      throw new Error("missing fixture flow nodes");
+    }
+    const groupedSpanIds = llmSpans.map((span) => span.spanId);
+    const groupedNode: GenAIFlowNode = {
+      ...llmTemplate,
+      nodeId: "group:agent:llm:chat:chat gpt-5.5",
+      spanId: "group:agent:llm:chat:chat gpt-5.5",
+      name: "chat gpt-5.5 x9",
+      grouped: true,
+      callCount: 9,
+      groupedSpanIds,
+      durationMs: 1000,
+      avgDurationMs: 1000,
+      maxDurationMs: 1000,
+      tokenUsage: { input: 900, output: 90, total: 990 },
+      descendantSpanIds: groupedSpanIds,
+      descendantTokenUsage: { input: 900, output: 90, total: 990 },
+      descendantLlmCalls: 9,
+      descendantLlmSpanIds: groupedSpanIds,
+    };
+    const onSelectSpan = vi.fn();
+
+    const { container } = render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={{
+          ...baseSummary,
+          flowNodes: [workflowNode, agentNode, groupedNode],
+          flowEdges: [
+            { source: "workflow", target: "agent" },
+            { source: "agent", target: groupedNode.spanId },
+          ],
+        }}
+        selectedSpanId={null}
+        onSelectSpan={onSelectSpan}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /llm chat gpt-5\.5 x9/i }));
+
+    expect(onSelectSpan).toHaveBeenCalledWith(null);
+    expect(screen.getByRole("button", { name: /LLM call spans/ })).toBeTruthy();
+    expect(screen.getByText("9 / 11 spans")).toBeTruthy();
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(9);
+  });
+
+  it("filters waterfall spans when a grouped LLM/tool loop node is selected", () => {
+    setObservedCanvasWidth(900);
+    const spans = [
+      makeSpan({
+        spanId: "workflow",
+        name: "Budget Guru",
+        attributes: {
+          "gen_ai.operation.name": "invoke_workflow",
+          "gen_ai.workflow.name": "Budget Guru",
+        },
+      }),
+      makeSpan({
+        spanId: "agent",
+        parentSpanId: "workflow",
+        name: "LangGraph",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "LangGraph",
+        },
+      }),
+      makeSpan({
+        spanId: "llm-1",
+        parentSpanId: "agent",
+        name: "chat gpt-5.5",
+        attributes: {
+          "gen_ai.operation.name": "chat",
+          "gen_ai.request.model": "gpt-5.5",
+          "gen_ai.usage.input_tokens": 100,
+          "gen_ai.usage.output_tokens": 10,
+        },
+      }),
+      makeSpan({
+        spanId: "tool-1",
+        parentSpanId: "agent",
+        name: "execute_tool lookup_context",
+        attributes: {
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": "lookup_context",
+        },
+      }),
+      makeSpan({
+        spanId: "llm-2",
+        parentSpanId: "agent",
+        name: "chat gpt-5.5",
+        attributes: {
+          "gen_ai.operation.name": "chat",
+          "gen_ai.request.model": "gpt-5.5",
+          "gen_ai.usage.input_tokens": 110,
+          "gen_ai.usage.output_tokens": 11,
+        },
+      }),
+      makeSpan({
+        spanId: "tool-2",
+        parentSpanId: "agent",
+        name: "execute_tool lookup_context",
+        attributes: {
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": "lookup_context",
+        },
+      }),
+    ];
+    const baseSummary = makeGenAISummary(spans);
+    const workflowNode = baseSummary.flowNodes.find((node) => node.spanId === "workflow");
+    const agentNode = baseSummary.flowNodes.find((node) => node.spanId === "agent");
+    const llmTemplate = baseSummary.flowNodes.find((node) => node.spanId === "llm-1");
+    if (!workflowNode || !agentNode || !llmTemplate) {
+      throw new Error("missing fixture flow nodes");
+    }
+    const groupedSpanIds = ["llm-1", "tool-1", "llm-2", "tool-2"];
+    const loopNode: GenAIFlowNode = {
+      ...llmTemplate,
+      nodeId: "group:agent:loop:chat_lookup_context",
+      spanId: "group:agent:loop:chat_lookup_context",
+      name: "chat gpt-5.5 + lookup_context loop x2",
+      kind: "loop",
+      operation: "loop",
+      grouped: true,
+      callCount: 2,
+      groupedSpanIds,
+      durationMs: 2200,
+      avgDurationMs: 550,
+      maxDurationMs: 1000,
+      tokenUsage: { input: 210, output: 21, total: 231 },
+      descendantSpanIds: groupedSpanIds,
+      descendantTokenUsage: { input: 210, output: 21, total: 231 },
+      descendantLlmCalls: 2,
+      descendantLlmSpanIds: ["llm-1", "llm-2"],
+      descendantToolCalls: 2,
+      descendantToolSpanIds: ["tool-1", "tool-2"],
+    };
+    const onSelectSpan = vi.fn();
+
+    const { container } = render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={{
+          ...baseSummary,
+          flowNodes: [workflowNode, agentNode, loopNode],
+          flowEdges: [
+            { source: "workflow", target: "agent" },
+            { source: "agent", target: loopNode.spanId },
+          ],
+        }}
+        selectedSpanId={null}
+        onSelectSpan={onSelectSpan}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /loop chat gpt-5\.5 \+ lookup_context loop x2/i }));
+
+    expect(onSelectSpan).toHaveBeenCalledWith(null);
+    expect(screen.getByRole("button", { name: /Loop spans/ })).toBeTruthy();
+    expect(screen.getByText("4 / 6 spans")).toBeTruthy();
+    expect(container.querySelectorAll(".waterfall__row")).toHaveLength(4);
+  });
+
+  it("renders branching GenAI agent flows vertically on narrow panels", () => {
+    setObservedCanvasWidth(480);
+    const spans = makeBranchingFixtureSpans();
+
+    render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={makeGenAISummary(spans)}
+        selectedSpanId={null}
+        onSelectSpan={vi.fn()}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    const canvas = screen.getByTestId("genai-agent-flow");
+    const flowNodes = Array.from(canvas.querySelectorAll<HTMLElement>(".genai-flow__dag-node"));
+    const educationNode = flowNodes.find((node) => node.textContent?.includes("Education Agent")) ?? null;
+    const investmentNode = flowNodes.find((node) => node.textContent?.includes("Investment Agent")) ?? null;
+
+    expect(canvas.classList.contains("genai-flow__canvas--vertical")).toBe(true);
+    expect(educationNode?.style.left).toBeTruthy();
+    expect(investmentNode?.style.left).toBeTruthy();
+    expect(educationNode?.style.left).not.toBe(investmentNode?.style.left);
+    expect(educationNode?.style.top).toBe(investmentNode?.style.top);
+  });
+
+  it("switches branching GenAI agent flows horizontal on wide panels", () => {
+    setObservedCanvasWidth(900);
+    const spans = makeBranchingFixtureSpans();
+
+    render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={makeGenAISummary(spans)}
+        selectedSpanId={null}
+        onSelectSpan={vi.fn()}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    const canvas = screen.getByTestId("genai-agent-flow");
+    const flowNodes = Array.from(canvas.querySelectorAll<HTMLElement>(".genai-flow__dag-node"));
+    const educationNode = flowNodes.find((node) => node.textContent?.includes("Education Agent")) ?? null;
+    const investmentNode = flowNodes.find((node) => node.textContent?.includes("Investment Agent")) ?? null;
+
+    expect(canvas.classList.contains("genai-flow__canvas--horizontal")).toBe(true);
+    expect(educationNode?.style.left).toBe(investmentNode?.style.left);
+    expect(educationNode?.style.top).not.toBe(investmentNode?.style.top);
+  });
+
+  it("routes wide horizontal merge links around intermediate cards", () => {
+    setObservedCanvasWidth(1200);
+    const spans = [
+      makeSpan({
+        spanId: "workflow",
+        name: "Budget Guru",
+        attributes: {
+          "gen_ai.operation.name": "invoke_workflow",
+          "gen_ai.workflow.name": "Budget Guru",
+        },
+      }),
+      makeSpan({
+        spanId: "triage",
+        parentSpanId: "workflow",
+        name: "Triage Agent",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "Triage Agent",
+        },
+      }),
+      makeSpan({
+        spanId: "investment-1",
+        parentSpanId: "triage",
+        name: "Investment Agent",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "Investment Agent",
+        },
+      }),
+      makeSpan({
+        spanId: "education",
+        parentSpanId: "triage",
+        name: "Education Agent",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "Education Agent",
+        },
+      }),
+      makeSpan({
+        spanId: "budgeting",
+        parentSpanId: "investment-1",
+        name: "Budgeting Agent",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "Budgeting Agent",
+        },
+      }),
+      makeSpan({
+        spanId: "investment-2",
+        parentSpanId: "budgeting",
+        name: "Investment Agent",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "Investment Agent",
+        },
+      }),
+      makeSpan({
+        spanId: "summarizer",
+        parentSpanId: "workflow",
+        name: "Summarizer Agent",
+        links: [
+          { traceId: "trace-genai", spanId: "education", attributes: {} },
+          { traceId: "trace-genai", spanId: "investment-2", attributes: {} },
+        ],
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "Summarizer Agent",
+        },
+      }),
+    ];
+
+    render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={makeGenAISummary(spans)}
+        selectedSpanId={null}
+        onSelectSpan={vi.fn()}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    const canvas = screen.getByTestId("genai-agent-flow");
+    const flowNodes = Array.from(canvas.querySelectorAll<HTMLElement>(".genai-flow__dag-node"));
+    const firstInvestmentNode = flowNodes.find((node) => node.textContent?.includes("Investment Agent")) ?? null;
+    const educationNode = flowNodes.find((node) => node.textContent?.includes("Education Agent")) ?? null;
+    const budgetingNode = flowNodes.find((node) => node.textContent?.includes("Budgeting Agent")) ?? null;
+    const routedPaths = Array.from(canvas.querySelectorAll<SVGPathElement>(".genai-flow__link"))
+      .map((path) => path.getAttribute("d") ?? "")
+      .filter((path) => path.includes(" L"));
+
+    expect(canvas.classList.contains("genai-flow__canvas--horizontal")).toBe(true);
+    expect(firstInvestmentNode?.style.top).toBe(budgetingNode?.style.top);
+    expect(educationNode?.style.top).not.toBe(budgetingNode?.style.top);
+    expect(routedPaths.length).toBeGreaterThan(0);
+  });
+
+  it("switches linear GenAI flows horizontal on wide panels", () => {
+    setObservedCanvasWidth(900);
+    const spans = [
+      makeSpan({
+        spanId: "workflow",
+        name: "Assistant Workflow",
+        attributes: {
+          "gen_ai.operation.name": "invoke_workflow",
+          "gen_ai.workflow.name": "Assistant Workflow",
+        },
+      }),
+      makeSpan({
+        spanId: "agent",
+        parentSpanId: "workflow",
+        name: "Planner Agent",
+        attributes: {
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.agent.name": "Planner Agent",
+        },
+      }),
+      makeSpan({
+        spanId: "llm",
+        parentSpanId: "agent",
+        name: "assistant: chat",
+        attributes: {
+          "gen_ai.operation.name": "chat",
+          "gen_ai.request.model": "gpt-5.5",
+        },
+      }),
+    ];
+
+    render(
+      <TraceWaterfall
+        spans={spans}
+        genAI={makeGenAISummary(spans)}
+        selectedSpanId={null}
+        onSelectSpan={vi.fn()}
+        traceDurationMs={2500}
+        validationIndex={emptyValidationIndex}
+      />,
+    );
+
+    const canvas = screen.getByTestId("genai-agent-flow");
+    const flowNodes = Array.from(canvas.querySelectorAll<HTMLElement>(".genai-flow__dag-node"));
+    const workflowNode = flowNodes.find((node) => node.textContent?.includes("Assistant Workflow")) ?? null;
+    const agentNode = flowNodes.find((node) => node.textContent?.includes("Planner Agent")) ?? null;
+
+    expect(canvas.classList.contains("genai-flow__canvas--horizontal")).toBe(true);
+    expect(canvas.classList.contains("genai-flow__canvas--vertical")).toBe(false);
+    expect(workflowNode?.style.top).toBe(agentNode?.style.top);
+    expect(workflowNode?.style.left).not.toBe(agentNode?.style.left);
+  });
+});

--- a/observer/client/src/traces/TraceWaterfall.tsx
+++ b/observer/client/src/traces/TraceWaterfall.tsx
@@ -61,7 +61,7 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
     return true;
   });
   const filteredSpanIds = genAISpanFilter ? new Set(genAISpanFilter.spanIds) : null;
-  const flat = filteredSpanIds ? allFlat.filter((s) => filteredSpanIds.has(s.spanId)) : collapsedFlat;
+  const flat = filteredSpanIds ? collapsedFlat.filter((s) => filteredSpanIds.has(s.spanId)) : collapsedFlat;
   const selectedSpanVisible = selectedSpanId ? flat.some((s) => s.spanId === selectedSpanId) : false;
 
   const applyGenAISpanFilter = (type: GenAISpanFilterType, spanIds: string[]) => {

--- a/observer/client/src/traces/TraceWaterfall.tsx
+++ b/observer/client/src/traces/TraceWaterfall.tsx
@@ -6,8 +6,9 @@ import type { ValidationIndex } from "../validation/utils";
 import { lookupSpanValidation } from "../validation/utils";
 import { TELEMETRY_SERIES_COLORS } from "../palette";
 import { GenAITraceOverview } from "./GenAITraceOverview";
+import { formatEvaluationName, getSpanEvaluations } from "./genai-evaluations";
 
-type GenAISpanFilterType = "security" | "privacy" | "llm" | "tool" | "loop";
+type GenAISpanFilterType = "security" | "privacy" | "llm" | "tool" | "loop" | "quality";
 
 interface TraceWaterfallProps {
   spans: Span[];
@@ -38,6 +39,16 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
   const [genAISpanFilter, setGenAISpanFilter] = useState<{ type: GenAISpanFilterType; spanIds: string[] } | null>(null);
 
   const serviceColors = useMemo(() => getServiceColorMap(spans), [spans]);
+  const evaluationsBySpanId = useMemo(() => {
+    const result = new Map<string, ReturnType<typeof getSpanEvaluations>>();
+    for (const span of spans) {
+      const evaluations = getSpanEvaluations(span);
+      if (evaluations.length > 0) {
+        result.set(span.spanId, evaluations);
+      }
+    }
+    return result;
+  }, [spans]);
 
   const roots = buildWaterfallTree(spans);
   const allFlat = flattenTree(roots);
@@ -127,6 +138,8 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
           const svcColor = serviceColors.get(s.resource?.serviceName ?? "unknown") ?? TELEMETRY_SERIES_COLORS[0];
           const childCount = countDescendants(s);
           const validation = lookupSpanValidation(validationIndex, s.traceId, s.spanId);
+          const evaluations = evaluationsBySpanId.get(s.spanId) ?? [];
+          const failedEvaluations = evaluations.filter((evaluation) => !evaluation.passed);
 
           return (
             <div
@@ -148,6 +161,15 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
                 <span className="waterfall__service-dot" style={{ background: svcColor }} />
                 <span className="waterfall__service-name">{s.resource?.serviceName ?? ""}</span>
                 <span className="waterfall__span-name">{s.name}</span>
+                {failedEvaluations.length > 0 ? (
+                  <span className="waterfall__ai-chip waterfall__ai-chip--issue" data-tooltip={formatEvaluationTooltip(failedEvaluations)}>
+                    <span className="waterfall__ai-chip-label">{formatWaterfallEvaluationChipLabel(failedEvaluations)}</span>
+                  </span>
+                ) : evaluations.length > 0 ? (
+                  <span className="waterfall__ai-chip waterfall__ai-chip--ok" data-tooltip="No quality issues">
+                    <span className="waterfall__ai-chip-label">Quality</span>
+                  </span>
+                ) : null}
                 <ValidationBadge count={validation?.count ?? 0} severity={validation?.highestSeverity ?? null} />
               </div>
               <div className="waterfall__row-timeline">
@@ -177,6 +199,18 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
   );
 }
 
+function formatWaterfallEvaluationChipLabel(evaluations: ReturnType<typeof getSpanEvaluations>): string {
+  const firstName = evaluations[0]?.name ? formatEvaluationName(evaluations[0].name) : "Quality";
+  return evaluations.length > 1 ? `${firstName}...(+${evaluations.length - 1})` : firstName;
+}
+
+function formatEvaluationTooltip(evaluations: ReturnType<typeof getSpanEvaluations>): string {
+  if (evaluations.length === 1) {
+    return `${formatEvaluationName(evaluations[0].name)} quality issue`;
+  }
+  return `${evaluations.length} quality issues: ${evaluations.map((evaluation) => formatEvaluationName(evaluation.name)).join(", ")}`;
+}
+
 function countDescendants(span: WaterfallSpan): number {
   let count = span.children.length;
   for (const child of span.children) {
@@ -197,6 +231,8 @@ function formatGenAISpanFilterLabel(type: GenAISpanFilterType): string {
       return "Tool call spans";
     case "loop":
       return "Loop spans";
+    case "quality":
+      return "Quality issue spans";
   }
 }
 

--- a/observer/client/src/traces/TraceWaterfall.tsx
+++ b/observer/client/src/traces/TraceWaterfall.tsx
@@ -5,10 +5,8 @@ import { ValidationBadge } from "../components/ValidationBadge";
 import type { ValidationIndex } from "../validation/utils";
 import { lookupSpanValidation } from "../validation/utils";
 import { TELEMETRY_SERIES_COLORS } from "../palette";
-import { GenAITraceOverview } from "./GenAITraceOverview";
+import { GenAITraceOverview, type GenAISpanFilterType } from "./GenAITraceOverview";
 import { formatEvaluationName, getSpanEvaluations } from "./genai-evaluations";
-
-type GenAISpanFilterType = "security" | "privacy" | "llm" | "tool" | "loop" | "quality";
 
 interface TraceWaterfallProps {
   spans: Span[];

--- a/observer/client/src/traces/TraceWaterfall.tsx
+++ b/observer/client/src/traces/TraceWaterfall.tsx
@@ -1,17 +1,21 @@
 import React, { useState, useMemo } from "react";
-import type { Span } from "../api/types";
+import type { GenAITraceSummary, Span } from "../api/types";
 import { buildWaterfallTree, flattenTree, type WaterfallSpan } from "./waterfall-layout";
 import { ValidationBadge } from "../components/ValidationBadge";
 import type { ValidationIndex } from "../validation/utils";
 import { lookupSpanValidation } from "../validation/utils";
 import { TELEMETRY_SERIES_COLORS } from "../palette";
+import { GenAITraceOverview } from "./GenAITraceOverview";
+
+type GenAISpanFilterType = "security" | "privacy" | "llm" | "tool" | "loop";
 
 interface TraceWaterfallProps {
   spans: Span[];
   selectedSpanId: string | null;
-  onSelectSpan: (spanId: string) => void;
+  onSelectSpan: (spanId: string | null) => void;
   traceDurationMs: number;
   validationIndex: ValidationIndex;
+  genAI?: GenAITraceSummary | null;
 }
 
 // Consistent service colors — same service always gets same color
@@ -29,13 +33,15 @@ function getServiceColorMap(spans: Span[]): Map<string, string> {
 }
 
 /** Renders a collapsible span waterfall with timing bars and service colors. */
-export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurationMs, validationIndex }: TraceWaterfallProps): React.ReactElement {
+export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurationMs, validationIndex, genAI }: TraceWaterfallProps): React.ReactElement {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [genAISpanFilter, setGenAISpanFilter] = useState<{ type: GenAISpanFilterType; spanIds: string[] } | null>(null);
 
   const serviceColors = useMemo(() => getServiceColorMap(spans), [spans]);
 
   const roots = buildWaterfallTree(spans);
-  const flat = flattenTree(roots).filter((s) => {
+  const allFlat = flattenTree(roots);
+  const collapsedFlat = allFlat.filter((s) => {
     let parent = spans.find((p) => p.spanId === s.parentSpanId);
     while (parent) {
       if (collapsed.has(parent.spanId)) return false;
@@ -43,6 +49,19 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
     }
     return true;
   });
+  const filteredSpanIds = genAISpanFilter ? new Set(genAISpanFilter.spanIds) : null;
+  const flat = filteredSpanIds ? allFlat.filter((s) => filteredSpanIds.has(s.spanId)) : collapsedFlat;
+  const selectedSpanVisible = selectedSpanId ? flat.some((s) => s.spanId === selectedSpanId) : false;
+
+  const applyGenAISpanFilter = (type: GenAISpanFilterType, spanIds: string[]) => {
+    setGenAISpanFilter({ type, spanIds });
+    setCollapsed(new Set());
+    onSelectSpan(null);
+  };
+
+  const clearGenAISpanFilter = () => {
+    setGenAISpanFilter(null);
+  };
 
   const toggleCollapse = (e: React.MouseEvent, spanId: string) => {
     e.stopPropagation();
@@ -62,12 +81,28 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
 
   return (
     <div className="waterfall">
+      <GenAITraceOverview
+        summary={genAI ?? null}
+        selectedSpanId={selectedSpanId}
+        onSelectSpan={onSelectSpan}
+        onApplySpanFilter={applyGenAISpanFilter}
+        validationIndex={validationIndex}
+      />
+
       {/* Waterfall header with trace metadata */}
       <div className="waterfall__header">
         <div className="waterfall__header-left">
-          <span className="waterfall__span-count">{spans.length} spans</span>
+          <span className="waterfall__span-count">
+            {genAISpanFilter ? `${flat.length} / ${spans.length} spans` : `${spans.length} spans`}
+          </span>
           {errorCount > 0 ? (
             <span className="trace-status trace-status--error">{errorCount} error{errorCount > 1 ? "s" : ""}</span>
+          ) : null}
+          {genAISpanFilter ? (
+            <button className="waterfall__filter-chip" type="button" onClick={clearGenAISpanFilter}>
+              {formatGenAISpanFilterLabel(genAISpanFilter.type)}: {flat.length}
+              <span aria-hidden="true">×</span>
+            </button>
           ) : null}
         </div>
         <div className="waterfall__header-right">
@@ -96,7 +131,7 @@ export function TraceWaterfall({ spans, selectedSpanId, onSelectSpan, traceDurat
           return (
             <div
               key={s.spanId}
-              className={`waterfall__row ${s.spanId === selectedSpanId ? "waterfall__row--selected" : ""}`}
+              className={`waterfall__row ${s.spanId === selectedSpanId && selectedSpanVisible ? "waterfall__row--selected" : ""}`}
               onClick={() => onSelectSpan(s.spanId)}
             >
               <div className="waterfall__row-service" style={{ paddingLeft: `${8 + s.depth * 16}px` }}>
@@ -148,6 +183,21 @@ function countDescendants(span: WaterfallSpan): number {
     count += countDescendants(child);
   }
   return count;
+}
+
+function formatGenAISpanFilterLabel(type: GenAISpanFilterType): string {
+  switch (type) {
+    case "security":
+      return "Security risk spans";
+    case "privacy":
+      return "Privacy risk spans";
+    case "llm":
+      return "LLM call spans";
+    case "tool":
+      return "Tool call spans";
+    case "loop":
+      return "Loop spans";
+  }
 }
 
 function hexToRgba(hex: string, alpha: number): string {

--- a/observer/client/src/traces/TracesTab.style.test.tsx
+++ b/observer/client/src/traces/TracesTab.style.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TracesTab, traceStatusLabel } from "./TracesTab";
 import { SpanDetailsPanel } from "./SpanDetailsPanel";
 import { MetricsTab } from "../metrics/MetricsTab";
+import type { Span } from "../api/types";
 
 declare const require: (id: string) => any;
 declare const process: { cwd(): string };
@@ -290,7 +291,12 @@ describe("TracesTab row layout", () => {
           endTimeUnixNano: "2026-04-11T12:00:01Z",
           durationMs: 42,
           status: { code: "OK", message: "" },
-          attributes: {},
+          attributes: {
+            "gen_ai.evaluation.name": "groundedness",
+            "gen_ai.evaluation.score.value": 0.32,
+            "gen_ai.evaluation.explanation": "Answer was not grounded in retrieved context.",
+            "assistant.evaluation.outcome": "failed",
+          },
           events: [],
           links: [],
           resource: { serviceName: "checkout", attributes: {} },
@@ -305,6 +311,96 @@ describe("TracesTab row layout", () => {
     expect(closeBtn).toBeTruthy();
     fireEvent.click(closeBtn);
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("opens AI details for spans with GenAI evaluation issues", () => {
+    render(
+      <SpanDetailsPanel
+        span={{
+          traceId: "trace-1",
+          spanId: "span-1",
+          parentSpanId: "",
+          name: "chat gpt-5.5",
+          kind: "INTERNAL",
+          startTimeUnixNano: "2026-04-11T12:00:00Z",
+          endTimeUnixNano: "2026-04-11T12:00:01Z",
+          durationMs: 42,
+          status: { code: "OK", message: "" },
+          attributes: {},
+          events: [
+            {
+              name: "gen_ai.evaluation.result",
+              timeUnixNano: "2026-04-11T12:00:00.500Z",
+              attributes: {
+                "gen_ai.evaluation.name": "groundedness",
+                "gen_ai.evaluation.score.label": "fail",
+                "gen_ai.evaluation.score.value": 0.32,
+                "gen_ai.evaluation.explanation": "Answer was not grounded in retrieved context.",
+                "assistant.evaluation.outcome": "failed",
+              },
+            },
+          ],
+          links: [],
+          resource: { serviceName: "assistant", attributes: {} },
+          scope: { name: "otel", version: "" },
+        }}
+        validationFindings={[]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /AI details/i }).classList.contains("span-details__tab--active")).toBe(true);
+    expect(screen.getByText("Evaluations")).toBeTruthy();
+    expect(screen.getByText("1 issue")).toBeTruthy();
+    expect(screen.getByText("Groundedness")).toBeTruthy();
+    expect(screen.getByText("fail")).toBeTruthy();
+    expect(screen.getByText("0.32")).toBeTruthy();
+    expect(screen.getByText("Answer was not grounded in retrieved context.")).toBeTruthy();
+  });
+
+  it("does not reset the selected details tab when evaluations arrive for the same span", () => {
+    const span: Span = {
+      traceId: "trace-1",
+      spanId: "span-1",
+      parentSpanId: "",
+      name: "chat gpt-5.5",
+      kind: "INTERNAL",
+      startTimeUnixNano: "2026-04-11T12:00:00Z",
+      endTimeUnixNano: "2026-04-11T12:00:01Z",
+      durationMs: 42,
+      status: { code: "OK", message: "" },
+      attributes: {},
+      events: [],
+      links: [],
+      resource: { serviceName: "assistant", attributes: {} },
+      scope: { name: "otel", version: "" },
+    };
+    const { rerender } = render(<SpanDetailsPanel span={span} validationFindings={[]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Attributes" }));
+    expect(screen.getByRole("button", { name: "Attributes" }).classList.contains("span-details__tab--active")).toBe(true);
+
+    rerender(
+      <SpanDetailsPanel
+        span={{
+          ...span,
+          events: [
+            {
+              name: "gen_ai.evaluation.result",
+              timeUnixNano: "2026-04-11T12:00:00.500Z",
+              attributes: {
+                "gen_ai.evaluation.name": "groundedness",
+                "gen_ai.evaluation.score.label": "fail",
+                "assistant.evaluation.outcome": "failed",
+              },
+            },
+          ],
+        }}
+        validationFindings={[]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Attributes" }).classList.contains("span-details__tab--active")).toBe(true);
+    expect(screen.getByRole("button", { name: /AI details/i })).toBeTruthy();
   });
 
   it("does not render a close button in the span detail panel when onClose is not provided", () => {

--- a/observer/client/src/traces/TracesTab.test.tsx
+++ b/observer/client/src/traces/TracesTab.test.tsx
@@ -27,6 +27,82 @@ afterEach(() => {
 });
 
 describe("TracesTab", () => {
+  it("renders unfiltered traces from the live websocket snapshot without a REST query", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-websocket", rootSpanName: "GET /live-websocket", serviceName: "checkout", spanCount: 1, durationMs: 1, status: "ok" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    expect(screen.getByText("GET /live-websocket")).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes filtered traces from REST when live telemetry changes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { traceId: "trace-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 1, durationMs: 10, status: "ok" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { traceId: "trace-2", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 2, durationMs: 20, status: "ok" },
+        ],
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const view = render(
+      <TracesTab
+        traces={[
+          { traceId: "live-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 1, durationMs: 1, status: "ok" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter field"), {
+      target: { value: "rootSpanName" },
+    });
+    fireEvent.change(screen.getByLabelText("rootSpanName value"), {
+      target: { value: "GET /orders" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply filter" }));
+
+    await screen.findByText("trace-1");
+
+    view.rerender(
+      <TracesTab
+        traces={[
+          { traceId: "live-2", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 2, durationMs: 2, status: "ok" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    await screen.findByText("trace-2");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/query/traces?filter%5BrootSpanName%5D%5Beq%5D=GET+%2Forders", expect.any(Object));
+  });
+
   it("filters traces from the compact explorer toolbar via the REST query endpoint", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -49,7 +125,7 @@ describe("TracesTab", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("Filter field"), {
+    fireEvent.change(await screen.findByLabelText("Filter field"), {
       target: { value: "rootSpanName" },
     });
     expect((screen.getByRole("button", { name: "=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
@@ -83,6 +159,61 @@ describe("TracesTab", () => {
     expect(screen.queryByText("--")).toBeNull();
   });
 
+  it("opens selected trace details at the widest usable panel width", async () => {
+    const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          traceId: "trace-1",
+          rootSpanName: "GET /orders",
+          serviceName: "checkout",
+          spanCount: 1,
+          durationMs: 42,
+          status: "ok",
+          spans: [
+            {
+              traceId: "trace-1",
+              spanId: "span-1",
+              parentSpanId: "",
+              name: "GET /orders",
+              kind: "SERVER",
+              startTimeUnixNano: "2026-06-12T18:00:00.000Z",
+              endTimeUnixNano: "2026-06-12T18:00:00.042Z",
+              durationMs: 42,
+              status: { code: "OK" },
+              attributes: {},
+              events: [],
+              links: [],
+              resource: { attributes: {}, serviceName: "checkout" },
+              scope: { name: "test" },
+            },
+          ],
+        }),
+      }) as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-1", rootSpanName: "GET /orders", serviceName: "checkout", spanCount: 1, durationMs: 42, status: "ok" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    const traceRow = (await screen.findByText("GET /orders")).closest("button");
+    expect(traceRow).toBeTruthy();
+    fireEvent.click(traceRow as HTMLButtonElement);
+
+    await screen.findByText("Trace ID");
+
+    const panel = container.querySelector<HTMLElement>(".resizable-panel.signal-view__panel");
+    expect(panel?.style.getPropertyValue("--panel-width")).toBe("min(1600px, calc(100vw - 320px))");
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/traces/trace-1", undefined);
+  });
+
   it("handles a null filtered trace response without crashing", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -102,7 +233,7 @@ describe("TracesTab", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("Filter field"), {
+    fireEvent.change(await screen.findByLabelText("Filter field"), {
       target: { value: "serviceName" },
     });
     expect((screen.getByRole("button", { name: "=" }) as HTMLButtonElement).classList.contains("filter-builder__operator--active")).toBe(true);
@@ -137,7 +268,7 @@ describe("TracesTab", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("Filter field"), {
+    fireEvent.change(await screen.findByLabelText("Filter field"), {
       target: { value: "minDurationMs" },
     });
     fireEvent.click(screen.getByRole("button", { name: "<" }));
@@ -179,6 +310,8 @@ describe("TracesTab", () => {
     const panelStyles = window.getComputedStyle(panel);
     const contentStyles = window.getComputedStyle(content);
 
+    expect(css).toContain("width: var(--panel-width, min(560px, calc(100vw - 320px)));");
+    expect(css).toContain("flex: 0 0 var(--panel-width, min(560px, calc(100vw - 320px)));");
     expect(layoutStyles.flexDirection).toBe("row");
     expect(panelStyles.position).toBe("static");
     expect(panelStyles.borderTopWidth).toBe("0px");

--- a/observer/client/src/traces/TracesTab.test.tsx
+++ b/observer/client/src/traces/TracesTab.test.tsx
@@ -47,6 +47,25 @@ describe("TracesTab", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("differentiates GenAI traces in the trace list", () => {
+    render(
+      <TracesTab
+        traces={[
+          { traceId: "trace-genai", rootSpanName: "POST /v2/assistant/sessions", serviceName: "assistant", spanCount: 4, durationMs: 120, status: "ok", isGenAI: true },
+          { traceId: "trace-http", rootSpanName: "GET /health", serviceName: "api", spanCount: 1, durationMs: 3, status: "ok" },
+        ]}
+        telemetryError={null}
+        onInteract={vi.fn()}
+        validationFindings={[]}
+        validationIndex={{ trace: new Map(), span: new Map(), metric: new Map(), log: new Map() }}
+      />,
+    );
+
+    expect(screen.getByLabelText("GenAI trace")).toBeTruthy();
+    expect(screen.getByText("POST /v2/assistant/sessions")).toBeTruthy();
+    expect(screen.getByText("GET /health")).toBeTruthy();
+  });
+
   it("refreshes filtered traces from REST when live telemetry changes", async () => {
     const fetchMock = vi
       .fn()

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -335,7 +335,14 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
                     ref={virtualizer.measureElement}
                   >
                     <span className="data-table__td data-table__td--operation">
-                      <span className="trace-row__operation explorer-row__primary">{t.rootSpanName}</span>
+                      <span className="trace-row__operation-wrap">
+                        {t.isGenAI ? (
+                          <span className="trace-row__genai-badge" aria-label="GenAI trace" title="GenAI trace">
+                            GenAI
+                          </span>
+                        ) : null}
+                        <span className="trace-row__operation explorer-row__primary">{t.rootSpanName}</span>
+                      </span>
                     </span>
                     <span className="data-table__td data-table__td--trace-id">
                       <span className="trace-row__trace-id explorer-row__secondary">{t.traceId}</span>

--- a/observer/client/src/traces/TracesTab.tsx
+++ b/observer/client/src/traces/TracesTab.tsx
@@ -40,6 +40,9 @@ const TRACE_FILTER_DEFINITIONS: FilterDefinition[] = [
   { key: "maxSpanCount", label: "Max Span Count", kind: "number", placeholder: "10", chipLabel: "Max Span Count", operatorLabels: { eq: "<=", neq: ">" }, step: 1 },
 ];
 const TRACE_SUGGESTIBLE_FIELDS = new Set(["rootSpanName", "serviceName"]);
+const TRACE_DETAIL_PANEL_DEFAULT_WIDTH = "min(1600px, calc(100vw - 320px))";
+const TRACE_DETAIL_PANEL_MIN_WIDTH = 560;
+const TRACE_DETAIL_PANEL_MAX_WIDTH = 1600;
 
 function assignQueryFilter(query: TracesQuery, clause: FilterClause): void {
   const targetKey = clause.op === "neq" ? "notFilters" : "filters";
@@ -362,7 +365,13 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
 
         {/* Detail panel */}
         {selectedTraceId && traceDetail ? (
-          <ResizablePanel className="signal-view__panel" resizeLabel="Resize traces panel">
+          <ResizablePanel
+            className="signal-view__panel"
+            defaultWidth={TRACE_DETAIL_PANEL_DEFAULT_WIDTH}
+            minWidth={TRACE_DETAIL_PANEL_MIN_WIDTH}
+            maxWidth={TRACE_DETAIL_PANEL_MAX_WIDTH}
+            resizeLabel="Resize traces panel"
+          >
             <DetailPanel
               title={traceDetail.rootSpanName}
               subtitle={`${traceDetail.spanCount} spans${errorSpanCount > 0 ? ` \u00B7 ${errorSpanCount} error${errorSpanCount > 1 ? "s" : ""}` : ""} \u00B7 ${formatTraceDuration(traceDetail.durationMs)}`}
@@ -374,6 +383,7 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
               </div>
               <TraceWaterfall
                 spans={traceDetail.spans}
+                genAI={traceDetail.genAI ?? null}
                 selectedSpanId={selectedSpanId}
                 onSelectSpan={setSelectedSpanId}
                 traceDurationMs={traceDetail.durationMs ?? 0}
@@ -382,13 +392,25 @@ export function TracesTab({ traces, telemetryError, onInteract, validationFindin
             </DetailPanel>
           </ResizablePanel>
         ) : selectedTraceId && detailLoading ? (
-          <ResizablePanel className="signal-view__panel" resizeLabel="Resize traces panel">
+          <ResizablePanel
+            className="signal-view__panel"
+            defaultWidth={TRACE_DETAIL_PANEL_DEFAULT_WIDTH}
+            minWidth={TRACE_DETAIL_PANEL_MIN_WIDTH}
+            maxWidth={TRACE_DETAIL_PANEL_MAX_WIDTH}
+            resizeLabel="Resize traces panel"
+          >
             <DetailPanel title="Loading..." onClose={() => selectTrace(null)}>
               <p className="explorer__status">Fetching trace detail...</p>
             </DetailPanel>
           </ResizablePanel>
         ) : selectedTraceId && detailError ? (
-          <ResizablePanel className="signal-view__panel" resizeLabel="Resize traces panel">
+          <ResizablePanel
+            className="signal-view__panel"
+            defaultWidth={TRACE_DETAIL_PANEL_DEFAULT_WIDTH}
+            minWidth={TRACE_DETAIL_PANEL_MIN_WIDTH}
+            maxWidth={TRACE_DETAIL_PANEL_MAX_WIDTH}
+            resizeLabel="Resize traces panel"
+          >
             <DetailPanel
               title="Trace detail unavailable"
               subtitle={selectedSummary?.rootSpanName ?? selectedTraceId.slice(-12)}

--- a/observer/client/src/traces/genai-evaluations.test.ts
+++ b/observer/client/src/traces/genai-evaluations.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { Span } from "../api/types";
+import { getSpanEvaluations } from "./genai-evaluations";
+
+function makeSpan(overrides: Partial<Span>): Span {
+  return {
+    traceId: "trace-genai",
+    spanId: "span-1",
+    parentSpanId: "",
+    name: "chat gpt-5.5",
+    kind: "INTERNAL",
+    startTimeUnixNano: "2026-06-12T18:00:00.000Z",
+    endTimeUnixNano: "2026-06-12T18:00:01.000Z",
+    durationMs: 1000,
+    status: { code: "UNSET" },
+    attributes: {},
+    events: [],
+    links: [],
+    resource: { attributes: {}, serviceName: "assistant" },
+    scope: { name: "test" },
+    ...overrides,
+  };
+}
+
+describe("getSpanEvaluations", () => {
+  it("merges event and span-level evaluations", () => {
+    const evaluations = getSpanEvaluations(
+      makeSpan({
+        attributes: {
+          "gen_ai.evaluation.name": "groundedness",
+          "gen_ai.evaluation.score.label": "pass",
+          "gen_ai.evaluation.score.value": 0.91,
+          "gen_ai.evaluation.passed": true,
+        },
+        events: [
+          {
+            name: "gen_ai.evaluation.result",
+            timeUnixNano: "2026-06-12T18:00:00.500Z",
+            attributes: {
+              "gen_ai.evaluation.name": "toxicity",
+              "gen_ai.evaluation.score.label": "fail",
+              "assistant.evaluation.outcome": "failed",
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(evaluations.map((evaluation) => evaluation.name).sort()).toEqual(["groundedness", "toxicity"]);
+    expect(evaluations.find((evaluation) => evaluation.name === "groundedness")?.passed).toBe(true);
+    expect(evaluations.find((evaluation) => evaluation.name === "toxicity")?.passed).toBe(false);
+  });
+});

--- a/observer/client/src/traces/genai-evaluations.ts
+++ b/observer/client/src/traces/genai-evaluations.ts
@@ -1,0 +1,205 @@
+import type { Span } from "../api/types";
+
+export interface GenAIEvaluation {
+  name: string;
+  scoreLabel?: string;
+  scoreValue?: number;
+  explanation?: string;
+  passed: boolean;
+  errorType?: string;
+}
+
+const EVALUATION_EVENT_NAMES = new Set(["gen_ai.evaluation.result", "gen_ai.evaluation.results"]);
+
+export function getSpanEvaluations(span: Span): GenAIEvaluation[] {
+  const evaluations: GenAIEvaluation[] = [];
+
+  for (const event of span.events ?? []) {
+    if (EVALUATION_EVENT_NAMES.has(event.name) || hasEvaluationAttributes(event.attributes)) {
+      evaluations.push(...getEvaluationsFromAttributes(event.attributes));
+    }
+  }
+
+  if (evaluations.length > 0) {
+    return dedupeEvaluations(evaluations);
+  }
+
+  evaluations.push(...getEvaluationsFromAttributes(span.attributes ?? {}));
+  return dedupeEvaluations(evaluations);
+}
+
+export function getFailedSpanEvaluations(span: Span): GenAIEvaluation[] {
+  return getSpanEvaluations(span).filter((evaluation) => !evaluation.passed);
+}
+
+export function formatEvaluationName(name: string): string {
+  return name
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function getEvaluationsFromAttributes(attributes: Record<string, unknown>): GenAIEvaluation[] {
+  const nestedEvaluations = parseNestedEvaluations(attributes["gen_ai.evaluations"]);
+  if (nestedEvaluations.length > 0) {
+    return nestedEvaluations.flatMap((value) => (isRecord(value) ? [evaluationFromAttributes(value)] : []));
+  }
+
+  if (!hasEvaluationAttributes(attributes)) {
+    return [];
+  }
+
+  return [evaluationFromAttributes(attributes)];
+}
+
+function evaluationFromAttributes(attributes: Record<string, unknown>): GenAIEvaluation {
+  const name = firstString(
+    attributes["gen_ai.evaluation.name"],
+    attributes["assistant.evaluation.name"],
+    attributes["evaluation.name"],
+    "evaluation",
+  );
+  const scoreLabel = firstOptionalString(attributes["gen_ai.evaluation.score.label"], attributes["assistant.evaluation.score.label"]);
+  const scoreValue = firstOptionalNumber(attributes["gen_ai.evaluation.score.value"], attributes["assistant.evaluation.score.value"]);
+  const explanation = firstOptionalString(attributes["gen_ai.evaluation.explanation"], attributes["assistant.evaluation.explanation"]);
+  const errorType = firstOptionalString(attributes["error.type"]);
+
+  return {
+    name,
+    scoreLabel,
+    scoreValue,
+    explanation,
+    passed: !evaluationAttributesFailed(attributes),
+    errorType,
+  };
+}
+
+function dedupeEvaluations(evaluations: GenAIEvaluation[]): GenAIEvaluation[] {
+  const deduped: GenAIEvaluation[] = [];
+
+  for (const evaluation of evaluations) {
+    const existing = deduped.find((candidate) => evaluationsMatch(candidate, evaluation));
+    if (existing) {
+      existing.scoreLabel ??= evaluation.scoreLabel;
+      existing.scoreValue ??= evaluation.scoreValue;
+      existing.explanation ??= evaluation.explanation;
+      existing.errorType ??= evaluation.errorType;
+      continue;
+    }
+
+    deduped.push({ ...evaluation });
+  }
+
+  return deduped;
+}
+
+function evaluationsMatch(left: GenAIEvaluation, right: GenAIEvaluation): boolean {
+  return (
+    normalizeEvaluationKeyValue(left.name) === normalizeEvaluationKeyValue(right.name) &&
+    left.passed === right.passed &&
+    compatibleOptionalKeyValue(left.scoreLabel, right.scoreLabel) &&
+    compatibleOptionalKeyValue(left.errorType, right.errorType) &&
+    compatibleOptionalValue(left.scoreValue, right.scoreValue) &&
+    compatibleOptionalValue(left.explanation, right.explanation)
+  );
+}
+
+function compatibleOptionalValue<T>(left: T | undefined, right: T | undefined): boolean {
+  return left === undefined || right === undefined || left === right;
+}
+
+function compatibleOptionalKeyValue(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalizeEvaluationKeyValue(left);
+  const normalizedRight = normalizeEvaluationKeyValue(right);
+  return normalizedLeft === "" || normalizedRight === "" || normalizedLeft === normalizedRight;
+}
+
+function normalizeEvaluationKeyValue(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function parseNestedEvaluations(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function hasEvaluationAttributes(attributes: Record<string, unknown>): boolean {
+  return (
+    Object.keys(attributes).some((key) => key.startsWith("gen_ai.evaluation.")) ||
+    "gen_ai.evaluations" in attributes ||
+    "assistant.evaluation.outcome" in attributes ||
+    "assistant.evaluation.name" in attributes
+  );
+}
+
+function evaluationAttributesFailed(attributes: Record<string, unknown>): boolean {
+  const passed = attributes["gen_ai.evaluation.passed"];
+  if (typeof passed === "boolean") {
+    return !passed;
+  }
+  if (typeof passed === "string" && ["true", "false"].includes(passed.trim().toLowerCase())) {
+    return passed.trim().toLowerCase() === "false";
+  }
+
+  const outcome = firstOptionalString(attributes["assistant.evaluation.outcome"], attributes["gen_ai.evaluation.outcome"])?.toLowerCase();
+  if (outcome && ["failed", "fail", "error", "no_data"].includes(outcome)) {
+    return true;
+  }
+  if (outcome && ["passed", "pass", "ok", "success"].includes(outcome)) {
+    return false;
+  }
+
+  const scoreLabel = firstOptionalString(attributes["gen_ai.evaluation.score.label"], attributes["assistant.evaluation.score.label"])?.toLowerCase();
+  if (scoreLabel && ["failed", "fail", "error", "bad"].includes(scoreLabel)) {
+    return true;
+  }
+
+  const errorType = firstOptionalString(attributes["error.type"])?.toLowerCase();
+  return Boolean(errorType && errorType !== "unknown" && errorType !== "none");
+}
+
+function firstString(...values: unknown[]): string {
+  return firstOptionalString(...values) ?? "";
+}
+
+function firstOptionalString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.trim();
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function firstOptionalNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/observer/client/src/traces/genai-evaluations.ts
+++ b/observer/client/src/traces/genai-evaluations.ts
@@ -20,10 +20,6 @@ export function getSpanEvaluations(span: Span): GenAIEvaluation[] {
     }
   }
 
-  if (evaluations.length > 0) {
-    return dedupeEvaluations(evaluations);
-  }
-
   evaluations.push(...getEvaluationsFromAttributes(span.attributes ?? {}));
   return dedupeEvaluations(evaluations);
 }

--- a/observer/cmd/obstudio/install.go
+++ b/observer/cmd/obstudio/install.go
@@ -27,10 +27,11 @@ const (
 	codexManagedBlockStart = "# BEGIN OBSTUDIO MCP CONFIG"
 	codexManagedBlockEnd   = "# END OBSTUDIO MCP CONFIG"
 
-	defaultSharedObserverBaseURL = "http://127.0.0.1:3000"
-	defaultSharedObserverMCPURL  = defaultSharedObserverBaseURL + "/mcp"
-	defaultSharedObserverHealth  = defaultSharedObserverBaseURL + "/api/health"
-	sharedObserverHealthTimeout  = 750 * time.Millisecond
+	defaultSharedObserverBaseURL      = "http://127.0.0.1:3000"
+	defaultSharedObserverMCPURL       = defaultSharedObserverBaseURL + "/mcp"
+	defaultSharedObserverHealth       = defaultSharedObserverBaseURL + "/api/health"
+	sharedObserverHealthTimeout       = 750 * time.Millisecond
+	disableSharedObserverDetectionEnv = "OBSTUDIO_DISABLE_SHARED_OBSERVER_DETECTION"
 
 	sharedObserverStateDirName  = ".obstudio"
 	sharedObserverStateFileName = "shared-observer.json"
@@ -125,7 +126,7 @@ func runInstall(target, sharedURL string) error {
 	}
 	resolvedSharedURL := sharedURL
 	autodetectedSharedURL := false
-	if resolvedSharedURL == "" {
+	if resolvedSharedURL == "" && os.Getenv(disableSharedObserverDetectionEnv) == "" {
 		if detectedURL, ok := detectConfiguredSharedObserverURL(http.DefaultClient); ok {
 			resolvedSharedURL = detectedURL
 			autodetectedSharedURL = true

--- a/observer/cmd/obstudio/install_test.go
+++ b/observer/cmd/obstudio/install_test.go
@@ -968,6 +968,7 @@ func smokeHomeEnv(homeDir string) []string {
 	env := []string{
 		"HOME=" + homeDir,
 		"USERPROFILE=" + homeDir,
+		disableSharedObserverDetectionEnv + "=1",
 	}
 	if runtime.GOOS == "windows" {
 		volume := filepath.VolumeName(homeDir)

--- a/observer/internal/store/genai.go
+++ b/observer/internal/store/genai.go
@@ -1,0 +1,1158 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type GenAISpanKind string
+
+const (
+	GenAISpanWorkflow  GenAISpanKind = "workflow"
+	GenAISpanAgent     GenAISpanKind = "agent"
+	GenAISpanTool      GenAISpanKind = "tool"
+	GenAISpanLLM       GenAISpanKind = "llm"
+	GenAISpanRetrieval GenAISpanKind = "retrieval"
+	GenAISpanLoop      GenAISpanKind = "loop"
+	GenAISpanGeneric   GenAISpanKind = "genai"
+)
+
+type GenAITokenUsage struct {
+	Input  float64 `json:"input"`
+	Output float64 `json:"output"`
+	Total  float64 `json:"total"`
+}
+
+type GenAITraceSummary struct {
+	IsGenAI    bool            `json:"isGenAI"`
+	Tokens     GenAITokenUsage `json:"tokens"`
+	ToolCalls  int             `json:"toolCalls"`
+	LLMCalls   int             `json:"llmCalls"`
+	ModelNames []string        `json:"modelNames"`
+	FlowNodes  []GenAIFlowNode `json:"flowNodes"`
+	FlowEdges  []GenAIFlowEdge `json:"flowEdges"`
+}
+
+type GenAIFlowNode struct {
+	NodeID                        string          `json:"nodeId"`
+	TraceID                       string          `json:"traceId"`
+	SpanID                        string          `json:"spanId"`
+	Name                          string          `json:"name"`
+	Kind                          GenAISpanKind   `json:"kind"`
+	Operation                     string          `json:"operation,omitempty"`
+	ModelNames                    []string        `json:"modelNames"`
+	TokenUsage                    GenAITokenUsage `json:"tokenUsage"`
+	Depth                         int             `json:"depth"`
+	DurationMs                    float64         `json:"durationMs"`
+	AvgDurationMs                 float64         `json:"avgDurationMs,omitempty"`
+	MaxDurationMs                 float64         `json:"maxDurationMs,omitempty"`
+	StatusCode                    string          `json:"statusCode"`
+	Grouped                       bool            `json:"grouped"`
+	CallCount                     int             `json:"callCount,omitempty"`
+	GroupedSpanIDs                []string        `json:"groupedSpanIds"`
+	ParentFlowSpanID              string          `json:"parentFlowSpanId,omitempty"`
+	DescendantSpanIDs             []string        `json:"descendantSpanIds"`
+	DescendantTokenUsage          GenAITokenUsage `json:"descendantTokenUsage"`
+	DescendantLLMCalls            int             `json:"descendantLlmCalls"`
+	DescendantLLMSpanIDs          []string        `json:"descendantLlmSpanIds"`
+	DescendantToolCalls           int             `json:"descendantToolCalls"`
+	DescendantToolSpanIDs         []string        `json:"descendantToolSpanIds"`
+	DescendantSecurityRiskCount   int             `json:"descendantSecurityRiskCount"`
+	DescendantSecurityRiskSpanIDs []string        `json:"descendantSecurityRiskSpanIds"`
+	DescendantPrivacyRiskCount    int             `json:"descendantPrivacyRiskCount"`
+	DescendantPrivacyRiskSpanIDs  []string        `json:"descendantPrivacyRiskSpanIds"`
+	DescendantRiskCount           int             `json:"descendantRiskCount"`
+
+	parentSpanID string
+	linkSpanIDs  []string
+}
+
+type GenAIFlowEdge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+const genAIPrefix = "gen_ai."
+const genAIFlowGroupThreshold = 8
+const genAIFlowCycleMinIterations = 2
+const genAIFlowCycleMaxPatternLength = 4
+
+var (
+	genAIOperationKeys = []string{
+		"gen_ai.operation.name",
+		"gen_ai.operation",
+		"llm.operation",
+		"openinference.span.kind",
+	}
+	genAIModelKeys = []string{
+		"gen_ai.request.model",
+		"gen_ai.response.model",
+		"llm.model_name",
+		"llm.request.model",
+		"openai.request.model",
+		"openai.response.model",
+		"ai.model.id",
+		"model",
+	}
+	genAIInputTokenKeys = []string{
+		"gen_ai.usage.input_tokens",
+		"gen_ai.usage.prompt_tokens",
+		"llm.token_count.prompt",
+		"openai.usage.prompt_tokens",
+		"ai.usage.input_tokens",
+		"prompt_tokens",
+	}
+	genAIOutputTokenKeys = []string{
+		"gen_ai.usage.output_tokens",
+		"gen_ai.usage.completion_tokens",
+		"llm.token_count.completion",
+		"openai.usage.completion_tokens",
+		"ai.usage.output_tokens",
+		"completion_tokens",
+	}
+	genAITotalTokenKeys = []string{
+		"gen_ai.usage.total_tokens",
+		"llm.token_count.total",
+		"openai.usage.total_tokens",
+		"ai.usage.total_tokens",
+		"total_tokens",
+	}
+	genAIToolNameKeys = []string{
+		"gen_ai.tool.name",
+		"tool.name",
+		"ai.tool.name",
+		"openinference.tool.name",
+	}
+	genAIAgentNameKeys = []string{
+		"gen_ai.agent.name",
+		"agent.name",
+		"ai.agent.name",
+	}
+	genAIRetrievalNameKeys = []string{
+		"gen_ai.retrieval.source",
+		"gen_ai.retrieval.source.name",
+		"gen_ai.data_source.name",
+		"retrieval.source",
+		"retrieval.source.name",
+		"data_source.name",
+	}
+)
+
+func buildGenAITraceSummary(spans []Span) *GenAITraceSummary {
+	nodes := buildGenAIFlowNodes(spans, maxGenAIFlowNodeSpanListSize())
+	genAISpans := make([]Span, 0)
+	for _, span := range spans {
+		if isGenAISpan(span) {
+			genAISpans = append(genAISpans, span)
+		}
+	}
+	if len(genAISpans) == 0 {
+		return nil
+	}
+
+	var tokens GenAITokenUsage
+	modelSet := make(map[string]struct{})
+	toolCalls := 0
+	llmCalls := 0
+	for _, span := range genAISpans {
+		tokens = addTokenUsage(tokens, getGenAITokenUsage(span))
+		for _, model := range getGenAIModelNames(span) {
+			modelSet[model] = struct{}{}
+		}
+		switch classifyGenAISpan(span) {
+		case GenAISpanTool:
+			toolCalls++
+		case GenAISpanLLM:
+			llmCalls++
+		}
+	}
+	if tokens.Total == 0 {
+		tokens.Total = tokens.Input + tokens.Output
+	}
+
+	modelNames := make([]string, 0, len(modelSet))
+	for model := range modelSet {
+		modelNames = append(modelNames, model)
+	}
+	sort.Strings(modelNames)
+
+	return &GenAITraceSummary{
+		IsGenAI:    true,
+		Tokens:     tokens,
+		ToolCalls:  toolCalls,
+		LLMCalls:   llmCalls,
+		ModelNames: modelNames,
+		FlowNodes:  nodes,
+		FlowEdges:  buildGenAIFlowEdges(nodes),
+	}
+}
+
+func buildGenAIFlowNodes(spans []Span, descendantCap int) []GenAIFlowNode {
+	if len(spans) == 0 {
+		return nil
+	}
+
+	byID := make(map[string]Span, len(spans))
+	childrenByParent := make(map[string][]Span)
+	for _, span := range spans {
+		byID[span.SpanID] = span
+	}
+	for _, span := range spans {
+		if span.ParentSpanID != "" {
+			if _, ok := byID[span.ParentSpanID]; ok {
+				childrenByParent[span.ParentSpanID] = append(childrenByParent[span.ParentSpanID], span)
+			}
+		}
+	}
+	for parentID := range childrenByParent {
+		sort.SliceStable(childrenByParent[parentID], func(i, j int) bool {
+			return childrenByParent[parentID][i].StartTime.Before(childrenByParent[parentID][j].StartTime)
+		})
+	}
+
+	roots := make([]Span, 0)
+	for _, span := range spans {
+		if span.ParentSpanID == "" {
+			roots = append(roots, span)
+			continue
+		}
+		if _, ok := byID[span.ParentSpanID]; !ok {
+			roots = append(roots, span)
+		}
+	}
+	sort.SliceStable(roots, func(i, j int) bool {
+		return roots[i].StartTime.Before(roots[j].StartTime)
+	})
+
+	nodes := make([]GenAIFlowNode, 0)
+	nodeIndexBySpanID := make(map[string]int)
+
+	addDescendant := func(parentFlowSpanID string, span Span) {
+		index, ok := nodeIndexBySpanID[parentFlowSpanID]
+		if !ok {
+			return
+		}
+		node := &nodes[index]
+		node.DescendantSpanIDs = appendSpanIDWithCap(node.DescendantSpanIDs, span.SpanID, descendantCap)
+		addGenAIFlowNodeDescendantSignals(node, span, descendantCap)
+	}
+
+	addDescendantToAncestors := func(ancestorFlowSpanIDs []string, span Span) {
+		for _, parentFlowSpanID := range ancestorFlowSpanIDs {
+			addDescendant(parentFlowSpanID, span)
+		}
+	}
+
+	appendAncestor := func(ancestorFlowSpanIDs []string, spanID string) []string {
+		next := make([]string, 0, len(ancestorFlowSpanIDs)+1)
+		next = append(next, ancestorFlowSpanIDs...)
+		next = append(next, spanID)
+		return next
+	}
+
+	var visit func(Span, []string, int)
+	visit = func(span Span, ancestorFlowSpanIDs []string, flowDepth int) {
+		if len(ancestorFlowSpanIDs) > 0 {
+			addDescendantToAncestors(ancestorFlowSpanIDs, span)
+		}
+
+		nextAncestorFlowSpanIDs := ancestorFlowSpanIDs
+		nextFlowDepth := flowDepth
+		if isGenAIFlowNodeSpan(span) {
+			parentFlowSpanID := ""
+			if len(ancestorFlowSpanIDs) > 0 {
+				parentFlowSpanID = ancestorFlowSpanIDs[len(ancestorFlowSpanIDs)-1]
+			}
+			node := newGenAIFlowNode(span, flowDepth)
+			node.ParentFlowSpanID = parentFlowSpanID
+			addGenAIFlowNodeOwnSignals(&node, span)
+			nodes = append(nodes, node)
+			nodeIndexBySpanID[span.SpanID] = len(nodes) - 1
+			nextAncestorFlowSpanIDs = appendAncestor(ancestorFlowSpanIDs, span.SpanID)
+			nextFlowDepth = flowDepth + 1
+		}
+		for _, child := range childrenByParent[span.SpanID] {
+			visit(child, nextAncestorFlowSpanIDs, nextFlowDepth)
+		}
+	}
+
+	for _, root := range roots {
+		visit(root, nil, 0)
+	}
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	return groupGenAIFlowNodes(nodes)
+}
+
+func newGenAIFlowNode(span Span, depth int) GenAIFlowNode {
+	kind := classifyGenAISpan(span)
+	operation := getGenAIOperation(span)
+	return GenAIFlowNode{
+		NodeID:                        span.SpanID,
+		TraceID:                       span.TraceID,
+		SpanID:                        span.SpanID,
+		Name:                          getGenAIFlowNodeName(span, kind, operation),
+		Kind:                          kind,
+		Operation:                     operation,
+		ModelNames:                    getGenAIModelNames(span),
+		TokenUsage:                    getGenAITokenUsage(span),
+		Depth:                         depth,
+		DurationMs:                    span.DurationMs,
+		StatusCode:                    span.Status.Code,
+		GroupedSpanIDs:                []string{},
+		DescendantSpanIDs:             []string{},
+		DescendantLLMSpanIDs:          []string{},
+		DescendantToolSpanIDs:         []string{},
+		DescendantSecurityRiskSpanIDs: []string{},
+		DescendantPrivacyRiskSpanIDs:  []string{},
+		parentSpanID:                  span.ParentSpanID,
+		linkSpanIDs:                   getGenAILinkSpanIDs(span),
+	}
+}
+
+func groupGenAIFlowNodes(nodes []GenAIFlowNode) []GenAIFlowNode {
+	if len(nodes) == 0 {
+		return nodes
+	}
+	hasChildFlowNode := genAIFlowChildNodeMap(nodes)
+	nodes = groupRepeatedGenAIFlowCycles(nodes, hasChildFlowNode)
+	return groupRepeatedGenAIFlowNodes(nodes, genAIFlowChildNodeMap(nodes))
+}
+
+func genAIFlowChildNodeMap(nodes []GenAIFlowNode) map[string]bool {
+	hasChildFlowNode := make(map[string]bool)
+	for _, node := range nodes {
+		if node.ParentFlowSpanID != "" {
+			hasChildFlowNode[node.ParentFlowSpanID] = true
+		}
+	}
+	return hasChildFlowNode
+}
+
+func groupRepeatedGenAIFlowCycles(nodes []GenAIFlowNode, hasChildFlowNode map[string]bool) []GenAIFlowNode {
+	if len(nodes) < genAIFlowCycleMinIterations*2 {
+		return nodes
+	}
+
+	grouped := make([]GenAIFlowNode, 0, len(nodes))
+	for index := 0; index < len(nodes); {
+		match := bestGenAIFlowCycleMatch(nodes, index, hasChildFlowNode)
+		if match.totalNodes == 0 {
+			grouped = append(grouped, nodes[index])
+			index++
+			continue
+		}
+
+		indexes := make([]int, 0, match.totalNodes)
+		for offset := 0; offset < match.totalNodes; offset++ {
+			indexes = append(indexes, index+offset)
+		}
+		grouped = append(grouped, newGroupedGenAIFlowCycleNode(nodes, indexes, match.patternLength, match.iterations))
+		index += match.totalNodes
+	}
+	return grouped
+}
+
+type genAIFlowCycleMatch struct {
+	patternLength int
+	iterations    int
+	totalNodes    int
+}
+
+func bestGenAIFlowCycleMatch(nodes []GenAIFlowNode, start int, hasChildFlowNode map[string]bool) genAIFlowCycleMatch {
+	best := genAIFlowCycleMatch{}
+	maxPatternLength := genAIFlowCycleMaxPatternLength
+	if remaining := len(nodes) - start; remaining < maxPatternLength {
+		maxPatternLength = remaining
+	}
+
+	for patternLength := 2; patternLength <= maxPatternLength; patternLength++ {
+		if !isGenAIFlowCyclePattern(nodes, start, patternLength, hasChildFlowNode) {
+			continue
+		}
+
+		iterations := 1
+		for matchesGenAIFlowCyclePattern(nodes, start, patternLength, iterations+1, hasChildFlowNode) {
+			iterations++
+		}
+		if iterations < genAIFlowCycleMinIterations {
+			continue
+		}
+		totalNodes := iterations * patternLength
+		if totalNodes > best.totalNodes || (totalNodes == best.totalNodes && patternLength < best.patternLength) {
+			best = genAIFlowCycleMatch{
+				patternLength: patternLength,
+				iterations:    iterations,
+				totalNodes:    totalNodes,
+			}
+		}
+	}
+	return best
+}
+
+func isGenAIFlowCyclePattern(nodes []GenAIFlowNode, start, patternLength int, hasChildFlowNode map[string]bool) bool {
+	if start+patternLength > len(nodes) {
+		return false
+	}
+	parentFlowSpanID := nodes[start].ParentFlowSpanID
+	hasLLM := false
+	hasTool := false
+	for index := start; index < start+patternLength; index++ {
+		node := nodes[index]
+		if !isLoopGroupableGenAIFlowNode(node, hasChildFlowNode) {
+			return false
+		}
+		if node.ParentFlowSpanID != parentFlowSpanID {
+			return false
+		}
+		switch node.Kind {
+		case GenAISpanLLM:
+			hasLLM = true
+		case GenAISpanTool:
+			hasTool = true
+		}
+	}
+	return hasLLM && hasTool
+}
+
+func matchesGenAIFlowCyclePattern(nodes []GenAIFlowNode, start, patternLength, iterations int, hasChildFlowNode map[string]bool) bool {
+	nextStart := start + (iterations-1)*patternLength
+	if nextStart+patternLength > len(nodes) {
+		return false
+	}
+
+	parentFlowSpanID := nodes[start].ParentFlowSpanID
+	for offset := 0; offset < patternLength; offset++ {
+		patternNode := nodes[start+offset]
+		nextNode := nodes[nextStart+offset]
+		if !isLoopGroupableGenAIFlowNode(nextNode, hasChildFlowNode) {
+			return false
+		}
+		if nextNode.ParentFlowSpanID != parentFlowSpanID {
+			return false
+		}
+		if genAIFlowCycleNodeSignature(nextNode) != genAIFlowCycleNodeSignature(patternNode) {
+			return false
+		}
+	}
+	return true
+}
+
+func isLoopGroupableGenAIFlowNode(node GenAIFlowNode, hasChildFlowNode map[string]bool) bool {
+	switch node.Kind {
+	case GenAISpanLLM, GenAISpanTool:
+	default:
+		return false
+	}
+	return !hasChildFlowNode[node.SpanID]
+}
+
+func genAIFlowCycleNodeSignature(node GenAIFlowNode) string {
+	return strings.Join([]string{
+		string(node.Kind),
+		node.Operation,
+		node.Name,
+		strings.Join(node.ModelNames, ","),
+	}, "\x00")
+}
+
+func groupRepeatedGenAIFlowNodes(nodes []GenAIFlowNode, hasChildFlowNode map[string]bool) []GenAIFlowNode {
+	if len(nodes) <= genAIFlowGroupThreshold {
+		return nodes
+	}
+
+	groups := make(map[string][]int)
+	for index, node := range nodes {
+		if !isGroupableGenAIFlowNode(node, hasChildFlowNode) {
+			continue
+		}
+		key := genAIFlowGroupKey(node)
+		groups[key] = append(groups[key], index)
+	}
+
+	groupedByFirstIndex := make(map[int]GenAIFlowNode)
+	removed := make(map[int]bool)
+	for _, indexes := range groups {
+		if len(indexes) <= genAIFlowGroupThreshold {
+			continue
+		}
+		grouped := newGroupedGenAIFlowNode(nodes, indexes)
+		groupedByFirstIndex[indexes[0]] = grouped
+		for _, index := range indexes[1:] {
+			removed[index] = true
+		}
+	}
+	if len(groupedByFirstIndex) == 0 {
+		return nodes
+	}
+
+	result := make([]GenAIFlowNode, 0, len(nodes)-len(removed))
+	for index, node := range nodes {
+		if grouped, ok := groupedByFirstIndex[index]; ok {
+			result = append(result, grouped)
+			continue
+		}
+		if removed[index] {
+			continue
+		}
+		result = append(result, node)
+	}
+	return result
+}
+
+func isGroupableGenAIFlowNode(node GenAIFlowNode, hasChildFlowNode map[string]bool) bool {
+	switch node.Kind {
+	case GenAISpanLLM, GenAISpanTool:
+	default:
+		return false
+	}
+	if hasChildFlowNode[node.SpanID] {
+		return false
+	}
+	return true
+}
+
+func genAIFlowGroupKey(node GenAIFlowNode) string {
+	return strings.Join([]string{
+		node.ParentFlowSpanID,
+		string(node.Kind),
+		node.Operation,
+		node.Name,
+		strings.Join(node.ModelNames, ","),
+	}, "\x00")
+}
+
+func newGroupedGenAIFlowNode(nodes []GenAIFlowNode, indexes []int) GenAIFlowNode {
+	first := nodes[indexes[0]]
+	groupedSpanIDs := make([]string, 0, len(indexes))
+	var tokenUsage GenAITokenUsage
+	var durationTotal float64
+	var durationMax float64
+	statusCode := "OK"
+	securityRiskSpanIDs := make([]string, 0)
+	privacyRiskSpanIDs := make([]string, 0)
+	linkSpanIDs := make([]string, 0)
+	internalSpanIDs := make(map[string]struct{})
+	riskCount := 0
+
+	for _, index := range indexes {
+		internalSpanIDs[nodes[index].SpanID] = struct{}{}
+	}
+
+	for _, index := range indexes {
+		node := nodes[index]
+		groupedSpanIDs = append(groupedSpanIDs, node.SpanID)
+		tokenUsage = addTokenUsage(tokenUsage, node.TokenUsage)
+		durationTotal += node.DurationMs
+		if node.DurationMs > durationMax {
+			durationMax = node.DurationMs
+		}
+		if node.StatusCode == "ERROR" {
+			statusCode = "ERROR"
+		}
+		securityRiskSpanIDs = append(securityRiskSpanIDs, node.DescendantSecurityRiskSpanIDs...)
+		privacyRiskSpanIDs = append(privacyRiskSpanIDs, node.DescendantPrivacyRiskSpanIDs...)
+		for _, linkSpanID := range node.linkSpanIDs {
+			if _, ok := internalSpanIDs[linkSpanID]; !ok {
+				linkSpanIDs = append(linkSpanIDs, linkSpanID)
+			}
+		}
+		riskCount += node.DescendantRiskCount
+	}
+
+	callCount := len(indexes)
+	groupID := genAIFlowGroupID(first.ParentFlowSpanID, string(first.Kind), first.Operation, first.Name, strings.Join(first.ModelNames, ","))
+	groupedName := fmt.Sprintf("%s x%d", first.Name, callCount)
+	avgDuration := 0.0
+	if callCount > 0 {
+		avgDuration = durationTotal / float64(callCount)
+	}
+
+	grouped := GenAIFlowNode{
+		NodeID:                        groupID,
+		TraceID:                       first.TraceID,
+		SpanID:                        groupID,
+		Name:                          groupedName,
+		Kind:                          first.Kind,
+		Operation:                     first.Operation,
+		ModelNames:                    first.ModelNames,
+		TokenUsage:                    tokenUsage,
+		Depth:                         first.Depth,
+		DurationMs:                    durationMax,
+		AvgDurationMs:                 avgDuration,
+		MaxDurationMs:                 durationMax,
+		StatusCode:                    statusCode,
+		Grouped:                       true,
+		CallCount:                     callCount,
+		GroupedSpanIDs:                groupedSpanIDs,
+		ParentFlowSpanID:              first.ParentFlowSpanID,
+		DescendantSpanIDs:             groupedSpanIDs,
+		DescendantTokenUsage:          tokenUsage,
+		DescendantSecurityRiskCount:   len(securityRiskSpanIDs),
+		DescendantSecurityRiskSpanIDs: securityRiskSpanIDs,
+		DescendantPrivacyRiskCount:    len(privacyRiskSpanIDs),
+		DescendantPrivacyRiskSpanIDs:  privacyRiskSpanIDs,
+		DescendantRiskCount:           riskCount,
+		linkSpanIDs:                   uniqueStrings(linkSpanIDs),
+	}
+	switch first.Kind {
+	case GenAISpanLLM:
+		grouped.DescendantLLMCalls = callCount
+		grouped.DescendantLLMSpanIDs = groupedSpanIDs
+		grouped.DescendantToolSpanIDs = []string{}
+	case GenAISpanTool:
+		grouped.DescendantToolCalls = callCount
+		grouped.DescendantToolSpanIDs = groupedSpanIDs
+		grouped.DescendantLLMSpanIDs = []string{}
+	default:
+		grouped.DescendantLLMSpanIDs = []string{}
+		grouped.DescendantToolSpanIDs = []string{}
+	}
+	return grouped
+}
+
+func newGroupedGenAIFlowCycleNode(nodes []GenAIFlowNode, indexes []int, patternLength int, iterations int) GenAIFlowNode {
+	first := nodes[indexes[0]]
+	patternNodes := make([]GenAIFlowNode, 0, patternLength)
+	for _, index := range indexes[:patternLength] {
+		patternNodes = append(patternNodes, nodes[index])
+	}
+
+	groupedSpanIDs := make([]string, 0, len(indexes))
+	llmSpanIDs := make([]string, 0)
+	toolSpanIDs := make([]string, 0)
+	securityRiskSpanIDs := make([]string, 0)
+	privacyRiskSpanIDs := make([]string, 0)
+	internalSpanIDs := make(map[string]struct{})
+	var tokenUsage GenAITokenUsage
+	var durationTotal float64
+	var durationMax float64
+	statusCode := "OK"
+	riskCount := 0
+	llmCalls := 0
+	toolCalls := 0
+
+	for _, index := range indexes {
+		node := nodes[index]
+		internalSpanIDs[node.SpanID] = struct{}{}
+	}
+
+	for _, index := range indexes {
+		node := nodes[index]
+		groupedSpanIDs = append(groupedSpanIDs, node.SpanID)
+		groupedSpanIDs = append(groupedSpanIDs, node.DescendantSpanIDs...)
+		tokenUsage = addTokenUsage(tokenUsage, node.TokenUsage)
+		durationTotal += node.DurationMs
+		if node.DurationMs > durationMax {
+			durationMax = node.DurationMs
+		}
+		if node.StatusCode == "ERROR" {
+			statusCode = "ERROR"
+		}
+
+		switch node.Kind {
+		case GenAISpanLLM:
+			llmCalls++
+			llmSpanIDs = append(llmSpanIDs, node.SpanID)
+		case GenAISpanTool:
+			toolCalls++
+			toolSpanIDs = append(toolSpanIDs, node.SpanID)
+		}
+		llmCalls += node.DescendantLLMCalls
+		llmSpanIDs = append(llmSpanIDs, node.DescendantLLMSpanIDs...)
+		toolCalls += node.DescendantToolCalls
+		toolSpanIDs = append(toolSpanIDs, node.DescendantToolSpanIDs...)
+
+		securityRiskSpanIDs = append(securityRiskSpanIDs, node.DescendantSecurityRiskSpanIDs...)
+		privacyRiskSpanIDs = append(privacyRiskSpanIDs, node.DescendantPrivacyRiskSpanIDs...)
+		riskCount += node.DescendantRiskCount
+	}
+
+	linkSpanIDs := make([]string, 0)
+	for _, index := range indexes {
+		for _, linkSpanID := range nodes[index].linkSpanIDs {
+			if _, ok := internalSpanIDs[linkSpanID]; !ok {
+				linkSpanIDs = append(linkSpanIDs, linkSpanID)
+			}
+		}
+	}
+
+	groupID := genAIFlowGroupID(first.ParentFlowSpanID, "loop", genAIFlowCyclePatternName(patternNodes))
+	avgDuration := 0.0
+	if len(indexes) > 0 {
+		avgDuration = durationTotal / float64(len(indexes))
+	}
+
+	return GenAIFlowNode{
+		NodeID:                        groupID,
+		TraceID:                       first.TraceID,
+		SpanID:                        groupID,
+		Name:                          fmt.Sprintf("%s loop x%d", genAIFlowCyclePatternName(patternNodes), iterations),
+		Kind:                          GenAISpanLoop,
+		Operation:                     "loop",
+		ModelNames:                    uniqueStrings(flattenGenAIFlowNodeModelNames(patternNodes)),
+		TokenUsage:                    tokenUsage,
+		Depth:                         first.Depth,
+		DurationMs:                    durationTotal,
+		AvgDurationMs:                 avgDuration,
+		MaxDurationMs:                 durationMax,
+		StatusCode:                    statusCode,
+		Grouped:                       true,
+		CallCount:                     iterations,
+		GroupedSpanIDs:                uniqueStrings(groupedSpanIDs),
+		ParentFlowSpanID:              first.ParentFlowSpanID,
+		DescendantSpanIDs:             uniqueStrings(groupedSpanIDs),
+		DescendantTokenUsage:          tokenUsage,
+		DescendantLLMCalls:            llmCalls,
+		DescendantLLMSpanIDs:          uniqueStrings(llmSpanIDs),
+		DescendantToolCalls:           toolCalls,
+		DescendantToolSpanIDs:         uniqueStrings(toolSpanIDs),
+		DescendantSecurityRiskCount:   len(uniqueStrings(securityRiskSpanIDs)),
+		DescendantSecurityRiskSpanIDs: uniqueStrings(securityRiskSpanIDs),
+		DescendantPrivacyRiskCount:    len(uniqueStrings(privacyRiskSpanIDs)),
+		DescendantPrivacyRiskSpanIDs:  uniqueStrings(privacyRiskSpanIDs),
+		DescendantRiskCount:           riskCount,
+		linkSpanIDs:                   uniqueStrings(linkSpanIDs),
+	}
+}
+
+func genAIFlowCyclePatternName(nodes []GenAIFlowNode) string {
+	parts := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		parts = append(parts, node.Name)
+	}
+	return strings.Join(parts, " + ")
+}
+
+func genAIFlowGroupID(parts ...string) string {
+	safeParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		part = strings.ReplaceAll(part, "\x00", "_")
+		part = strings.ReplaceAll(part, ":", "_")
+		part = strings.ReplaceAll(part, " ", "_")
+		if part == "" {
+			part = "_"
+		}
+		safeParts = append(safeParts, part)
+	}
+	return "group:" + strings.Join(safeParts, ":")
+}
+
+func flattenGenAIFlowNodeModelNames(nodes []GenAIFlowNode) []string {
+	modelNames := make([]string, 0)
+	for _, node := range nodes {
+		modelNames = append(modelNames, node.ModelNames...)
+	}
+	return modelNames
+}
+
+func buildGenAIFlowEdges(nodes []GenAIFlowNode) []GenAIFlowEdge {
+	selectedIDs := make(map[string]struct{}, len(nodes))
+	groupAliasBySpanID := make(map[string]string)
+	for _, node := range nodes {
+		selectedIDs[node.SpanID] = struct{}{}
+		for _, groupedSpanID := range node.GroupedSpanIDs {
+			groupAliasBySpanID[groupedSpanID] = node.SpanID
+		}
+	}
+
+	resolveSelectedFlowSpanID := func(spanID string) (string, bool) {
+		if _, ok := selectedIDs[spanID]; ok {
+			return spanID, true
+		}
+		if groupID, ok := groupAliasBySpanID[spanID]; ok {
+			return groupID, true
+		}
+		return "", false
+	}
+
+	edges := make([]GenAIFlowEdge, 0, len(nodes))
+	seen := make(map[GenAIFlowEdge]struct{})
+	for _, node := range nodes {
+		var predecessors []string
+		for _, link := range node.linkSpanIDs {
+			if predecessor, ok := resolveSelectedFlowSpanID(link); ok && predecessor != node.SpanID {
+				predecessors = append(predecessors, predecessor)
+			}
+		}
+		if len(predecessors) == 0 && node.ParentFlowSpanID != "" {
+			if predecessor, ok := resolveSelectedFlowSpanID(node.ParentFlowSpanID); ok && predecessor != node.SpanID {
+				predecessors = append(predecessors, predecessor)
+			}
+		}
+		for _, predecessor := range uniqueStrings(predecessors) {
+			if predecessor == node.SpanID {
+				continue
+			}
+			edge := GenAIFlowEdge{Source: predecessor, Target: node.SpanID}
+			if _, ok := seen[edge]; ok {
+				continue
+			}
+			seen[edge] = struct{}{}
+			edges = append(edges, edge)
+		}
+	}
+	return edges
+}
+
+func isGenAISpan(span Span) bool {
+	return hasAttributePrefix(span.Attributes, genAIPrefix) || hasAttributePrefix(span.Resource.Attributes, genAIPrefix)
+}
+
+func isGenAIFlowNodeSpan(span Span) bool {
+	if isInferredGenAISpan(span) {
+		return false
+	}
+	switch classifyGenAISpan(span) {
+	case GenAISpanWorkflow, GenAISpanAgent, GenAISpanTool, GenAISpanLLM, GenAISpanRetrieval:
+		return true
+	default:
+		return false
+	}
+}
+
+func isInferredGenAISpan(span Span) bool {
+	for _, attrs := range []map[string]any{span.Resource.Attributes, span.Attributes} {
+		if inferredType := strings.TrimSpace(fmt.Sprint(attrs["_sf_inferredServiceType"])); inferredType != "" && inferredType != "<nil>" {
+			switch inferredType {
+			case "database", "_sf_pubsub", "_sf_service", "_sf_llm":
+				return true
+			}
+		}
+	}
+	if value, ok := span.Resource.Attributes["sf.inferred"]; ok && toBool(value) {
+		return true
+	}
+	if value, ok := span.Attributes["sf.inferred"]; ok && toBool(value) {
+		return true
+	}
+	if value, ok := span.Resource.Attributes["splunk.inferred"]; ok && toBool(value) {
+		return true
+	}
+	if value, ok := span.Attributes["splunk.inferred"]; ok && toBool(value) {
+		return true
+	}
+	return false
+}
+
+func classifyGenAISpan(span Span) GenAISpanKind {
+	operation := strings.ToLower(getGenAIOperation(span))
+	toolName := getFirstAttributeString(span.Attributes, genAIToolNameKeys)
+	agentName := getFirstAttributeString(span.Attributes, genAIAgentNameKeys)
+	modelNames := getGenAIModelNames(span)
+	tokens := getGenAITokenUsage(span)
+	spanName := strings.ToLower(span.Name)
+
+	switch {
+	case toolName != "" || strings.Contains(operation, "tool") || operation == "function" || strings.Contains(spanName, " tool"):
+		return GenAISpanTool
+	case strings.Contains(operation, "workflow"):
+		return GenAISpanWorkflow
+	case agentName != "" || strings.Contains(operation, "agent"):
+		return GenAISpanAgent
+	case operation == "retrieval" || operation == "retriever" || strings.Contains(operation, "retrieval") || strings.Contains(operation, "retriever"):
+		return GenAISpanRetrieval
+	case len(modelNames) > 0 || tokens.Total > 0 || operation == "llm" || strings.Contains(operation, "chat") || strings.Contains(operation, "completion") || strings.Contains(operation, "embedding") || strings.Contains(operation, "generate"):
+		return GenAISpanLLM
+	default:
+		return GenAISpanGeneric
+	}
+}
+
+func getGenAIOperation(span Span) string {
+	return getFirstAttributeString(span.Attributes, genAIOperationKeys)
+}
+
+func getGenAIModelNames(span Span) []string {
+	var models []string
+	for _, key := range genAIModelKeys {
+		models = append(models, splitAttributeValues(span.Attributes[key])...)
+	}
+	return uniqueStrings(models)
+}
+
+func getGenAITokenUsage(span Span) GenAITokenUsage {
+	input := firstNumericAttribute(span.Attributes, genAIInputTokenKeys)
+	output := firstNumericAttribute(span.Attributes, genAIOutputTokenKeys)
+	total := firstNumericAttribute(span.Attributes, genAITotalTokenKeys)
+	if total == 0 {
+		total = input + output
+	}
+	return GenAITokenUsage{Input: input, Output: output, Total: total}
+}
+
+func getGenAIFlowNodeName(span Span, kind GenAISpanKind, operation string) string {
+	switch kind {
+	case GenAISpanWorkflow:
+		if name := firstNonBlankString(span.Attributes["gen_ai.workflow.name"], span.Attributes["workflow.name"], operation); name != "" {
+			return name
+		}
+	case GenAISpanAgent:
+		if name := firstNonBlankString(span.Attributes["gen_ai.agent.name"], span.Attributes["agent.name"], operation); name != "" {
+			return name
+		}
+	case GenAISpanTool:
+		if name := firstNonBlankString(span.Attributes["gen_ai.tool.name"], span.Attributes["tool.name"], operation); name != "" {
+			return name
+		}
+	case GenAISpanRetrieval:
+		if source := getFirstAttributeString(span.Attributes, genAIRetrievalNameKeys); source != "" && operation != "" {
+			return operation + " " + source
+		}
+		if source := getFirstAttributeString(span.Attributes, genAIRetrievalNameKeys); source != "" {
+			return source
+		}
+	case GenAISpanLLM:
+		if operation != "" && len(getGenAIModelNames(span)) > 0 {
+			return operation + " " + strings.Join(getGenAIModelNames(span), ", ")
+		}
+		if operation != "" {
+			return operation
+		}
+	}
+	if operation != "" {
+		return operation
+	}
+	return span.Name
+}
+
+func addGenAIFlowNodeOwnSignals(node *GenAIFlowNode, span Span) {
+	addGenAIFlowNodeRiskSignals(node, span, 0)
+}
+
+func addGenAIFlowNodeDescendantSignals(node *GenAIFlowNode, span Span, spanListCap int) {
+	if isGenAISpan(span) {
+		node.DescendantTokenUsage = addTokenUsage(node.DescendantTokenUsage, getGenAITokenUsage(span))
+		switch classifyGenAISpan(span) {
+		case GenAISpanLLM:
+			node.DescendantLLMCalls++
+			node.DescendantLLMSpanIDs = appendSpanIDWithCap(node.DescendantLLMSpanIDs, span.SpanID, spanListCap)
+		case GenAISpanTool:
+			node.DescendantToolCalls++
+			node.DescendantToolSpanIDs = appendSpanIDWithCap(node.DescendantToolSpanIDs, span.SpanID, spanListCap)
+		}
+	}
+	addGenAIFlowNodeRiskSignals(node, span, spanListCap)
+}
+
+func addGenAIFlowNodeRiskSignals(node *GenAIFlowNode, span Span, spanListCap int) {
+	hasSecurityRisk := hasGenAISecurityRiskAttributes(span)
+	hasPrivacyRisk := hasGenAIPrivacyRiskAttributes(span)
+	if hasSecurityRisk || hasPrivacyRisk {
+		node.DescendantRiskCount++
+	}
+	if hasSecurityRisk {
+		node.DescendantSecurityRiskCount++
+		node.DescendantSecurityRiskSpanIDs = appendSpanIDWithCap(node.DescendantSecurityRiskSpanIDs, span.SpanID, spanListCap)
+	}
+	if hasPrivacyRisk {
+		node.DescendantPrivacyRiskCount++
+		node.DescendantPrivacyRiskSpanIDs = appendSpanIDWithCap(node.DescendantPrivacyRiskSpanIDs, span.SpanID, spanListCap)
+	}
+}
+
+func appendSpanIDWithCap(spanIDs []string, spanID string, cap int) []string {
+	if cap > 0 && len(spanIDs) >= cap {
+		return spanIDs
+	}
+	return append(spanIDs, spanID)
+}
+
+func hasGenAISecurityRiskAttributes(span Span) bool {
+	return hasAttributePrefix(span.Attributes, "gen_ai.security.")
+}
+
+func hasGenAIPrivacyRiskAttributes(span Span) bool {
+	return hasAttributePrefix(span.Attributes, "gen_ai.privacy.")
+}
+
+func getGenAILinkSpanIDs(span Span) []string {
+	if len(span.Links) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(span.Links))
+	for _, link := range span.Links {
+		if link.SpanID != "" {
+			ids = append(ids, link.SpanID)
+		}
+	}
+	return uniqueStrings(ids)
+}
+
+func addTokenUsage(a, b GenAITokenUsage) GenAITokenUsage {
+	return GenAITokenUsage{
+		Input:  a.Input + b.Input,
+		Output: a.Output + b.Output,
+		Total:  a.Total + b.Total,
+	}
+}
+
+func hasAttributePrefix(attrs map[string]any, prefix string) bool {
+	for key := range attrs {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func getFirstAttributeString(attrs map[string]any, keys []string) string {
+	for _, key := range keys {
+		values := splitAttributeValues(attrs[key])
+		if len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func firstNonBlankString(values ...any) string {
+	for _, value := range values {
+		for _, part := range splitAttributeValues(value) {
+			if strings.TrimSpace(part) != "" {
+				return strings.TrimSpace(part)
+			}
+		}
+	}
+	return ""
+}
+
+func splitAttributeValues(value any) []string {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case string:
+		parts := strings.Split(typed, ",")
+		values := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if trimmed := strings.TrimSpace(part); trimmed != "" {
+				values = append(values, trimmed)
+			}
+		}
+		return values
+	case []string:
+		values := make([]string, 0, len(typed))
+		for _, part := range typed {
+			if trimmed := strings.TrimSpace(part); trimmed != "" {
+				values = append(values, trimmed)
+			}
+		}
+		return values
+	case []any:
+		var values []string
+		for _, item := range typed {
+			values = append(values, splitAttributeValues(item)...)
+		}
+		return values
+	case json.Number:
+		return []string{string(typed)}
+	case float64, float32, int, int64, int32, uint64, uint32, bool:
+		return []string{strings.TrimSpace(fmt.Sprint(value))}
+	default:
+		return nil
+	}
+}
+
+func firstNumericAttribute(attrs map[string]any, keys []string) float64 {
+	for _, key := range keys {
+		raw, ok := attrs[key]
+		if !ok {
+			continue
+		}
+		value, ok := numericAttributeValue(raw)
+		if ok && value >= 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func toFloat64(value any) float64 {
+	numericValue, ok := numericAttributeValue(value)
+	if !ok {
+		return 0
+	}
+	return numericValue
+}
+
+func numericAttributeValue(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case nil:
+		return 0, false
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case int32:
+		return float64(typed), true
+	case uint64:
+		return float64(typed), true
+	case uint32:
+		return float64(typed), true
+	case string:
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	case json.Number:
+		parsed, err := strconv.ParseFloat(string(typed), 64)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
+}
+
+func toBool(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(typed))
+		return err == nil && parsed
+	default:
+		return false
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func maxGenAIFlowNodeSpanListSize() int {
+	raw := os.Getenv("MAX_FLOW_NODE_SPAN_LIST_SIZE")
+	if raw == "" {
+		return 1000
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
+		return 1000
+	}
+	return parsed
+}

--- a/observer/internal/store/genai.go
+++ b/observer/internal/store/genai.go
@@ -158,7 +158,6 @@ var (
 )
 
 func buildGenAITraceSummary(spans []Span) *GenAITraceSummary {
-	nodes := buildGenAIFlowNodes(spans, maxGenAIFlowNodeSpanListSize())
 	genAISpans := make([]Span, 0)
 	for _, span := range spans {
 		if isGenAISpan(span) {
@@ -168,6 +167,7 @@ func buildGenAITraceSummary(spans []Span) *GenAITraceSummary {
 	if len(genAISpans) == 0 {
 		return nil
 	}
+	nodes := buildGenAIFlowNodes(spans, maxGenAIFlowNodeSpanListSize())
 
 	var tokens GenAITokenUsage
 	toolCalls := 0
@@ -1262,14 +1262,6 @@ func firstNumericAttributeValue(attrs map[string]any, keys []string) (float64, b
 		}
 	}
 	return 0, false
-}
-
-func toFloat64(value any) float64 {
-	numericValue, ok := numericAttributeValue(value)
-	if !ok {
-		return 0
-	}
-	return numericValue
 }
 
 func numericAttributeValue(value any) (float64, bool) {

--- a/observer/internal/store/genai.go
+++ b/observer/internal/store/genai.go
@@ -91,15 +91,27 @@ var (
 		"llm.operation",
 		"openinference.span.kind",
 	}
-	genAIModelKeys = []string{
-		"gen_ai.request.model",
+	genAIResponseModelKeys = []string{
 		"gen_ai.response.model",
-		"llm.model_name",
+		"openai.response.model",
+	}
+	genAIRequestModelKeys = []string{
+		"gen_ai.request.model",
 		"llm.request.model",
 		"openai.request.model",
-		"openai.response.model",
+	}
+	genAIOtherModelKeys = []string{
+		"llm.model_name",
 		"ai.model.id",
 		"model",
+	}
+	genAIPlaceholderModelNames = map[string]struct{}{
+		"unknown":       {},
+		"unknown_model": {},
+		"n/a":           {},
+		"none":          {},
+		"null":          {},
+		"<nil>":         {},
 	}
 	genAIInputTokenKeys = []string{
 		"gen_ai.usage.input_tokens",
@@ -158,14 +170,10 @@ func buildGenAITraceSummary(spans []Span) *GenAITraceSummary {
 	}
 
 	var tokens GenAITokenUsage
-	modelSet := make(map[string]struct{})
 	toolCalls := 0
 	llmCalls := 0
 	for _, span := range genAISpans {
 		tokens = addTokenUsage(tokens, getGenAITokenUsage(span))
-		for _, model := range getGenAIModelNames(span) {
-			modelSet[model] = struct{}{}
-		}
 		if isGenAIEvaluationOnlySpan(span) {
 			continue
 		}
@@ -176,22 +184,12 @@ func buildGenAITraceSummary(spans []Span) *GenAITraceSummary {
 			llmCalls++
 		}
 	}
-	if tokens.Total == 0 {
-		tokens.Total = tokens.Input + tokens.Output
-	}
-
-	modelNames := make([]string, 0, len(modelSet))
-	for model := range modelSet {
-		modelNames = append(modelNames, model)
-	}
-	sort.Strings(modelNames)
-
 	return &GenAITraceSummary{
 		IsGenAI:    true,
 		Tokens:     tokens,
 		ToolCalls:  toolCalls,
 		LLMCalls:   llmCalls,
-		ModelNames: modelNames,
+		ModelNames: getGenAITraceModelNames(genAISpans),
 		FlowNodes:  nodes,
 		FlowEdges:  buildGenAIFlowEdges(nodes),
 	}
@@ -603,9 +601,9 @@ func newGroupedGenAIFlowNode(nodes []GenAIFlowNode, indexes []int) GenAIFlowNode
 		StatusCode:                        statusCode,
 		Grouped:                           true,
 		CallCount:                         callCount,
-		GroupedSpanIDs:                    groupedSpanIDs,
+		GroupedSpanIDs:                    cloneStrings(groupedSpanIDs),
 		ParentFlowSpanID:                  first.ParentFlowSpanID,
-		DescendantSpanIDs:                 groupedSpanIDs,
+		DescendantSpanIDs:                 cloneStrings(groupedSpanIDs),
 		DescendantTokenUsage:              tokenUsage,
 		DescendantSecurityRiskCount:       len(securityRiskSpanIDs),
 		DescendantSecurityRiskSpanIDs:     securityRiskSpanIDs,
@@ -620,11 +618,11 @@ func newGroupedGenAIFlowNode(nodes []GenAIFlowNode, indexes []int) GenAIFlowNode
 	switch first.Kind {
 	case GenAISpanLLM:
 		grouped.DescendantLLMCalls = callCount
-		grouped.DescendantLLMSpanIDs = groupedSpanIDs
+		grouped.DescendantLLMSpanIDs = cloneStrings(groupedSpanIDs)
 		grouped.DescendantToolSpanIDs = []string{}
 	case GenAISpanTool:
 		grouped.DescendantToolCalls = callCount
-		grouped.DescendantToolSpanIDs = groupedSpanIDs
+		grouped.DescendantToolSpanIDs = cloneStrings(groupedSpanIDs)
 		grouped.DescendantLLMSpanIDs = []string{}
 	default:
 		grouped.DescendantLLMSpanIDs = []string{}
@@ -913,17 +911,48 @@ func getGenAIOperation(span Span) string {
 
 func getGenAIModelNames(span Span) []string {
 	var models []string
-	for _, key := range genAIModelKeys {
-		models = append(models, splitAttributeValues(span.Attributes[key])...)
+	for _, keys := range [][]string{genAIResponseModelKeys, genAIRequestModelKeys, genAIOtherModelKeys} {
+		models = append(models, getGenAIModelNamesForKeys(span, keys)...)
 	}
 	return uniqueStrings(models)
+}
+
+func getGenAITraceModelNames(spans []Span) []string {
+	models := make([]string, 0)
+	for _, keys := range [][]string{genAIResponseModelKeys, genAIRequestModelKeys, genAIOtherModelKeys} {
+		for _, span := range spans {
+			models = append(models, getGenAIModelNamesForKeys(span, keys)...)
+		}
+	}
+	return uniqueStrings(models)
+}
+
+func getGenAIModelNamesForKeys(span Span, keys []string) []string {
+	models := make([]string, 0)
+	for _, key := range keys {
+		for _, model := range splitAttributeValues(span.Attributes[key]) {
+			if isKnownGenAIModelName(model) {
+				models = append(models, model)
+			}
+		}
+	}
+	return models
+}
+
+func isKnownGenAIModelName(model string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if normalized == "" {
+		return false
+	}
+	_, unknown := genAIPlaceholderModelNames[normalized]
+	return !unknown
 }
 
 func getGenAITokenUsage(span Span) GenAITokenUsage {
 	input := firstNumericAttribute(span.Attributes, genAIInputTokenKeys)
 	output := firstNumericAttribute(span.Attributes, genAIOutputTokenKeys)
-	total := firstNumericAttribute(span.Attributes, genAITotalTokenKeys)
-	if total == 0 {
+	total, hasTotal := firstNumericAttributeValue(span.Attributes, genAITotalTokenKeys)
+	if !hasTotal {
 		total = input + output
 	}
 	return GenAITokenUsage{Input: input, Output: output, Total: total}
@@ -951,8 +980,9 @@ func getGenAIFlowNodeName(span Span, kind GenAISpanKind, operation string) strin
 			return source
 		}
 	case GenAISpanLLM:
-		if operation != "" && len(getGenAIModelNames(span)) > 0 {
-			return operation + " " + strings.Join(getGenAIModelNames(span), ", ")
+		modelNames := getGenAIModelNames(span)
+		if operation != "" && len(modelNames) > 0 {
+			return operation + " " + modelNames[0]
 		}
 		if operation != "" {
 			return operation
@@ -1220,6 +1250,11 @@ func splitAttributeValues(value any) []string {
 }
 
 func firstNumericAttribute(attrs map[string]any, keys []string) float64 {
+	value, _ := firstNumericAttributeValue(attrs, keys)
+	return value
+}
+
+func firstNumericAttributeValue(attrs map[string]any, keys []string) (float64, bool) {
 	for _, key := range keys {
 		raw, ok := attrs[key]
 		if !ok {
@@ -1227,10 +1262,10 @@ func firstNumericAttribute(attrs map[string]any, keys []string) float64 {
 		}
 		value, ok := numericAttributeValue(raw)
 		if ok && value >= 0 {
-			return value
+			return value, true
 		}
 	}
-	return 0
+	return 0, false
 }
 
 func toFloat64(value any) float64 {
@@ -1302,6 +1337,13 @@ func uniqueStrings(values []string) []string {
 		result = append(result, value)
 	}
 	return result
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), values...)
 }
 
 func maxGenAIFlowNodeSpanListSize() int {

--- a/observer/internal/store/genai.go
+++ b/observer/internal/store/genai.go
@@ -38,34 +38,37 @@ type GenAITraceSummary struct {
 }
 
 type GenAIFlowNode struct {
-	NodeID                        string          `json:"nodeId"`
-	TraceID                       string          `json:"traceId"`
-	SpanID                        string          `json:"spanId"`
-	Name                          string          `json:"name"`
-	Kind                          GenAISpanKind   `json:"kind"`
-	Operation                     string          `json:"operation,omitempty"`
-	ModelNames                    []string        `json:"modelNames"`
-	TokenUsage                    GenAITokenUsage `json:"tokenUsage"`
-	Depth                         int             `json:"depth"`
-	DurationMs                    float64         `json:"durationMs"`
-	AvgDurationMs                 float64         `json:"avgDurationMs,omitempty"`
-	MaxDurationMs                 float64         `json:"maxDurationMs,omitempty"`
-	StatusCode                    string          `json:"statusCode"`
-	Grouped                       bool            `json:"grouped"`
-	CallCount                     int             `json:"callCount,omitempty"`
-	GroupedSpanIDs                []string        `json:"groupedSpanIds"`
-	ParentFlowSpanID              string          `json:"parentFlowSpanId,omitempty"`
-	DescendantSpanIDs             []string        `json:"descendantSpanIds"`
-	DescendantTokenUsage          GenAITokenUsage `json:"descendantTokenUsage"`
-	DescendantLLMCalls            int             `json:"descendantLlmCalls"`
-	DescendantLLMSpanIDs          []string        `json:"descendantLlmSpanIds"`
-	DescendantToolCalls           int             `json:"descendantToolCalls"`
-	DescendantToolSpanIDs         []string        `json:"descendantToolSpanIds"`
-	DescendantSecurityRiskCount   int             `json:"descendantSecurityRiskCount"`
-	DescendantSecurityRiskSpanIDs []string        `json:"descendantSecurityRiskSpanIds"`
-	DescendantPrivacyRiskCount    int             `json:"descendantPrivacyRiskCount"`
-	DescendantPrivacyRiskSpanIDs  []string        `json:"descendantPrivacyRiskSpanIds"`
-	DescendantRiskCount           int             `json:"descendantRiskCount"`
+	NodeID                            string          `json:"nodeId"`
+	TraceID                           string          `json:"traceId"`
+	SpanID                            string          `json:"spanId"`
+	Name                              string          `json:"name"`
+	Kind                              GenAISpanKind   `json:"kind"`
+	Operation                         string          `json:"operation,omitempty"`
+	ModelNames                        []string        `json:"modelNames"`
+	TokenUsage                        GenAITokenUsage `json:"tokenUsage"`
+	Depth                             int             `json:"depth"`
+	DurationMs                        float64         `json:"durationMs"`
+	AvgDurationMs                     float64         `json:"avgDurationMs,omitempty"`
+	MaxDurationMs                     float64         `json:"maxDurationMs,omitempty"`
+	StatusCode                        string          `json:"statusCode"`
+	Grouped                           bool            `json:"grouped"`
+	CallCount                         int             `json:"callCount,omitempty"`
+	GroupedSpanIDs                    []string        `json:"groupedSpanIds"`
+	ParentFlowSpanID                  string          `json:"parentFlowSpanId,omitempty"`
+	DescendantSpanIDs                 []string        `json:"descendantSpanIds"`
+	DescendantTokenUsage              GenAITokenUsage `json:"descendantTokenUsage"`
+	DescendantLLMCalls                int             `json:"descendantLlmCalls"`
+	DescendantLLMSpanIDs              []string        `json:"descendantLlmSpanIds"`
+	DescendantToolCalls               int             `json:"descendantToolCalls"`
+	DescendantToolSpanIDs             []string        `json:"descendantToolSpanIds"`
+	DescendantSecurityRiskCount       int             `json:"descendantSecurityRiskCount"`
+	DescendantSecurityRiskSpanIDs     []string        `json:"descendantSecurityRiskSpanIds"`
+	DescendantPrivacyRiskCount        int             `json:"descendantPrivacyRiskCount"`
+	DescendantPrivacyRiskSpanIDs      []string        `json:"descendantPrivacyRiskSpanIds"`
+	DescendantRiskCount               int             `json:"descendantRiskCount"`
+	DescendantEvaluationCount         int             `json:"descendantEvaluationCount"`
+	DescendantEvaluationFailedCount   int             `json:"descendantEvaluationFailedCount"`
+	DescendantEvaluationFailedSpanIDs []string        `json:"descendantEvaluationFailedSpanIds"`
 
 	parentSpanID string
 	linkSpanIDs  []string
@@ -162,6 +165,9 @@ func buildGenAITraceSummary(spans []Span) *GenAITraceSummary {
 		tokens = addTokenUsage(tokens, getGenAITokenUsage(span))
 		for _, model := range getGenAIModelNames(span) {
 			modelSet[model] = struct{}{}
+		}
+		if isGenAIEvaluationOnlySpan(span) {
+			continue
 		}
 		switch classifyGenAISpan(span) {
 		case GenAISpanTool:
@@ -294,25 +300,26 @@ func newGenAIFlowNode(span Span, depth int) GenAIFlowNode {
 	kind := classifyGenAISpan(span)
 	operation := getGenAIOperation(span)
 	return GenAIFlowNode{
-		NodeID:                        span.SpanID,
-		TraceID:                       span.TraceID,
-		SpanID:                        span.SpanID,
-		Name:                          getGenAIFlowNodeName(span, kind, operation),
-		Kind:                          kind,
-		Operation:                     operation,
-		ModelNames:                    getGenAIModelNames(span),
-		TokenUsage:                    getGenAITokenUsage(span),
-		Depth:                         depth,
-		DurationMs:                    span.DurationMs,
-		StatusCode:                    span.Status.Code,
-		GroupedSpanIDs:                []string{},
-		DescendantSpanIDs:             []string{},
-		DescendantLLMSpanIDs:          []string{},
-		DescendantToolSpanIDs:         []string{},
-		DescendantSecurityRiskSpanIDs: []string{},
-		DescendantPrivacyRiskSpanIDs:  []string{},
-		parentSpanID:                  span.ParentSpanID,
-		linkSpanIDs:                   getGenAILinkSpanIDs(span),
+		NodeID:                            span.SpanID,
+		TraceID:                           span.TraceID,
+		SpanID:                            span.SpanID,
+		Name:                              getGenAIFlowNodeName(span, kind, operation),
+		Kind:                              kind,
+		Operation:                         operation,
+		ModelNames:                        getGenAIModelNames(span),
+		TokenUsage:                        getGenAITokenUsage(span),
+		Depth:                             depth,
+		DurationMs:                        span.DurationMs,
+		StatusCode:                        span.Status.Code,
+		GroupedSpanIDs:                    []string{},
+		DescendantSpanIDs:                 []string{},
+		DescendantLLMSpanIDs:              []string{},
+		DescendantToolSpanIDs:             []string{},
+		DescendantSecurityRiskSpanIDs:     []string{},
+		DescendantPrivacyRiskSpanIDs:      []string{},
+		DescendantEvaluationFailedSpanIDs: []string{},
+		parentSpanID:                      span.ParentSpanID,
+		linkSpanIDs:                       getGenAILinkSpanIDs(span),
 	}
 }
 
@@ -537,9 +544,12 @@ func newGroupedGenAIFlowNode(nodes []GenAIFlowNode, indexes []int) GenAIFlowNode
 	statusCode := "OK"
 	securityRiskSpanIDs := make([]string, 0)
 	privacyRiskSpanIDs := make([]string, 0)
+	evaluationFailedSpanIDs := make([]string, 0)
 	linkSpanIDs := make([]string, 0)
 	internalSpanIDs := make(map[string]struct{})
 	riskCount := 0
+	evaluationCount := 0
+	evaluationFailedCount := 0
 
 	for _, index := range indexes {
 		internalSpanIDs[nodes[index].SpanID] = struct{}{}
@@ -558,6 +568,9 @@ func newGroupedGenAIFlowNode(nodes []GenAIFlowNode, indexes []int) GenAIFlowNode
 		}
 		securityRiskSpanIDs = append(securityRiskSpanIDs, node.DescendantSecurityRiskSpanIDs...)
 		privacyRiskSpanIDs = append(privacyRiskSpanIDs, node.DescendantPrivacyRiskSpanIDs...)
+		evaluationCount += node.DescendantEvaluationCount
+		evaluationFailedCount += node.DescendantEvaluationFailedCount
+		evaluationFailedSpanIDs = append(evaluationFailedSpanIDs, node.DescendantEvaluationFailedSpanIDs...)
 		for _, linkSpanID := range node.linkSpanIDs {
 			if _, ok := internalSpanIDs[linkSpanID]; !ok {
 				linkSpanIDs = append(linkSpanIDs, linkSpanID)
@@ -575,31 +588,34 @@ func newGroupedGenAIFlowNode(nodes []GenAIFlowNode, indexes []int) GenAIFlowNode
 	}
 
 	grouped := GenAIFlowNode{
-		NodeID:                        groupID,
-		TraceID:                       first.TraceID,
-		SpanID:                        groupID,
-		Name:                          groupedName,
-		Kind:                          first.Kind,
-		Operation:                     first.Operation,
-		ModelNames:                    first.ModelNames,
-		TokenUsage:                    tokenUsage,
-		Depth:                         first.Depth,
-		DurationMs:                    durationMax,
-		AvgDurationMs:                 avgDuration,
-		MaxDurationMs:                 durationMax,
-		StatusCode:                    statusCode,
-		Grouped:                       true,
-		CallCount:                     callCount,
-		GroupedSpanIDs:                groupedSpanIDs,
-		ParentFlowSpanID:              first.ParentFlowSpanID,
-		DescendantSpanIDs:             groupedSpanIDs,
-		DescendantTokenUsage:          tokenUsage,
-		DescendantSecurityRiskCount:   len(securityRiskSpanIDs),
-		DescendantSecurityRiskSpanIDs: securityRiskSpanIDs,
-		DescendantPrivacyRiskCount:    len(privacyRiskSpanIDs),
-		DescendantPrivacyRiskSpanIDs:  privacyRiskSpanIDs,
-		DescendantRiskCount:           riskCount,
-		linkSpanIDs:                   uniqueStrings(linkSpanIDs),
+		NodeID:                            groupID,
+		TraceID:                           first.TraceID,
+		SpanID:                            groupID,
+		Name:                              groupedName,
+		Kind:                              first.Kind,
+		Operation:                         first.Operation,
+		ModelNames:                        first.ModelNames,
+		TokenUsage:                        tokenUsage,
+		Depth:                             first.Depth,
+		DurationMs:                        durationMax,
+		AvgDurationMs:                     avgDuration,
+		MaxDurationMs:                     durationMax,
+		StatusCode:                        statusCode,
+		Grouped:                           true,
+		CallCount:                         callCount,
+		GroupedSpanIDs:                    groupedSpanIDs,
+		ParentFlowSpanID:                  first.ParentFlowSpanID,
+		DescendantSpanIDs:                 groupedSpanIDs,
+		DescendantTokenUsage:              tokenUsage,
+		DescendantSecurityRiskCount:       len(securityRiskSpanIDs),
+		DescendantSecurityRiskSpanIDs:     securityRiskSpanIDs,
+		DescendantPrivacyRiskCount:        len(privacyRiskSpanIDs),
+		DescendantPrivacyRiskSpanIDs:      privacyRiskSpanIDs,
+		DescendantRiskCount:               riskCount,
+		DescendantEvaluationCount:         evaluationCount,
+		DescendantEvaluationFailedCount:   evaluationFailedCount,
+		DescendantEvaluationFailedSpanIDs: uniqueStrings(evaluationFailedSpanIDs),
+		linkSpanIDs:                       uniqueStrings(linkSpanIDs),
 	}
 	switch first.Kind {
 	case GenAISpanLLM:
@@ -629,12 +645,15 @@ func newGroupedGenAIFlowCycleNode(nodes []GenAIFlowNode, indexes []int, patternL
 	toolSpanIDs := make([]string, 0)
 	securityRiskSpanIDs := make([]string, 0)
 	privacyRiskSpanIDs := make([]string, 0)
+	evaluationFailedSpanIDs := make([]string, 0)
 	internalSpanIDs := make(map[string]struct{})
 	var tokenUsage GenAITokenUsage
 	var durationTotal float64
 	var durationMax float64
 	statusCode := "OK"
 	riskCount := 0
+	evaluationCount := 0
+	evaluationFailedCount := 0
 	llmCalls := 0
 	toolCalls := 0
 
@@ -672,6 +691,9 @@ func newGroupedGenAIFlowCycleNode(nodes []GenAIFlowNode, indexes []int, patternL
 		securityRiskSpanIDs = append(securityRiskSpanIDs, node.DescendantSecurityRiskSpanIDs...)
 		privacyRiskSpanIDs = append(privacyRiskSpanIDs, node.DescendantPrivacyRiskSpanIDs...)
 		riskCount += node.DescendantRiskCount
+		evaluationCount += node.DescendantEvaluationCount
+		evaluationFailedCount += node.DescendantEvaluationFailedCount
+		evaluationFailedSpanIDs = append(evaluationFailedSpanIDs, node.DescendantEvaluationFailedSpanIDs...)
 	}
 
 	linkSpanIDs := make([]string, 0)
@@ -690,35 +712,38 @@ func newGroupedGenAIFlowCycleNode(nodes []GenAIFlowNode, indexes []int, patternL
 	}
 
 	return GenAIFlowNode{
-		NodeID:                        groupID,
-		TraceID:                       first.TraceID,
-		SpanID:                        groupID,
-		Name:                          fmt.Sprintf("%s loop x%d", genAIFlowCyclePatternName(patternNodes), iterations),
-		Kind:                          GenAISpanLoop,
-		Operation:                     "loop",
-		ModelNames:                    uniqueStrings(flattenGenAIFlowNodeModelNames(patternNodes)),
-		TokenUsage:                    tokenUsage,
-		Depth:                         first.Depth,
-		DurationMs:                    durationTotal,
-		AvgDurationMs:                 avgDuration,
-		MaxDurationMs:                 durationMax,
-		StatusCode:                    statusCode,
-		Grouped:                       true,
-		CallCount:                     iterations,
-		GroupedSpanIDs:                uniqueStrings(groupedSpanIDs),
-		ParentFlowSpanID:              first.ParentFlowSpanID,
-		DescendantSpanIDs:             uniqueStrings(groupedSpanIDs),
-		DescendantTokenUsage:          tokenUsage,
-		DescendantLLMCalls:            llmCalls,
-		DescendantLLMSpanIDs:          uniqueStrings(llmSpanIDs),
-		DescendantToolCalls:           toolCalls,
-		DescendantToolSpanIDs:         uniqueStrings(toolSpanIDs),
-		DescendantSecurityRiskCount:   len(uniqueStrings(securityRiskSpanIDs)),
-		DescendantSecurityRiskSpanIDs: uniqueStrings(securityRiskSpanIDs),
-		DescendantPrivacyRiskCount:    len(uniqueStrings(privacyRiskSpanIDs)),
-		DescendantPrivacyRiskSpanIDs:  uniqueStrings(privacyRiskSpanIDs),
-		DescendantRiskCount:           riskCount,
-		linkSpanIDs:                   uniqueStrings(linkSpanIDs),
+		NodeID:                            groupID,
+		TraceID:                           first.TraceID,
+		SpanID:                            groupID,
+		Name:                              fmt.Sprintf("%s loop x%d", genAIFlowCyclePatternName(patternNodes), iterations),
+		Kind:                              GenAISpanLoop,
+		Operation:                         "loop",
+		ModelNames:                        uniqueStrings(flattenGenAIFlowNodeModelNames(patternNodes)),
+		TokenUsage:                        tokenUsage,
+		Depth:                             first.Depth,
+		DurationMs:                        durationTotal,
+		AvgDurationMs:                     avgDuration,
+		MaxDurationMs:                     durationMax,
+		StatusCode:                        statusCode,
+		Grouped:                           true,
+		CallCount:                         iterations,
+		GroupedSpanIDs:                    uniqueStrings(groupedSpanIDs),
+		ParentFlowSpanID:                  first.ParentFlowSpanID,
+		DescendantSpanIDs:                 uniqueStrings(groupedSpanIDs),
+		DescendantTokenUsage:              tokenUsage,
+		DescendantLLMCalls:                llmCalls,
+		DescendantLLMSpanIDs:              uniqueStrings(llmSpanIDs),
+		DescendantToolCalls:               toolCalls,
+		DescendantToolSpanIDs:             uniqueStrings(toolSpanIDs),
+		DescendantSecurityRiskCount:       len(uniqueStrings(securityRiskSpanIDs)),
+		DescendantSecurityRiskSpanIDs:     uniqueStrings(securityRiskSpanIDs),
+		DescendantPrivacyRiskCount:        len(uniqueStrings(privacyRiskSpanIDs)),
+		DescendantPrivacyRiskSpanIDs:      uniqueStrings(privacyRiskSpanIDs),
+		DescendantRiskCount:               riskCount,
+		DescendantEvaluationCount:         evaluationCount,
+		DescendantEvaluationFailedCount:   evaluationFailedCount,
+		DescendantEvaluationFailedSpanIDs: uniqueStrings(evaluationFailedSpanIDs),
+		linkSpanIDs:                       uniqueStrings(linkSpanIDs),
 	}
 }
 
@@ -803,11 +828,14 @@ func buildGenAIFlowEdges(nodes []GenAIFlowNode) []GenAIFlowEdge {
 }
 
 func isGenAISpan(span Span) bool {
-	return hasAttributePrefix(span.Attributes, genAIPrefix) || hasAttributePrefix(span.Resource.Attributes, genAIPrefix)
+	return hasAttributePrefix(span.Attributes, genAIPrefix) || hasAttributePrefix(span.Resource.Attributes, genAIPrefix) || hasGenAIEvaluationSignal(span)
 }
 
 func isGenAIFlowNodeSpan(span Span) bool {
 	if isInferredGenAISpan(span) {
+		return false
+	}
+	if isGenAIEvaluationOnlySpan(span) {
 		return false
 	}
 	switch classifyGenAISpan(span) {
@@ -925,21 +953,25 @@ func getGenAIFlowNodeName(span Span, kind GenAISpanKind, operation string) strin
 
 func addGenAIFlowNodeOwnSignals(node *GenAIFlowNode, span Span) {
 	addGenAIFlowNodeRiskSignals(node, span, 0)
+	addGenAIFlowNodeEvaluationSignals(node, span, 0)
 }
 
 func addGenAIFlowNodeDescendantSignals(node *GenAIFlowNode, span Span, spanListCap int) {
 	if isGenAISpan(span) {
 		node.DescendantTokenUsage = addTokenUsage(node.DescendantTokenUsage, getGenAITokenUsage(span))
-		switch classifyGenAISpan(span) {
-		case GenAISpanLLM:
-			node.DescendantLLMCalls++
-			node.DescendantLLMSpanIDs = appendSpanIDWithCap(node.DescendantLLMSpanIDs, span.SpanID, spanListCap)
-		case GenAISpanTool:
-			node.DescendantToolCalls++
-			node.DescendantToolSpanIDs = appendSpanIDWithCap(node.DescendantToolSpanIDs, span.SpanID, spanListCap)
+		if !isGenAIEvaluationOnlySpan(span) {
+			switch classifyGenAISpan(span) {
+			case GenAISpanLLM:
+				node.DescendantLLMCalls++
+				node.DescendantLLMSpanIDs = appendSpanIDWithCap(node.DescendantLLMSpanIDs, span.SpanID, spanListCap)
+			case GenAISpanTool:
+				node.DescendantToolCalls++
+				node.DescendantToolSpanIDs = appendSpanIDWithCap(node.DescendantToolSpanIDs, span.SpanID, spanListCap)
+			}
 		}
 	}
 	addGenAIFlowNodeRiskSignals(node, span, spanListCap)
+	addGenAIFlowNodeEvaluationSignals(node, span, spanListCap)
 }
 
 func addGenAIFlowNodeRiskSignals(node *GenAIFlowNode, span Span, spanListCap int) {
@@ -971,6 +1003,120 @@ func hasGenAISecurityRiskAttributes(span Span) bool {
 
 func hasGenAIPrivacyRiskAttributes(span Span) bool {
 	return hasAttributePrefix(span.Attributes, "gen_ai.privacy.")
+}
+
+func addGenAIFlowNodeEvaluationSignals(node *GenAIFlowNode, span Span, spanListCap int) {
+	evaluationCount, failedCount := getGenAIEvaluationCounts(span)
+	if evaluationCount == 0 {
+		return
+	}
+	node.DescendantEvaluationCount += evaluationCount
+	node.DescendantEvaluationFailedCount += failedCount
+	if failedCount > 0 {
+		node.DescendantEvaluationFailedSpanIDs = appendSpanIDWithCap(node.DescendantEvaluationFailedSpanIDs, span.SpanID, spanListCap)
+	}
+}
+
+func getGenAIEvaluationCounts(span Span) (int, int) {
+	evaluationCount := 0
+	failedCount := 0
+	for _, event := range span.Events {
+		if !isGenAIEvaluationEvent(event) {
+			continue
+		}
+		evaluationCount++
+		if genAIEvaluationAttributesFailed(event.Attributes) {
+			failedCount++
+		}
+	}
+	if evaluationCount > 0 {
+		return evaluationCount, failedCount
+	}
+	if !hasGenAIEvaluationAttributes(span.Attributes) {
+		return 0, 0
+	}
+	evaluationCount = 1
+	if genAIEvaluationAttributesFailed(span.Attributes) {
+		failedCount = 1
+	}
+	return evaluationCount, failedCount
+}
+
+func isGenAIEvaluationOnlySpan(span Span) bool {
+	if !hasGenAIEvaluationSignal(span) {
+		return false
+	}
+	if strings.TrimSpace(getGenAIOperation(span)) != "" {
+		return false
+	}
+	if getFirstAttributeString(span.Attributes, genAIToolNameKeys) != "" {
+		return false
+	}
+	if getFirstAttributeString(span.Attributes, genAIAgentNameKeys) != "" {
+		return false
+	}
+	if getFirstAttributeString(span.Attributes, genAIRetrievalNameKeys) != "" {
+		return false
+	}
+	return true
+}
+
+func hasGenAIEvaluationSignal(span Span) bool {
+	if hasGenAIEvaluationAttributes(span.Attributes) {
+		return true
+	}
+	for _, event := range span.Events {
+		if isGenAIEvaluationEvent(event) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGenAIEvaluationEvent(event SpanEvent) bool {
+	return event.Name == "gen_ai.evaluation.result" || hasGenAIEvaluationAttributes(event.Attributes)
+}
+
+func hasGenAIEvaluationAttributes(attrs map[string]any) bool {
+	if hasAttributePrefix(attrs, "gen_ai.evaluation.") {
+		return true
+	}
+	if _, ok := attrs["gen_ai.evaluations"]; ok {
+		return true
+	}
+	if _, ok := attrs["assistant.evaluation.outcome"]; ok {
+		return true
+	}
+	return false
+}
+
+func genAIEvaluationAttributesFailed(attrs map[string]any) bool {
+	if raw, ok := attrs["gen_ai.evaluation.passed"]; ok {
+		switch typed := raw.(type) {
+		case bool:
+			return !typed
+		case string:
+			parsed, err := strconv.ParseBool(strings.TrimSpace(typed))
+			if err == nil {
+				return !parsed
+			}
+		}
+	}
+
+	outcome := strings.ToLower(firstNonBlankString(attrs["assistant.evaluation.outcome"]))
+	switch outcome {
+	case "failed", "fail", "error", "no_data":
+		return true
+	}
+
+	scoreLabel := strings.ToLower(firstNonBlankString(attrs["gen_ai.evaluation.score.label"]))
+	switch scoreLabel {
+	case "failed", "fail", "error":
+		return true
+	}
+
+	errorType := strings.ToLower(firstNonBlankString(attrs["error.type"]))
+	return errorType != "" && errorType != "unknown" && errorType != "none"
 }
 
 func getGenAILinkSpanIDs(span Span) []string {

--- a/observer/internal/store/genai.go
+++ b/observer/internal/store/genai.go
@@ -201,16 +201,22 @@ func buildGenAIFlowNodes(spans []Span, descendantCap int) []GenAIFlowNode {
 	}
 
 	byID := make(map[string]Span, len(spans))
-	childrenByParent := make(map[string][]Span)
 	for _, span := range spans {
 		byID[span.SpanID] = span
 	}
+
+	childrenByParent := make(map[string][]Span)
+	roots := make([]Span, 0)
 	for _, span := range spans {
-		if span.ParentSpanID != "" {
-			if _, ok := byID[span.ParentSpanID]; ok {
-				childrenByParent[span.ParentSpanID] = append(childrenByParent[span.ParentSpanID], span)
-			}
+		if span.ParentSpanID == "" {
+			roots = append(roots, span)
+			continue
 		}
+		if _, ok := byID[span.ParentSpanID]; ok {
+			childrenByParent[span.ParentSpanID] = append(childrenByParent[span.ParentSpanID], span)
+			continue
+		}
+		roots = append(roots, span)
 	}
 	for parentID := range childrenByParent {
 		sort.SliceStable(childrenByParent[parentID], func(i, j int) bool {
@@ -218,16 +224,6 @@ func buildGenAIFlowNodes(spans []Span, descendantCap int) []GenAIFlowNode {
 		})
 	}
 
-	roots := make([]Span, 0)
-	for _, span := range spans {
-		if span.ParentSpanID == "" {
-			roots = append(roots, span)
-			continue
-		}
-		if _, ok := byID[span.ParentSpanID]; !ok {
-			roots = append(roots, span)
-		}
-	}
 	sort.SliceStable(roots, func(i, j int) bool {
 		return roots[i].StartTime.Before(roots[j].StartTime)
 	})

--- a/observer/internal/store/genai.go
+++ b/observer/internal/store/genai.go
@@ -877,21 +877,34 @@ func classifyGenAISpan(span Span) GenAISpanKind {
 	modelNames := getGenAIModelNames(span)
 	tokens := getGenAITokenUsage(span)
 	spanName := strings.ToLower(span.Name)
+	isToolOperation := strings.Contains(operation, "tool") || operation == "function" || strings.Contains(spanName, " tool")
+	isWorkflowOperation := strings.Contains(operation, "workflow")
+	isRetrievalOperation := operation == "retrieval" || operation == "retriever" || strings.Contains(operation, "retrieval") || strings.Contains(operation, "retriever")
+	isLLMOperation := operation == "llm" || strings.Contains(operation, "chat") || strings.Contains(operation, "completion") || strings.Contains(operation, "embedding") || strings.Contains(operation, "generate")
+	isAgentOperation := strings.Contains(operation, "agent")
 
 	switch {
-	case toolName != "" || strings.Contains(operation, "tool") || operation == "function" || strings.Contains(spanName, " tool"):
+	case toolName != "" || isToolOperation:
 		return GenAISpanTool
-	case strings.Contains(operation, "workflow"):
+	case isWorkflowOperation:
 		return GenAISpanWorkflow
-	case agentName != "" || strings.Contains(operation, "agent"):
-		return GenAISpanAgent
-	case operation == "retrieval" || operation == "retriever" || strings.Contains(operation, "retrieval") || strings.Contains(operation, "retriever"):
+	case isRetrievalOperation:
 		return GenAISpanRetrieval
-	case len(modelNames) > 0 || tokens.Total > 0 || operation == "llm" || strings.Contains(operation, "chat") || strings.Contains(operation, "completion") || strings.Contains(operation, "embedding") || strings.Contains(operation, "generate"):
+	case isLLMOperation:
+		return GenAISpanLLM
+	case isAgentOperation || (agentName != "" && !isGenAIStepSpan(span)):
+		return GenAISpanAgent
+	case isGenAIStepSpan(span):
+		return GenAISpanGeneric
+	case len(modelNames) > 0 || tokens.Total > 0:
 		return GenAISpanLLM
 	default:
 		return GenAISpanGeneric
 	}
+}
+
+func isGenAIStepSpan(span Span) bool {
+	return firstNonBlankString(span.Attributes["gen_ai.step.name"], span.Attributes["gen_ai.step.type"]) != ""
 }
 
 func getGenAIOperation(span Span) string {

--- a/observer/internal/store/store.go
+++ b/observer/internal/store/store.go
@@ -760,7 +760,7 @@ func (s *Store) Trace(traceID string, eventLimit int) *TraceDetail {
 		DurationMs:   computeTraceDuration(spans),
 		Status:       computeTraceStatus(spans),
 		Spans:        truncated,
-		GenAI:        buildGenAITraceSummary(truncated),
+		GenAI:        buildGenAITraceSummary(spans),
 	}
 }
 

--- a/observer/internal/store/store.go
+++ b/observer/internal/store/store.go
@@ -215,13 +215,14 @@ type SpanPreview struct {
 
 // TraceDetail represents the full details of a trace.
 type TraceDetail struct {
-	TraceID      string  `json:"traceId"`
-	RootSpanName string  `json:"rootSpanName"`
-	ServiceName  string  `json:"serviceName,omitempty"`
-	SpanCount    int     `json:"spanCount"`
-	DurationMs   float64 `json:"durationMs"`
-	Status       string  `json:"status"`
-	Spans        []Span  `json:"spans"`
+	TraceID      string             `json:"traceId"`
+	RootSpanName string             `json:"rootSpanName"`
+	ServiceName  string             `json:"serviceName,omitempty"`
+	SpanCount    int                `json:"spanCount"`
+	DurationMs   float64            `json:"durationMs"`
+	Status       string             `json:"status"`
+	Spans        []Span             `json:"spans"`
+	GenAI        *GenAITraceSummary `json:"genAI,omitempty"`
 }
 
 // MetricGroup represents a group of metric data points with the same name.
@@ -757,6 +758,7 @@ func (s *Store) Trace(traceID string, eventLimit int) *TraceDetail {
 		DurationMs:   computeTraceDuration(spans),
 		Status:       computeTraceStatus(spans),
 		Spans:        truncated,
+		GenAI:        buildGenAITraceSummary(truncated),
 	}
 }
 

--- a/observer/internal/store/store.go
+++ b/observer/internal/store/store.go
@@ -170,6 +170,7 @@ type TraceSummary struct {
 	SpanCount    int           `json:"spanCount"`
 	DurationMs   float64       `json:"durationMs"`
 	Status       string        `json:"status"`
+	IsGenAI      bool          `json:"isGenAI,omitempty"`
 	Spans        []SpanPreview `json:"spans,omitempty"`
 }
 
@@ -705,6 +706,7 @@ func (s *Store) QueryTraceSummariesFiltered(filter TraceSummaryFilter) []TraceSu
 			SpanCount:    len(spans),
 			DurationMs:   dur,
 			Status:       computeTraceStatus(spans),
+			IsGenAI:      traceHasGenAISignal(spans),
 			Spans:        makeSpanPreviews(spans, filter.SpanPreviewCap),
 		}
 		if !matchesTraceSummaryFilter(summary, filter) {
@@ -1249,6 +1251,7 @@ func (s *Store) QueryTracesFiltered(serviceName, spanName, status, traceIDPrefix
 			SpanCount:    len(spans),
 			DurationMs:   dur,
 			Status:       st,
+			IsGenAI:      traceHasGenAISignal(spans),
 			Spans:        previews,
 		})
 	}
@@ -1266,6 +1269,15 @@ func (s *Store) QueryTracesFiltered(serviceName, spanName, status, traceIDPrefix
 		results = results[:limit]
 	}
 	return results
+}
+
+func traceHasGenAISignal(spans []Span) bool {
+	for _, span := range spans {
+		if isGenAISpan(span) {
+			return true
+		}
+	}
+	return false
 }
 
 // QueryMetricsFiltered is used by MCP tools that need filtering.

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -1042,6 +1042,88 @@ func TestTrace_IncludesRetrievalFlowNode(t *testing.T) {
 	}
 }
 
+func TestTrace_GenAILangGraphStepsRollUpAndChatStaysLLM(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-langgraph", "workflow", "invoke_workflow_assistant_v3_turn", now, 1000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "assistant_v3_turn"
+	workflow.Attributes["gen_ai.request.model"] = "gpt-5.5"
+
+	agent := newTestSpan("trace-genai-langgraph", "agent", "invoke_agent LangGraph", now.Add(10*time.Millisecond), 900)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "LangGraph"
+
+	middleware := newTestSpan("trace-genai-langgraph", "middleware", "step SkillsMiddleware.before_agent", now.Add(20*time.Millisecond), 20)
+	middleware.ParentSpanID = "agent"
+	middleware.Attributes["gen_ai.agent.name"] = "LangGraph"
+	middleware.Attributes["gen_ai.step.name"] = "SkillsMiddleware.before_agent"
+	middleware.Attributes["gen_ai.step.type"] = "chain"
+
+	modelStep := newTestSpan("trace-genai-langgraph", "model-step", "step model", now.Add(40*time.Millisecond), 600)
+	modelStep.ParentSpanID = "agent"
+	modelStep.Attributes["gen_ai.agent.name"] = "LangGraph"
+	modelStep.Attributes["gen_ai.step.name"] = "model"
+	modelStep.Attributes["gen_ai.step.type"] = "chain"
+	modelStep.Attributes["gen_ai.step.status"] = "failed"
+	modelStep.Attributes["gen_ai.request.model"] = "gpt-5.5"
+	modelStep.Attributes["gen_ai.usage.input_tokens"] = 100
+	modelStep.Attributes["gen_ai.usage.output_tokens"] = 5
+
+	llm := newTestSpan("trace-genai-langgraph", "llm", "chat unknown_model", now.Add(50*time.Millisecond), 500)
+	llm.ParentSpanID = "model-step"
+	llm.Status = SpanStatus{Code: "ERROR", Message: "authentication failed"}
+	llm.Attributes["gen_ai.agent.name"] = "LangGraph"
+	llm.Attributes["gen_ai.operation.name"] = "chat"
+	llm.Attributes["gen_ai.request.model"] = "unknown_model"
+	llm.Attributes["gen_ai.provider.name"] = "azure"
+	llm.Attributes["error.type"] = "AuthenticationError"
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, agent, middleware, modelStep, llm})
+
+	result := s.Trace("trace-genai-langgraph", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+	if result.GenAI.LLMCalls != 1 {
+		t.Fatalf("expected chat span to count as an LLM call, got %d", result.GenAI.LLMCalls)
+	}
+
+	nodeNames := make([]string, 0, len(result.GenAI.FlowNodes))
+	nodesByID := make(map[string]GenAIFlowNode)
+	for _, node := range result.GenAI.FlowNodes {
+		nodeNames = append(nodeNames, node.Name)
+		nodesByID[node.SpanID] = node
+	}
+	if strings.Join(nodeNames, "|") != "assistant_v3_turn|LangGraph|chat unknown_model" {
+		t.Fatalf("unexpected flow nodes: %v", nodeNames)
+	}
+	if _, ok := nodesByID["middleware"]; ok {
+		t.Fatalf("expected middleware step to roll up instead of becoming a flow node: %#v", nodesByID["middleware"])
+	}
+	if _, ok := nodesByID["model-step"]; ok {
+		t.Fatalf("expected model step wrapper to roll up instead of becoming a flow node: %#v", nodesByID["model-step"])
+	}
+
+	llmNode := nodesByID["llm"]
+	if llmNode.Kind != GenAISpanLLM {
+		t.Fatalf("expected chat span to be an LLM node, got %q", llmNode.Kind)
+	}
+	if llmNode.ParentFlowSpanID != "agent" {
+		t.Fatalf("expected chat span to attach to the LangGraph agent through skipped step spans, got %q", llmNode.ParentFlowSpanID)
+	}
+
+	edges := make([]string, 0, len(result.GenAI.FlowEdges))
+	for _, edge := range result.GenAI.FlowEdges {
+		edges = append(edges, edge.Source+"->"+edge.Target)
+	}
+	if strings.Join(edges, "|") != "workflow->agent|agent->llm" {
+		t.Fatalf("unexpected flow edges: %v", edges)
+	}
+}
+
 func TestTrace_GenAIEvaluationOnlySpanRollsUpWithoutFlowNode(t *testing.T) {
 	s := New()
 	now := time.Now()

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -790,6 +790,654 @@ func TestTrace_DefaultEventLimit(t *testing.T) {
 	// Default eventLimit is 12
 }
 
+func TestTrace_NonGenAITraceOmitsGenAIProjection(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	span := newTestSpan("trace-1", "span-1", "GET /health", now, 10)
+	s.AddSpansForConnection("conn-1", []Span{span})
+
+	result := s.Trace("trace-1", 0)
+	if result == nil {
+		t.Fatal("expected trace to be found")
+	}
+	if result.GenAI != nil {
+		t.Fatalf("expected no GenAI projection for non-GenAI trace, got %#v", result.GenAI)
+	}
+}
+
+func TestTrace_IncludesBackendGenAIProjection(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	httpSpan := newTestSpan("trace-genai", "http", "POST /assistant", now.Add(10*time.Millisecond), 2900)
+	httpSpan.ParentSpanID = "workflow"
+
+	agent := newTestSpan("trace-genai", "agent", "invoke_agent", now.Add(20*time.Millisecond), 2500)
+	agent.ParentSpanID = "http"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "Triage Agent"
+
+	llm := newTestSpan("trace-genai", "llm", "chat", now.Add(30*time.Millisecond), 1200)
+	llm.ParentSpanID = "agent"
+	llm.Attributes["gen_ai.operation.name"] = "chat"
+	llm.Attributes["gen_ai.request.model"] = "gpt-5.5"
+	llm.Attributes["gen_ai.usage.input_tokens"] = "120"
+	llm.Attributes["gen_ai.usage.output_tokens"] = 30
+	llm.Attributes["ai.usage.input_tokens"] = 999
+	llm.Attributes["llm.token_count.completion"] = 888
+	llm.Attributes["gen_ai.security.prompt_injection.detected"] = true
+
+	tool := newTestSpan("trace-genai", "tool", "execute_tool", now.Add(40*time.Millisecond), 200)
+	tool.ParentSpanID = "agent"
+	tool.Attributes["gen_ai.operation.name"] = "execute_tool"
+	tool.Attributes["gen_ai.tool.name"] = "lookup_context"
+	tool.Attributes["gen_ai.privacy.pii.detected"] = true
+
+	summarizer := newTestSpan("trace-genai", "summarizer", "invoke_agent", now.Add(60*time.Millisecond), 700)
+	summarizer.ParentSpanID = "workflow"
+	summarizer.Links = []SpanLink{{TraceID: "trace-genai", SpanID: "tool"}}
+	summarizer.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	summarizer.Attributes["gen_ai.agent.name"] = "Summarizer Agent"
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, httpSpan, agent, llm, tool, summarizer})
+
+	result := s.Trace("trace-genai", 0)
+	if result == nil {
+		t.Fatal("expected trace to be found")
+	}
+	if result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	genAI := result.GenAI
+	if !genAI.IsGenAI {
+		t.Fatal("expected GenAI projection to be marked GenAI")
+	}
+	if genAI.Tokens != (GenAITokenUsage{Input: 120, Output: 30, Total: 150}) {
+		t.Fatalf("unexpected token rollup: %#v", genAI.Tokens)
+	}
+	if genAI.LLMCalls != 1 || genAI.ToolCalls != 1 {
+		t.Fatalf("expected 1 llm and 1 tool call, got llm=%d tool=%d", genAI.LLMCalls, genAI.ToolCalls)
+	}
+	if got := strings.Join(genAI.ModelNames, ","); got != "gpt-5.5" {
+		t.Fatalf("unexpected model names: %s", got)
+	}
+
+	nodeNames := make([]string, 0, len(genAI.FlowNodes))
+	nodesByID := make(map[string]GenAIFlowNode)
+	for _, node := range genAI.FlowNodes {
+		nodeNames = append(nodeNames, node.Name)
+		nodesByID[node.SpanID] = node
+	}
+	if strings.Join(nodeNames, "|") != "Budget Guru|Triage Agent|chat gpt-5.5|lookup_context|Summarizer Agent" {
+		t.Fatalf("unexpected flow nodes: %v", nodeNames)
+	}
+
+	workflowNode := nodesByID["workflow"]
+	if strings.Join(workflowNode.DescendantSpanIDs, ",") != "http,agent,llm,tool,summarizer" {
+		t.Fatalf("unexpected workflow descendants: %v", workflowNode.DescendantSpanIDs)
+	}
+	if workflowNode.DescendantLLMCalls != 1 || workflowNode.DescendantToolCalls != 1 {
+		t.Fatalf("expected workflow to roll up child LLM/tool spans, got llm=%d tool=%d", workflowNode.DescendantLLMCalls, workflowNode.DescendantToolCalls)
+	}
+	if strings.Join(workflowNode.DescendantLLMSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected workflow llm span ids: %v", workflowNode.DescendantLLMSpanIDs)
+	}
+	if strings.Join(workflowNode.DescendantToolSpanIDs, ",") != "tool" {
+		t.Fatalf("unexpected workflow tool span ids: %v", workflowNode.DescendantToolSpanIDs)
+	}
+	if strings.Join(workflowNode.DescendantSecurityRiskSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected workflow security risk span ids: %v", workflowNode.DescendantSecurityRiskSpanIDs)
+	}
+	if strings.Join(workflowNode.DescendantPrivacyRiskSpanIDs, ",") != "tool" {
+		t.Fatalf("unexpected workflow privacy risk span ids: %v", workflowNode.DescendantPrivacyRiskSpanIDs)
+	}
+
+	agentNode := nodesByID["agent"]
+	if agentNode.ParentFlowSpanID != "workflow" {
+		t.Fatalf("expected agent to attach to workflow through non-GenAI http span, got %q", agentNode.ParentFlowSpanID)
+	}
+	if strings.Join(agentNode.DescendantSpanIDs, ",") != "llm,tool" {
+		t.Fatalf("unexpected agent descendants: %v", agentNode.DescendantSpanIDs)
+	}
+	if agentNode.DescendantLLMCalls != 1 || agentNode.DescendantToolCalls != 1 {
+		t.Fatalf("unexpected descendant call rollups: llm=%d tool=%d", agentNode.DescendantLLMCalls, agentNode.DescendantToolCalls)
+	}
+	if strings.Join(agentNode.DescendantLLMSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected llm span ids: %v", agentNode.DescendantLLMSpanIDs)
+	}
+	if strings.Join(agentNode.DescendantToolSpanIDs, ",") != "tool" {
+		t.Fatalf("unexpected tool span ids: %v", agentNode.DescendantToolSpanIDs)
+	}
+	if strings.Join(agentNode.DescendantSecurityRiskSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected security risk span ids: %v", agentNode.DescendantSecurityRiskSpanIDs)
+	}
+	if strings.Join(agentNode.DescendantPrivacyRiskSpanIDs, ",") != "tool" {
+		t.Fatalf("unexpected privacy risk span ids: %v", agentNode.DescendantPrivacyRiskSpanIDs)
+	}
+
+	llmNode := nodesByID["llm"]
+	if llmNode.ParentFlowSpanID != "agent" {
+		t.Fatalf("expected llm to attach to agent, got %q", llmNode.ParentFlowSpanID)
+	}
+	if llmNode.TokenUsage != (GenAITokenUsage{Input: 120, Output: 30, Total: 150}) {
+		t.Fatalf("unexpected llm token usage: %#v", llmNode.TokenUsage)
+	}
+	if strings.Join(llmNode.DescendantSecurityRiskSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected llm security risk span ids: %v", llmNode.DescendantSecurityRiskSpanIDs)
+	}
+
+	toolNode := nodesByID["tool"]
+	if toolNode.ParentFlowSpanID != "agent" {
+		t.Fatalf("expected tool to attach to agent, got %q", toolNode.ParentFlowSpanID)
+	}
+	if strings.Join(toolNode.DescendantPrivacyRiskSpanIDs, ",") != "tool" {
+		t.Fatalf("unexpected tool privacy risk span ids: %v", toolNode.DescendantPrivacyRiskSpanIDs)
+	}
+
+	edges := make([]string, 0, len(genAI.FlowEdges))
+	for _, edge := range genAI.FlowEdges {
+		edges = append(edges, edge.Source+"->"+edge.Target)
+	}
+	if strings.Join(edges, "|") != "workflow->agent|agent->llm|agent->tool|tool->summarizer" {
+		t.Fatalf("unexpected flow edges: %v", edges)
+	}
+}
+
+func TestTrace_IncludesRetrievalFlowNode(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-retrieval", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-retrieval", "agent", "invoke_agent", now.Add(10*time.Millisecond), 2500)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "Research Agent"
+
+	retrieval := newTestSpan("trace-genai-retrieval", "retrieval", "retrieval vector_store", now.Add(20*time.Millisecond), 300)
+	retrieval.ParentSpanID = "agent"
+	retrieval.Attributes["gen_ai.operation.name"] = "retrieval"
+	retrieval.Attributes["gen_ai.retrieval.source"] = "vector_store"
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, agent, retrieval})
+
+	result := s.Trace("trace-genai-retrieval", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	var retrievalNode GenAIFlowNode
+	for _, node := range result.GenAI.FlowNodes {
+		if node.SpanID == "retrieval" {
+			retrievalNode = node
+			break
+		}
+	}
+	if retrievalNode.SpanID == "" {
+		t.Fatalf("expected retrieval flow node, got %#v", result.GenAI.FlowNodes)
+	}
+	if retrievalNode.Kind != GenAISpanRetrieval {
+		t.Fatalf("expected retrieval kind, got %q", retrievalNode.Kind)
+	}
+	if retrievalNode.Name != "retrieval vector_store" {
+		t.Fatalf("unexpected retrieval node name: %q", retrievalNode.Name)
+	}
+
+	edges := make([]string, 0, len(result.GenAI.FlowEdges))
+	for _, edge := range result.GenAI.FlowEdges {
+		edges = append(edges, edge.Source+"->"+edge.Target)
+	}
+	if strings.Join(edges, "|") != "workflow->agent|agent->retrieval" {
+		t.Fatalf("unexpected retrieval flow edges: %v", edges)
+	}
+}
+
+func TestTrace_GenAIProjectionCapsSpanListsButNotCounts(t *testing.T) {
+	t.Setenv("MAX_FLOW_NODE_SPAN_LIST_SIZE", "1")
+
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-cap", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-cap", "agent", "invoke_agent", now.Add(10*time.Millisecond), 2500)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "Triage Agent"
+
+	spans := []Span{workflow, agent}
+	for i := 0; i < 3; i++ {
+		llm := newTestSpan("trace-genai-cap", fmt.Sprintf("llm-%d", i), "chat", now.Add(time.Duration(20+i)*time.Millisecond), 100)
+		llm.ParentSpanID = "agent"
+		llm.Attributes["gen_ai.operation.name"] = "chat"
+		llm.Attributes["gen_ai.request.model"] = "gpt-5.5"
+		llm.Attributes["gen_ai.usage.input_tokens"] = 10
+		llm.Attributes["gen_ai.usage.output_tokens"] = 1
+		llm.Attributes["gen_ai.security.prompt_injection.detected"] = true
+		spans = append(spans, llm)
+	}
+
+	s.AddSpansForConnection("conn-1", spans)
+
+	result := s.Trace("trace-genai-cap", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	var agentNode GenAIFlowNode
+	for _, node := range result.GenAI.FlowNodes {
+		if node.SpanID == "agent" {
+			agentNode = node
+			break
+		}
+	}
+	if agentNode.SpanID == "" {
+		t.Fatal("expected agent node")
+	}
+	if got := len(agentNode.DescendantSpanIDs); got != 1 {
+		t.Fatalf("expected capped descendant span ID list, got %d ids: %v", got, agentNode.DescendantSpanIDs)
+	}
+	if got := len(agentNode.DescendantLLMSpanIDs); got != 1 {
+		t.Fatalf("expected capped LLM span ID list, got %d ids: %v", got, agentNode.DescendantLLMSpanIDs)
+	}
+	if got := len(agentNode.DescendantSecurityRiskSpanIDs); got != 1 {
+		t.Fatalf("expected capped risk span ID list, got %d ids: %v", got, agentNode.DescendantSecurityRiskSpanIDs)
+	}
+	if agentNode.DescendantLLMCalls != 3 {
+		t.Fatalf("expected uncapped LLM call count, got %d", agentNode.DescendantLLMCalls)
+	}
+	if agentNode.DescendantSecurityRiskCount != 3 || agentNode.DescendantRiskCount != 3 {
+		t.Fatalf("expected uncapped risk counts, got security=%d total=%d", agentNode.DescendantSecurityRiskCount, agentNode.DescendantRiskCount)
+	}
+	if agentNode.DescendantTokenUsage != (GenAITokenUsage{Input: 30, Output: 3, Total: 33}) {
+		t.Fatalf("expected uncapped token usage, got %#v", agentNode.DescendantTokenUsage)
+	}
+}
+
+func TestTrace_GenAITokenUsagePreservesExplicitZeroValues(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-zero", "workflow", "invoke_workflow", now, 1000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	llm := newTestSpan("trace-genai-zero", "llm", "chat", now.Add(10*time.Millisecond), 500)
+	llm.ParentSpanID = "workflow"
+	llm.Attributes["gen_ai.operation.name"] = "chat"
+	llm.Attributes["gen_ai.request.model"] = "gpt-5.5"
+	llm.Attributes["gen_ai.usage.input_tokens"] = 12
+	llm.Attributes["gen_ai.usage.output_tokens"] = 0
+	llm.Attributes["llm.token_count.completion"] = 888
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, llm})
+
+	result := s.Trace("trace-genai-zero", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+	if result.GenAI.Tokens != (GenAITokenUsage{Input: 12, Output: 0, Total: 12}) {
+		t.Fatalf("unexpected token usage: %#v", result.GenAI.Tokens)
+	}
+
+	foundLLMNode := false
+	for _, node := range result.GenAI.FlowNodes {
+		if node.SpanID == "llm" && node.TokenUsage != (GenAITokenUsage{Input: 12, Output: 0, Total: 12}) {
+			t.Fatalf("unexpected llm token usage: %#v", node.TokenUsage)
+		}
+		if node.SpanID == "llm" {
+			foundLLMNode = true
+		}
+	}
+	if !foundLLMNode {
+		t.Fatal("expected llm flow node")
+	}
+}
+
+func TestTrace_GroupsRepeatedLeafLLMNodes(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-loop", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-loop", "agent", "invoke_agent", now.Add(10*time.Millisecond), 2500)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "LangGraph"
+
+	spans := []Span{workflow, agent}
+	for i := 0; i < genAIFlowGroupThreshold+1; i++ {
+		spanID := fmt.Sprintf("llm-%d", i)
+		llm := newTestSpan("trace-genai-loop", spanID, "chat", now.Add(time.Duration(20+i)*time.Millisecond), float64(100+i))
+		llm.ParentSpanID = "agent"
+		llm.Attributes["gen_ai.operation.name"] = "chat"
+		llm.Attributes["gen_ai.request.model"] = "gpt-5.5"
+		llm.Attributes["gen_ai.usage.input_tokens"] = 10
+		llm.Attributes["gen_ai.usage.output_tokens"] = 1
+		if i == 0 {
+			llm.Attributes["gen_ai.security.prompt_injection.detected"] = true
+		}
+		spans = append(spans, llm)
+	}
+
+	s.AddSpansForConnection("conn-1", spans)
+
+	result := s.Trace("trace-genai-loop", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	genAI := result.GenAI
+	if genAI.LLMCalls != genAIFlowGroupThreshold+1 {
+		t.Fatalf("unexpected llm calls: %d", genAI.LLMCalls)
+	}
+	if len(genAI.FlowNodes) != 3 {
+		t.Fatalf("expected workflow, agent, grouped llm nodes; got %d nodes: %#v", len(genAI.FlowNodes), genAI.FlowNodes)
+	}
+
+	groupNode := GenAIFlowNode{}
+	for _, node := range genAI.FlowNodes {
+		if node.Kind == GenAISpanLLM {
+			groupNode = node
+			break
+		}
+	}
+	if !groupNode.Grouped {
+		t.Fatalf("expected llm node to be grouped: %#v", groupNode)
+	}
+	if groupNode.CallCount != genAIFlowGroupThreshold+1 {
+		t.Fatalf("unexpected grouped call count: %d", groupNode.CallCount)
+	}
+	if groupNode.Name != "chat gpt-5.5 x9" {
+		t.Fatalf("unexpected grouped node name: %q", groupNode.Name)
+	}
+	if strings.Join(groupNode.GroupedSpanIDs, ",") != "llm-0,llm-1,llm-2,llm-3,llm-4,llm-5,llm-6,llm-7,llm-8" {
+		t.Fatalf("unexpected grouped span ids: %v", groupNode.GroupedSpanIDs)
+	}
+	if groupNode.TokenUsage != (GenAITokenUsage{Input: 90, Output: 9, Total: 99}) {
+		t.Fatalf("unexpected grouped token usage: %#v", groupNode.TokenUsage)
+	}
+	if groupNode.DurationMs != 108 || groupNode.MaxDurationMs != 108 || groupNode.AvgDurationMs != 104 {
+		t.Fatalf("unexpected grouped durations: duration=%v max=%v avg=%v", groupNode.DurationMs, groupNode.MaxDurationMs, groupNode.AvgDurationMs)
+	}
+	if strings.Join(groupNode.DescendantSecurityRiskSpanIDs, ",") != "llm-0" {
+		t.Fatalf("unexpected grouped risk span ids: %v", groupNode.DescendantSecurityRiskSpanIDs)
+	}
+
+	edges := make([]string, 0, len(genAI.FlowEdges))
+	for _, edge := range genAI.FlowEdges {
+		edges = append(edges, edge.Source+"->"+edge.Target)
+	}
+	if len(edges) != 2 || edges[0] != "workflow->agent" || !strings.HasPrefix(edges[1], "agent->group:agent:llm:chat:chat_gpt-5.5") {
+		t.Fatalf("unexpected grouped flow edges: %v", edges)
+	}
+}
+
+func TestTrace_GroupsRepeatedLeafNodesUsesUniqueIDsForDifferentModels(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-model-groups", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-model-groups", "agent", "invoke_agent", now.Add(10*time.Millisecond), 2500)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "LangGraph"
+
+	spans := []Span{workflow, agent}
+	models := []string{"gpt-5.5", "claude-4"}
+	for modelIndex, model := range models {
+		for i := 0; i < genAIFlowGroupThreshold+1; i++ {
+			spanID := fmt.Sprintf("llm-%d-%d", modelIndex, i)
+			llm := newTestSpan("trace-genai-model-groups", spanID, "chat", now.Add(time.Duration(20+modelIndex*20+i)*time.Millisecond), float64(100+i))
+			llm.ParentSpanID = "agent"
+			llm.Attributes["gen_ai.request.model"] = model
+			spans = append(spans, llm)
+		}
+	}
+
+	s.AddSpansForConnection("conn-1", spans)
+
+	result := s.Trace("trace-genai-model-groups", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	groupIDs := make(map[string]struct{})
+	groupCount := 0
+	for _, node := range result.GenAI.FlowNodes {
+		if node.Kind != GenAISpanLLM || !node.Grouped {
+			continue
+		}
+		groupCount++
+		if _, exists := groupIDs[node.SpanID]; exists {
+			t.Fatalf("duplicate grouped node id %q in %#v", node.SpanID, result.GenAI.FlowNodes)
+		}
+		groupIDs[node.SpanID] = struct{}{}
+	}
+	if groupCount != len(models) {
+		t.Fatalf("expected one grouped LLM node per model, got %d nodes: %#v", groupCount, result.GenAI.FlowNodes)
+	}
+}
+
+func TestTrace_GroupsRepeatedLeafNodesPreservesSpanLinkEdges(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-group-links", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-group-links", "agent", "invoke_agent", now.Add(10*time.Millisecond), 2500)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "LangGraph"
+
+	tool := newTestSpan("trace-genai-group-links", "tool", "execute_tool", now.Add(15*time.Millisecond), 100)
+	tool.ParentSpanID = "agent"
+	tool.Attributes["gen_ai.operation.name"] = "execute_tool"
+	tool.Attributes["gen_ai.tool.name"] = "lookup_context"
+
+	spans := []Span{workflow, agent, tool}
+	for i := 0; i < genAIFlowGroupThreshold+1; i++ {
+		spanID := fmt.Sprintf("llm-%d", i)
+		llm := newTestSpan("trace-genai-group-links", spanID, "chat", now.Add(time.Duration(20+i)*time.Millisecond), float64(100+i))
+		llm.ParentSpanID = "agent"
+		llm.Links = []SpanLink{{TraceID: "trace-genai-group-links", SpanID: "tool"}}
+		llm.Attributes["gen_ai.operation.name"] = "chat"
+		llm.Attributes["gen_ai.request.model"] = "gpt-5.5"
+		llm.Attributes["gen_ai.usage.input_tokens"] = 10
+		llm.Attributes["gen_ai.usage.output_tokens"] = 1
+		spans = append(spans, llm)
+	}
+
+	s.AddSpansForConnection("conn-1", spans)
+
+	result := s.Trace("trace-genai-group-links", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	edges := make([]string, 0, len(result.GenAI.FlowEdges))
+	for _, edge := range result.GenAI.FlowEdges {
+		edges = append(edges, edge.Source+"->"+edge.Target)
+	}
+	if len(edges) != 3 || edges[0] != "workflow->agent" || edges[1] != "agent->tool" || !strings.HasPrefix(edges[2], "tool->group:agent:llm:chat:chat_gpt-5.5") {
+		t.Fatalf("unexpected grouped flow edges: %v", edges)
+	}
+}
+
+func TestTrace_GroupsRepeatedLLMToolCycles(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-cycle", "workflow", "invoke_workflow", now, 8000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-cycle", "agent", "invoke_agent", now.Add(10*time.Millisecond), 7000)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "LangGraph"
+
+	llm1 := newTestSpan("trace-genai-cycle", "llm-1", "chat", now.Add(20*time.Millisecond), 1000)
+	llm1.ParentSpanID = "agent"
+	llm1.Attributes["gen_ai.operation.name"] = "chat"
+	llm1.Attributes["gen_ai.request.model"] = "gpt-5.5"
+	llm1.Attributes["gen_ai.usage.input_tokens"] = 10
+	llm1.Attributes["gen_ai.usage.output_tokens"] = 2
+
+	tool1 := newTestSpan("trace-genai-cycle", "tool-1", "execute_tool", now.Add(30*time.Millisecond), 200)
+	tool1.ParentSpanID = "agent"
+	tool1.Links = []SpanLink{{TraceID: "trace-genai-cycle", SpanID: "llm-1"}}
+	tool1.Attributes["gen_ai.operation.name"] = "execute_tool"
+	tool1.Attributes["gen_ai.tool.name"] = "lookup_context"
+	tool1.Attributes["gen_ai.privacy.pii.detected"] = true
+
+	llm2 := newTestSpan("trace-genai-cycle", "llm-2", "chat", now.Add(40*time.Millisecond), 900)
+	llm2.ParentSpanID = "agent"
+	llm2.Links = []SpanLink{{TraceID: "trace-genai-cycle", SpanID: "tool-1"}}
+	llm2.Attributes["gen_ai.operation.name"] = "chat"
+	llm2.Attributes["gen_ai.request.model"] = "gpt-5.5"
+	llm2.Attributes["gen_ai.usage.input_tokens"] = 12
+	llm2.Attributes["gen_ai.usage.output_tokens"] = 3
+
+	tool2 := newTestSpan("trace-genai-cycle", "tool-2", "execute_tool", now.Add(50*time.Millisecond), 300)
+	tool2.ParentSpanID = "agent"
+	tool2.Links = []SpanLink{{TraceID: "trace-genai-cycle", SpanID: "llm-2"}}
+	tool2.Attributes["gen_ai.operation.name"] = "execute_tool"
+	tool2.Attributes["gen_ai.tool.name"] = "lookup_context"
+
+	summarizer := newTestSpan("trace-genai-cycle", "summarizer", "invoke_agent", now.Add(60*time.Millisecond), 600)
+	summarizer.ParentSpanID = "workflow"
+	summarizer.Links = []SpanLink{{TraceID: "trace-genai-cycle", SpanID: "tool-2"}}
+	summarizer.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	summarizer.Attributes["gen_ai.agent.name"] = "Summarizer Agent"
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, agent, llm1, tool1, llm2, tool2, summarizer})
+
+	result := s.Trace("trace-genai-cycle", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	genAI := result.GenAI
+	if genAI.LLMCalls != 2 || genAI.ToolCalls != 2 {
+		t.Fatalf("unexpected call rollup: llm=%d tool=%d", genAI.LLMCalls, genAI.ToolCalls)
+	}
+
+	nodesByKind := make(map[GenAISpanKind]GenAIFlowNode)
+	for _, node := range genAI.FlowNodes {
+		nodesByKind[node.Kind] = node
+	}
+	loopNode := nodesByKind[GenAISpanLoop]
+	if !loopNode.Grouped {
+		t.Fatalf("expected loop node to be grouped: %#v", loopNode)
+	}
+	if loopNode.CallCount != 2 {
+		t.Fatalf("expected two loop iterations, got %d", loopNode.CallCount)
+	}
+	if loopNode.Name != "chat gpt-5.5 + lookup_context loop x2" {
+		t.Fatalf("unexpected loop node name: %q", loopNode.Name)
+	}
+	if strings.Join(loopNode.GroupedSpanIDs, ",") != "llm-1,tool-1,llm-2,tool-2" {
+		t.Fatalf("unexpected loop span ids: %v", loopNode.GroupedSpanIDs)
+	}
+	if loopNode.DescendantLLMCalls != 2 || loopNode.DescendantToolCalls != 2 {
+		t.Fatalf("unexpected loop descendant calls: llm=%d tool=%d", loopNode.DescendantLLMCalls, loopNode.DescendantToolCalls)
+	}
+	if strings.Join(loopNode.DescendantLLMSpanIDs, ",") != "llm-1,llm-2" {
+		t.Fatalf("unexpected loop llm span ids: %v", loopNode.DescendantLLMSpanIDs)
+	}
+	if strings.Join(loopNode.DescendantToolSpanIDs, ",") != "tool-1,tool-2" {
+		t.Fatalf("unexpected loop tool span ids: %v", loopNode.DescendantToolSpanIDs)
+	}
+	if loopNode.TokenUsage != (GenAITokenUsage{Input: 22, Output: 5, Total: 27}) {
+		t.Fatalf("unexpected loop token rollup: %#v", loopNode.TokenUsage)
+	}
+	if strings.Join(loopNode.DescendantPrivacyRiskSpanIDs, ",") != "tool-1" {
+		t.Fatalf("unexpected loop privacy risk span ids: %v", loopNode.DescendantPrivacyRiskSpanIDs)
+	}
+
+	edges := make([]string, 0, len(genAI.FlowEdges))
+	for _, edge := range genAI.FlowEdges {
+		edges = append(edges, edge.Source+"->"+edge.Target)
+	}
+	if len(edges) != 3 || edges[0] != "workflow->agent" || !strings.HasPrefix(edges[1], "agent->group:agent:loop:") || !strings.HasPrefix(edges[2], "group:agent:loop:") || !strings.HasSuffix(edges[2], "->summarizer") {
+		t.Fatalf("unexpected loop flow edges: %v", edges)
+	}
+}
+
+func TestTrace_GroupedLoopPreservesExternalLinksFromCollapsedMembers(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-loop-link", "workflow", "invoke_workflow", now, 8000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-loop-link", "agent", "invoke_agent", now.Add(10*time.Millisecond), 7000)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "LangGraph"
+
+	primer := newTestSpan("trace-genai-loop-link", "primer", "execute_tool", now.Add(15*time.Millisecond), 100)
+	primer.ParentSpanID = "agent"
+	primer.Attributes["gen_ai.operation.name"] = "execute_tool"
+	primer.Attributes["gen_ai.tool.name"] = "load_context"
+
+	llm1 := newTestSpan("trace-genai-loop-link", "llm-1", "chat", now.Add(20*time.Millisecond), 1000)
+	llm1.ParentSpanID = "agent"
+	llm1.Attributes["gen_ai.operation.name"] = "chat"
+	llm1.Attributes["gen_ai.request.model"] = "gpt-5.5"
+
+	tool1 := newTestSpan("trace-genai-loop-link", "tool-1", "execute_tool", now.Add(30*time.Millisecond), 200)
+	tool1.ParentSpanID = "agent"
+	tool1.Links = []SpanLink{{TraceID: "trace-genai-loop-link", SpanID: "primer"}}
+	tool1.Attributes["gen_ai.operation.name"] = "execute_tool"
+	tool1.Attributes["gen_ai.tool.name"] = "lookup_context"
+
+	llm2 := newTestSpan("trace-genai-loop-link", "llm-2", "chat", now.Add(40*time.Millisecond), 900)
+	llm2.ParentSpanID = "agent"
+	llm2.Attributes["gen_ai.operation.name"] = "chat"
+	llm2.Attributes["gen_ai.request.model"] = "gpt-5.5"
+
+	tool2 := newTestSpan("trace-genai-loop-link", "tool-2", "execute_tool", now.Add(50*time.Millisecond), 300)
+	tool2.ParentSpanID = "agent"
+	tool2.Links = []SpanLink{{TraceID: "trace-genai-loop-link", SpanID: "primer"}}
+	tool2.Attributes["gen_ai.operation.name"] = "execute_tool"
+	tool2.Attributes["gen_ai.tool.name"] = "lookup_context"
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, agent, primer, llm1, tool1, llm2, tool2})
+
+	result := s.Trace("trace-genai-loop-link", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+
+	edges := make([]string, 0, len(result.GenAI.FlowEdges))
+	for _, edge := range result.GenAI.FlowEdges {
+		edges = append(edges, edge.Source+"->"+edge.Target)
+	}
+	if len(edges) != 3 || edges[0] != "workflow->agent" || edges[1] != "agent->primer" || !strings.HasPrefix(edges[2], "primer->group:agent:loop:") {
+		t.Fatalf("unexpected loop flow edges: %v", edges)
+	}
+}
+
 // ============================================================================
 // Compute Status Tests
 // ============================================================================

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -831,12 +831,33 @@ func TestTrace_IncludesBackendGenAIProjection(t *testing.T) {
 	llm.Attributes["ai.usage.input_tokens"] = 999
 	llm.Attributes["llm.token_count.completion"] = 888
 	llm.Attributes["gen_ai.security.prompt_injection.detected"] = true
+	llm.Events = []SpanEvent{
+		{
+			Name:      "gen_ai.evaluation.result",
+			Timestamp: now.Add(35 * time.Millisecond),
+			Attributes: map[string]any{
+				"gen_ai.evaluation.name":        "faithfulness",
+				"gen_ai.evaluation.score.label": "fail",
+				"assistant.evaluation.outcome":  "failed",
+			},
+		},
+	}
 
 	tool := newTestSpan("trace-genai", "tool", "execute_tool", now.Add(40*time.Millisecond), 200)
 	tool.ParentSpanID = "agent"
 	tool.Attributes["gen_ai.operation.name"] = "execute_tool"
 	tool.Attributes["gen_ai.tool.name"] = "lookup_context"
 	tool.Attributes["gen_ai.privacy.pii.detected"] = true
+	tool.Events = []SpanEvent{
+		{
+			Name:      "gen_ai.evaluation.result",
+			Timestamp: now.Add(45 * time.Millisecond),
+			Attributes: map[string]any{
+				"gen_ai.evaluation.name":   "toxicity",
+				"gen_ai.evaluation.passed": true,
+			},
+		},
+	}
 
 	summarizer := newTestSpan("trace-genai", "summarizer", "invoke_agent", now.Add(60*time.Millisecond), 700)
 	summarizer.ParentSpanID = "workflow"
@@ -897,6 +918,12 @@ func TestTrace_IncludesBackendGenAIProjection(t *testing.T) {
 	if strings.Join(workflowNode.DescendantPrivacyRiskSpanIDs, ",") != "tool" {
 		t.Fatalf("unexpected workflow privacy risk span ids: %v", workflowNode.DescendantPrivacyRiskSpanIDs)
 	}
+	if workflowNode.DescendantEvaluationCount != 2 || workflowNode.DescendantEvaluationFailedCount != 1 {
+		t.Fatalf("unexpected workflow evaluation rollup: count=%d failed=%d", workflowNode.DescendantEvaluationCount, workflowNode.DescendantEvaluationFailedCount)
+	}
+	if strings.Join(workflowNode.DescendantEvaluationFailedSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected workflow failed evaluation span ids: %v", workflowNode.DescendantEvaluationFailedSpanIDs)
+	}
 
 	agentNode := nodesByID["agent"]
 	if agentNode.ParentFlowSpanID != "workflow" {
@@ -920,6 +947,12 @@ func TestTrace_IncludesBackendGenAIProjection(t *testing.T) {
 	if strings.Join(agentNode.DescendantPrivacyRiskSpanIDs, ",") != "tool" {
 		t.Fatalf("unexpected privacy risk span ids: %v", agentNode.DescendantPrivacyRiskSpanIDs)
 	}
+	if agentNode.DescendantEvaluationCount != 2 || agentNode.DescendantEvaluationFailedCount != 1 {
+		t.Fatalf("unexpected agent evaluation rollup: count=%d failed=%d", agentNode.DescendantEvaluationCount, agentNode.DescendantEvaluationFailedCount)
+	}
+	if strings.Join(agentNode.DescendantEvaluationFailedSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected agent failed evaluation span ids: %v", agentNode.DescendantEvaluationFailedSpanIDs)
+	}
 
 	llmNode := nodesByID["llm"]
 	if llmNode.ParentFlowSpanID != "agent" {
@@ -931,6 +964,12 @@ func TestTrace_IncludesBackendGenAIProjection(t *testing.T) {
 	if strings.Join(llmNode.DescendantSecurityRiskSpanIDs, ",") != "llm" {
 		t.Fatalf("unexpected llm security risk span ids: %v", llmNode.DescendantSecurityRiskSpanIDs)
 	}
+	if llmNode.DescendantEvaluationCount != 1 || llmNode.DescendantEvaluationFailedCount != 1 {
+		t.Fatalf("unexpected llm evaluation rollup: count=%d failed=%d", llmNode.DescendantEvaluationCount, llmNode.DescendantEvaluationFailedCount)
+	}
+	if strings.Join(llmNode.DescendantEvaluationFailedSpanIDs, ",") != "llm" {
+		t.Fatalf("unexpected llm failed evaluation span ids: %v", llmNode.DescendantEvaluationFailedSpanIDs)
+	}
 
 	toolNode := nodesByID["tool"]
 	if toolNode.ParentFlowSpanID != "agent" {
@@ -938,6 +977,9 @@ func TestTrace_IncludesBackendGenAIProjection(t *testing.T) {
 	}
 	if strings.Join(toolNode.DescendantPrivacyRiskSpanIDs, ",") != "tool" {
 		t.Fatalf("unexpected tool privacy risk span ids: %v", toolNode.DescendantPrivacyRiskSpanIDs)
+	}
+	if toolNode.DescendantEvaluationCount != 1 || toolNode.DescendantEvaluationFailedCount != 0 || len(toolNode.DescendantEvaluationFailedSpanIDs) != 0 {
+		t.Fatalf("unexpected tool evaluation rollup: count=%d failed=%d ids=%v", toolNode.DescendantEvaluationCount, toolNode.DescendantEvaluationFailedCount, toolNode.DescendantEvaluationFailedSpanIDs)
 	}
 
 	edges := make([]string, 0, len(genAI.FlowEdges))
@@ -997,6 +1039,66 @@ func TestTrace_IncludesRetrievalFlowNode(t *testing.T) {
 	}
 	if strings.Join(edges, "|") != "workflow->agent|agent->retrieval" {
 		t.Fatalf("unexpected retrieval flow edges: %v", edges)
+	}
+}
+
+func TestTrace_GenAIEvaluationOnlySpanRollsUpWithoutFlowNode(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-eval", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-eval", "agent", "invoke_agent", now.Add(10*time.Millisecond), 2500)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "Research Agent"
+
+	evaluation := newTestSpan("trace-genai-eval", "eval", "evaluate groundedness", now.Add(20*time.Millisecond), 300)
+	evaluation.ParentSpanID = "agent"
+	evaluation.Attributes["gen_ai.evaluation.name"] = "groundedness"
+	evaluation.Attributes["gen_ai.request.model"] = "gpt-5.5"
+	evaluation.Attributes["gen_ai.workflow.name"] = "assistant_v3_turn"
+	evaluation.Attributes["assistant.evaluation.outcome"] = "failed"
+	evaluation.Events = []SpanEvent{
+		{
+			Name:      "gen_ai.evaluation.result",
+			Timestamp: now.Add(25 * time.Millisecond),
+			Attributes: map[string]any{
+				"gen_ai.evaluation.name":        "groundedness",
+				"gen_ai.evaluation.score.label": "fail",
+				"assistant.evaluation.outcome":  "failed",
+			},
+		},
+	}
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, agent, evaluation})
+
+	result := s.Trace("trace-genai-eval", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+	if result.GenAI.LLMCalls != 0 {
+		t.Fatalf("expected eval-only span not to count as LLM call, got %d", result.GenAI.LLMCalls)
+	}
+
+	nodeNames := make([]string, 0, len(result.GenAI.FlowNodes))
+	nodesByID := make(map[string]GenAIFlowNode)
+	for _, node := range result.GenAI.FlowNodes {
+		nodeNames = append(nodeNames, node.Name)
+		nodesByID[node.SpanID] = node
+	}
+	if strings.Join(nodeNames, "|") != "Budget Guru|Research Agent" {
+		t.Fatalf("unexpected flow nodes: %v", nodeNames)
+	}
+
+	agentNode := nodesByID["agent"]
+	if agentNode.DescendantEvaluationCount != 1 || agentNode.DescendantEvaluationFailedCount != 1 {
+		t.Fatalf("unexpected agent evaluation rollup: count=%d failed=%d", agentNode.DescendantEvaluationCount, agentNode.DescendantEvaluationFailedCount)
+	}
+	if strings.Join(agentNode.DescendantEvaluationFailedSpanIDs, ",") != "eval" {
+		t.Fatalf("unexpected failed evaluation span ids: %v", agentNode.DescendantEvaluationFailedSpanIDs)
 	}
 }
 

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -1078,6 +1078,7 @@ func TestTrace_GenAILangGraphStepsRollUpAndChatStaysLLM(t *testing.T) {
 	llm.Attributes["gen_ai.agent.name"] = "LangGraph"
 	llm.Attributes["gen_ai.operation.name"] = "chat"
 	llm.Attributes["gen_ai.request.model"] = "unknown_model"
+	llm.Attributes["gen_ai.response.model"] = "gpt-5.5"
 	llm.Attributes["gen_ai.provider.name"] = "azure"
 	llm.Attributes["error.type"] = "AuthenticationError"
 
@@ -1097,7 +1098,7 @@ func TestTrace_GenAILangGraphStepsRollUpAndChatStaysLLM(t *testing.T) {
 		nodeNames = append(nodeNames, node.Name)
 		nodesByID[node.SpanID] = node
 	}
-	if strings.Join(nodeNames, "|") != "assistant_v3_turn|LangGraph|chat unknown_model" {
+	if strings.Join(nodeNames, "|") != "assistant_v3_turn|LangGraph|chat gpt-5.5" {
 		t.Fatalf("unexpected flow nodes: %v", nodeNames)
 	}
 	if _, ok := nodesByID["middleware"]; ok {
@@ -1111,6 +1112,9 @@ func TestTrace_GenAILangGraphStepsRollUpAndChatStaysLLM(t *testing.T) {
 	if llmNode.Kind != GenAISpanLLM {
 		t.Fatalf("expected chat span to be an LLM node, got %q", llmNode.Kind)
 	}
+	if strings.Join(llmNode.ModelNames, "|") != "gpt-5.5" {
+		t.Fatalf("expected real response model without placeholder request model, got %v", llmNode.ModelNames)
+	}
 	if llmNode.ParentFlowSpanID != "agent" {
 		t.Fatalf("expected chat span to attach to the LangGraph agent through skipped step spans, got %q", llmNode.ParentFlowSpanID)
 	}
@@ -1121,6 +1125,37 @@ func TestTrace_GenAILangGraphStepsRollUpAndChatStaysLLM(t *testing.T) {
 	}
 	if strings.Join(edges, "|") != "workflow->agent|agent->llm" {
 		t.Fatalf("unexpected flow edges: %v", edges)
+	}
+}
+
+func TestTrace_GenAIModelNamesPreferResponseThenRequest(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	llm := newTestSpan("trace-genai-model-preference", "llm", "chat", now, 100)
+	llm.Attributes["gen_ai.operation.name"] = "chat"
+	llm.Attributes["gen_ai.provider.name"] = "azure"
+	llm.Attributes["gen_ai.request.model"] = "assistant-prod-deployment"
+	llm.Attributes["gen_ai.response.model"] = "gpt-5.5"
+
+	s.AddSpansForConnection("conn-1", []Span{llm})
+
+	result := s.Trace("trace-genai-model-preference", 0)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+	if strings.Join(result.GenAI.ModelNames, "|") != "gpt-5.5|assistant-prod-deployment" {
+		t.Fatalf("expected trace model names to prefer response then request, got %v", result.GenAI.ModelNames)
+	}
+	if len(result.GenAI.FlowNodes) != 1 {
+		t.Fatalf("expected one flow node, got %#v", result.GenAI.FlowNodes)
+	}
+	node := result.GenAI.FlowNodes[0]
+	if node.Name != "chat gpt-5.5" {
+		t.Fatalf("expected node title to use response model, got %q", node.Name)
+	}
+	if strings.Join(node.ModelNames, "|") != "gpt-5.5|assistant-prod-deployment" {
+		t.Fatalf("expected node model names to keep response then request, got %v", node.ModelNames)
 	}
 }
 
@@ -1262,6 +1297,7 @@ func TestTrace_GenAITokenUsagePreservesExplicitZeroValues(t *testing.T) {
 	llm.Attributes["gen_ai.request.model"] = "gpt-5.5"
 	llm.Attributes["gen_ai.usage.input_tokens"] = 12
 	llm.Attributes["gen_ai.usage.output_tokens"] = 0
+	llm.Attributes["gen_ai.usage.total_tokens"] = 0
 	llm.Attributes["llm.token_count.completion"] = 888
 
 	s.AddSpansForConnection("conn-1", []Span{workflow, llm})
@@ -1270,13 +1306,13 @@ func TestTrace_GenAITokenUsagePreservesExplicitZeroValues(t *testing.T) {
 	if result == nil || result.GenAI == nil {
 		t.Fatal("expected GenAI projection")
 	}
-	if result.GenAI.Tokens != (GenAITokenUsage{Input: 12, Output: 0, Total: 12}) {
+	if result.GenAI.Tokens != (GenAITokenUsage{Input: 12, Output: 0, Total: 0}) {
 		t.Fatalf("unexpected token usage: %#v", result.GenAI.Tokens)
 	}
 
 	foundLLMNode := false
 	for _, node := range result.GenAI.FlowNodes {
-		if node.SpanID == "llm" && node.TokenUsage != (GenAITokenUsage{Input: 12, Output: 0, Total: 12}) {
+		if node.SpanID == "llm" && node.TokenUsage != (GenAITokenUsage{Input: 12, Output: 0, Total: 0}) {
 			t.Fatalf("unexpected llm token usage: %#v", node.TokenUsage)
 		}
 		if node.SpanID == "llm" {

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -806,6 +806,35 @@ func TestTrace_NonGenAITraceOmitsGenAIProjection(t *testing.T) {
 	}
 }
 
+func TestQueryTraceSummariesFiltered_MarksGenAITraces(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	plain := newTestSpan("trace-plain", "plain-root", "GET /health", now, 10)
+
+	genai := newTestSpan("trace-genai", "workflow", "assistant_v3_turn", now.Add(100*time.Millisecond), 20)
+	genai.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	genai.Attributes["gen_ai.workflow.name"] = "assistant_v3_turn"
+
+	s.AddSpansForConnection("conn-1", []Span{plain, genai})
+
+	results := s.QueryTraceSummariesFiltered(TraceSummaryFilter{Limit: 10})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 traces, got %d", len(results))
+	}
+
+	byTraceID := make(map[string]TraceSummary)
+	for _, result := range results {
+		byTraceID[result.TraceID] = result
+	}
+	if byTraceID["trace-genai"].IsGenAI != true {
+		t.Fatalf("expected GenAI trace summary to be marked")
+	}
+	if byTraceID["trace-plain"].IsGenAI {
+		t.Fatalf("expected non-GenAI trace summary to stay unmarked")
+	}
+}
+
 func TestTrace_IncludesBackendGenAIProjection(t *testing.T) {
 	s := New()
 	now := time.Now()

--- a/observer/internal/store/store_test.go
+++ b/observer/internal/store/store_test.go
@@ -1248,6 +1248,68 @@ func TestTrace_GenAIEvaluationOnlySpanRollsUpWithoutFlowNode(t *testing.T) {
 	}
 }
 
+func TestTrace_GenAIProjectionUsesFullEventsWhenPayloadEventsAreTruncated(t *testing.T) {
+	s := New()
+	now := time.Now()
+
+	workflow := newTestSpan("trace-genai-eval-events", "workflow", "invoke_workflow", now, 3000)
+	workflow.Attributes["gen_ai.operation.name"] = "invoke_workflow"
+	workflow.Attributes["gen_ai.workflow.name"] = "Budget Guru"
+
+	agent := newTestSpan("trace-genai-eval-events", "agent", "invoke_agent", now.Add(10*time.Millisecond), 2500)
+	agent.ParentSpanID = "workflow"
+	agent.Attributes["gen_ai.operation.name"] = "invoke_agent"
+	agent.Attributes["gen_ai.agent.name"] = "Research Agent"
+
+	evaluation := newTestSpan("trace-genai-eval-events", "eval", "evaluate groundedness", now.Add(20*time.Millisecond), 300)
+	evaluation.ParentSpanID = "agent"
+	evaluation.Attributes["gen_ai.evaluation.name"] = "groundedness"
+	for i := 0; i < 20; i++ {
+		evaluation.Events = append(evaluation.Events, SpanEvent{
+			Name:      "gen_ai.evaluation.result",
+			Timestamp: now.Add(time.Duration(25+i) * time.Millisecond),
+			Attributes: map[string]any{
+				"gen_ai.evaluation.name":        "groundedness",
+				"gen_ai.evaluation.score.label": "fail",
+			},
+		})
+	}
+
+	s.AddSpansForConnection("conn-1", []Span{workflow, agent, evaluation})
+
+	result := s.Trace("trace-genai-eval-events", 1)
+	if result == nil || result.GenAI == nil {
+		t.Fatal("expected GenAI projection")
+	}
+	var payloadEval Span
+	for _, span := range result.Spans {
+		if span.SpanID == "eval" {
+			payloadEval = span
+			break
+		}
+	}
+	if payloadEval.SpanID == "" {
+		t.Fatal("expected eval span in payload")
+	}
+	if got := len(payloadEval.Events); got != 1 {
+		t.Fatalf("expected payload events to stay truncated, got %d", got)
+	}
+
+	var agentNode GenAIFlowNode
+	for _, node := range result.GenAI.FlowNodes {
+		if node.SpanID == "agent" {
+			agentNode = node
+			break
+		}
+	}
+	if agentNode.SpanID == "" {
+		t.Fatal("expected agent node")
+	}
+	if agentNode.DescendantEvaluationCount != 20 || agentNode.DescendantEvaluationFailedCount != 20 {
+		t.Fatalf("expected GenAI rollup to use full event set, got count=%d failed=%d", agentNode.DescendantEvaluationCount, agentNode.DescendantEvaluationFailedCount)
+	}
+}
+
 func TestTrace_GenAIProjectionCapsSpanListsButNotCounts(t *testing.T) {
 	t.Setenv("MAX_FLOW_NODE_SPAN_LIST_SIZE", "1")
 

--- a/observer/internal/web/server.go
+++ b/observer/internal/web/server.go
@@ -38,7 +38,7 @@ func Register(mux *http.ServeMux, s *store.Store, v *validator.Store) func() {
 		if strings.HasPrefix(r.URL.Path, "/assets/") {
 			// Asset names are stable, so keep webviews from pinning stale JS/CSS
 			// across extension upgrades.
-			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Cache-Control", "max-age=0, must-revalidate")
 			fileServer.ServeHTTP(w, r)
 			return
 		}

--- a/observer/internal/web/server.go
+++ b/observer/internal/web/server.go
@@ -36,9 +36,9 @@ func Register(mux *http.ServeMux, s *store.Store, v *validator.Store) func() {
 	// SPA fallback: serve index.html for paths that don't match a static file.
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/assets/") {
-			// Assets are served with versioned query strings (?v=...), so they can be
-			// cached indefinitely — a version bump in index.html busts the cache.
-			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			// Asset names are stable, so keep webviews from pinning stale JS/CSS
+			// across extension upgrades.
+			w.Header().Set("Cache-Control", "no-cache")
 			fileServer.ServeHTTP(w, r)
 			return
 		}

--- a/observer/internal/web/static/index.html
+++ b/observer/internal/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Observer — Telemetry Explorer</title>
   <link rel="icon" type="image/svg+xml" href="/assets/observer-icon.svg" />
-  <link rel="stylesheet" href="/assets/main.css?v=20260520-1cd" />
+  <link rel="stylesheet" href="/assets/main.css?v=0.0.8" />
 </head>
 <body>
   <div id="root"></div>
@@ -15,6 +15,6 @@
         '<pre style="color:red;padding:40px;font-size:14px;background:black;">JS Error:\n' + msg + '\nat ' + url + ':' + line + ':' + col + '\n' + (err && err.stack ? err.stack : '') + '</pre>';
     };
   </script>
-  <script src="/assets/main.js?v=20260520-1cd"></script>
+  <script src="/assets/main.js?v=0.0.8"></script>
 </body>
 </html>

--- a/observer/internal/web/static_test.go
+++ b/observer/internal/web/static_test.go
@@ -46,7 +46,7 @@ func TestStaticAssetsAreRevalidated(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected asset response status 200, got %d", recorder.Code)
 	}
-	if cache := recorder.Header().Get("Cache-Control"); cache != "no-cache" {
-		t.Fatalf("expected Cache-Control no-cache, got %q", cache)
+	if cache := recorder.Header().Get("Cache-Control"); cache != "max-age=0, must-revalidate" {
+		t.Fatalf("expected Cache-Control max-age=0, must-revalidate, got %q", cache)
 	}
 }

--- a/observer/internal/web/static_test.go
+++ b/observer/internal/web/static_test.go
@@ -1,10 +1,15 @@
 package web
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/signalfx/obstudio/observer/internal/store"
+	"github.com/signalfx/obstudio/observer/internal/validator"
 )
 
 func TestStaticIndexReferencesObserverIcon(t *testing.T) {
@@ -17,8 +22,31 @@ func TestStaticIndexReferencesObserverIcon(t *testing.T) {
 	if !strings.Contains(string(indexBytes), `/assets/observer-icon.svg`) {
 		t.Fatal("static index should reference the observer favicon asset")
 	}
+	if !strings.Contains(string(indexBytes), `/assets/main.js?v=0.0.8`) {
+		t.Fatal("static index should cache-bust main.js with the extension release version")
+	}
+	if !strings.Contains(string(indexBytes), `/assets/main.css?v=0.0.8`) {
+		t.Fatal("static index should cache-bust main.css with the extension release version")
+	}
 
 	if _, err := os.Stat(filepath.Join(rootDir, "assets", "observer-icon.svg")); err != nil {
 		t.Fatalf("observer favicon asset missing: %v", err)
+	}
+}
+
+func TestStaticAssetsAreRevalidated(t *testing.T) {
+	mux := http.NewServeMux()
+	cleanup := Register(mux, store.New(), validator.NewStore())
+	defer cleanup()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/assets/main.js?v=0.0.8", nil)
+	mux.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected asset response status 200, got %d", recorder.Code)
+	}
+	if cache := recorder.Header().Get("Cache-Control"); cache != "no-cache" {
+		t.Fatalf("expected Cache-Control no-cache, got %q", cache)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a GenAI-specific trace overview to Obstudio while keeping the traditional waterfall as the detailed span list.

- Build GenAI trace projections in the backend from stored spans, including workflow, agent, LLM, tool, retrieval, grouped repeated calls, loop groups, span-link edges, token/model/tool rollups, and security/privacy/evaluation span references.
- Prefer `gen_ai.response.model` / `openai.response.model` over request/deployment model attributes for GenAI trace summary and LLM node labels, while filtering placeholder values like `unknown_model`.
- Render a compact GenAI agent-flow canvas above the waterfall with responsive horizontal/vertical layout, distinct node icons by kind, loop/group cards, selectable cards, and badge actions that filter the waterfall to relevant spans.
- Show evaluation/quality rollups on GenAI flow nodes and let failed quality badges navigate directly to the failed span for inspection.
- Keep trace filtering aligned with Logs: websocket updates still drive live refreshes, and active trace filters re-query the backend on live telemetry changes so new matching traces appear without waiting for manual reload.
- Widen trace detail panels for the DAG/waterfall workflow, keep selected trace details refreshed when span counts change, and keep the resize observer stable during drag.
- Fix VS Code extension unload cleanup coverage, make web assets revalidate instead of pinning stale UI, and make install smoke tests avoid shared observer detection.
- Refine the GenAI flow guide/retrieval icon and anchor signal tooltips inside the node card so edge hovers do not clip at the canvas boundary.

## Screenshots

<img width="674" alt="GenAI trace DAG current flow" src="https://github.com/user-attachments/assets/41cc3134-fc4c-4dbe-b1e4-a0d14e226774" />

## Verification

- `npm run typecheck` in `observer/client`
- `npm test -- --run src/traces/TraceWaterfall.test.tsx src/traces/TracesTab.test.tsx` in `observer/client`
- `go test ./...` in `observer`
- `go test ./internal/store` in `observer`
- `npm test` in `extension`
- `make build` in `observer`
- `git diff --check`
- Combined review: Claude diff review plus independent baseline review; verified findings were fixed, false positives were checked against code/tests.
